### PR TITLE
Feature/oscheckforopen

### DIFF
--- a/.bcut_home
+++ b/.bcut_home
@@ -1,3 +1,8 @@
+if [[ $OSTYPE == 'darwin'* ]]; then
+  echo 'macOS'
+  alias start="open"
+fi
+
 
 if [ -f $PATH_TO_BASHCUTS/bashcuts/bashcuts_by_cli/.bash_commons ]; 
 then 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+.DS_Store

--- a/bashcuts_by_cli/.bash_commons
+++ b/bashcuts_by_cli/.bash_commons
@@ -3,7 +3,7 @@
 export PROMPT_COMMAND="echo -n \[\$(date +%H:%M:%S)\]\ "
 
 # GREP
-alias hg="history|grep "
+alias hg="history|grep"
 
 # NEW TERMINAL FROM TERMINAL WINDOWS
 alias new-bash='start "" "C:\Program Files\Git\git-bash.exe"' #UNLINKED TO CURRENT TERMINAL PROCESS


### PR DESCRIPTION
Introducing os check at the initialization of bashcuts in order to set an alias for "start" to equal open. Wherever "start" is used in the code base to open links/folders, open will be used on mac through the alias