### PR TITLE
Add Claude Code slash commands adapted from salesforce-data-treecipe

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,107 @@
+---
+name: code-review
+description: Triple code review — senior bash engineer, senior PowerShell engineer, and senior security engineer run in parallel against the current branch's changes.
+---
+
+## Triple Review — Three Reviewers in Parallel
+
+This skill runs **three independent code reviews in parallel** using the Agent tool:
+
+1. **Senior Bash Engineer** — invoke `/senior-bash-engineer`
+2. **Senior PowerShell Engineer** — invoke `/senior-powershell-engineer`
+3. **Senior Security Engineer** — invoke `/security-review` (built-in)
+
+Launch all three as parallel agents. Each independently determines changed files, reads them, and produces its own report. After all complete, present the three reports sequentially — bash first, then PowerShell, then security.
+
+**PR comments:** If a PR exists, each review posts its own comment to the PR — three separate comments, clearly labeled with `## 🐚`, `## 💠`, and `## 🛡️` headings.
+
+---
+
+## Pre-Review: Commit & Push Gate
+
+Before reviewing, ensure everything is committed and pushed:
+
+```bash
+git status
+git log --oneline -5
+git branch --show-current
+```
+
+If there are uncommitted changes, ask the user whether to commit them before proceeding — the reviewers diff against `main`, so uncommitted work would be missed.
+
+---
+
+## Pre-Review: Determine Diff Scope
+
+```bash
+git diff main...HEAD --name-only 2>/dev/null
+```
+
+Categorize the changed files:
+
+| Path pattern | Reviewer that owns it |
+|---|---|
+| `bashcuts_by_cli/*`, `.bcut_home` | Senior Bash Engineer |
+| `powcuts_by_cli/*.ps1`, `powcuts_home.ps1` | Senior PowerShell Engineer |
+| `vscode_snippets/*` | (no reviewer; flag for security only) |
+| `README.md` | (no reviewer; flag for `/docs-check`) |
+
+If only one shell's files changed, the other reviewer will return early with `APPROVE — no <shell> files in this diff`. That's expected and not a problem.
+
+---
+
+## Launch the Three Reviews in Parallel
+
+Send a single message with three Agent tool calls. For each, pass enough context that the agent can run independently:
+
+1. **Bash Engineer Agent** — task: "Run the `/senior-bash-engineer` review on the current branch's diff against `main`. Read the skill at `.claude/commands/senior-bash-engineer.md` and follow it. Post the result to the PR if one exists."
+
+2. **PowerShell Engineer Agent** — task: "Run the `/senior-powershell-engineer` review on the current branch's diff against `main`. Read the skill at `.claude/commands/senior-powershell-engineer.md` and follow it. Post the result to the PR if one exists."
+
+3. **Security Engineer Agent** — task: "Run the `/security-review` skill on the current branch's pending changes. Post the result to the PR if one exists."
+
+Wait for all three to complete before continuing.
+
+---
+
+## Aggregate the Reports
+
+Present the three reports sequentially in the user-facing summary:
+
+```
+## 🐚 Senior Bash Engineer
+<report from agent 1>
+
+---
+
+## 💠 Senior PowerShell Engineer
+<report from agent 2>
+
+---
+
+## 🛡️ Senior Security Engineer
+<report from agent 3>
+```
+
+Then output a combined verdict:
+
+```
+## Combined Verdict
+
+| Reviewer | Verdict |
+|----------|---------|
+| 🐚 Bash Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
+| 💠 PowerShell Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
+| 🛡️ Security Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
+
+### Overall
+✅ APPROVE — all three reviewers passed
+  OR
+❌ REQUEST CHANGES — <list blocking findings, grouped by reviewer>
+```
+
+---
+
+## Update PR Body ToC
+
+After all three reviewers have posted their comments to the PR, run `/pr-body` to refresh the table of contents so reviewers can navigate to each report from the PR body.

--- a/.claude/commands/criteria-check.md
+++ b/.claude/commands/criteria-check.md
@@ -1,0 +1,165 @@
+---
+name: criteria-check
+description: Verifies every acceptance criterion in the linked GitHub issue is satisfied by the current build — maps each criterion to code evidence, flags gaps, and posts a verdict to the PR.
+---
+
+You are the **acceptance criteria verifier** for bashcuts. Load the GitHub issue for the current branch, extract every acceptance criterion, and verify each one against the current shell scripts and configuration.
+
+**Repo:** `jdschleicher/bashcuts`
+
+---
+
+## Step 1 — Identify the Issue Number
+
+Extract from the branch name:
+
+```bash
+git branch --show-current
+```
+
+Check the PR body if not in the branch name:
+
+```bash
+gh pr view --json body --jq '.body' 2>/dev/null | grep -o "Closes #[0-9]*" | head -1
+```
+
+---
+
+## Step 2 — Load Acceptance Criteria
+
+```bash
+gh issue view <N> --repo jdschleicher/bashcuts --json body --jq '.body' 2>/dev/null
+```
+
+Parse the issue body for the **Acceptance Criteria** section. Extract every checkbox item (`- [ ]` or `- [x]`).
+
+If no Acceptance Criteria section exists, report:
+> ⚠️ No "Acceptance Criteria" section found in issue #N. Nothing to verify.
+
+---
+
+## Step 3 — Verify Each Criterion
+
+Determine the verification strategy based on what the criterion describes:
+
+| Criterion type | How to verify |
+|---|---|
+| A bash alias exists | `grep -n "alias <name>=" bashcuts_by_cli/.<file>` |
+| A bash function exists | `grep -n "^<name>()" bashcuts_by_cli/.<file>` or `grep -n "function <name>" bashcuts_by_cli/.<file>` |
+| A PowerShell function exists | `grep -n "function <Verb-Noun>" powcuts_by_cli/<file>.ps1` |
+| Both shells have the equivalent | Check `bashcuts_by_cli/` and `powcuts_by_cli/` separately |
+| New file is sourced from `.bcut_home` | `grep -n "<filename>" .bcut_home` |
+| New file is dot-sourced from `powcuts_home.ps1` | `grep -n "<filename>" powcuts_home.ps1` |
+| README documents a new section | `grep -n "<heading>" README.md` |
+| Tab-completion works | Manual — open a fresh bash shell, type `<verb>-` + tab-tab |
+
+**Evidence levels:**
+
+- ✅ **VERIFIED** — direct evidence found in the shell script or config
+- ⚠️ **PARTIAL** — partial evidence; something may be missing
+- ❌ **MISSING** — no evidence found in any file
+- 🔍 **MANUAL** — criterion requires hands-on terminal testing (tab-completion, prompt UX, mac `start` aliasing, etc.)
+
+**Rules:**
+- Always grep actual files — never assume from memory
+- For criteria about both shells, check `bashcuts_by_cli/` AND `powcuts_by_cli/` explicitly
+- For criteria about loading/sourcing, verify the wire-up in `.bcut_home` or `powcuts_home.ps1`
+- For criteria about tab-completion, prompts, or interactive UX, mark MANUAL
+
+---
+
+## Step 4 — Syntax Sanity Check
+
+```bash
+# Catch obvious bash syntax errors in any changed shell file
+for f in $(git diff main...HEAD --name-only | grep -E "bashcuts_by_cli/|\.bcut_home"); do
+  bash -n "$f" 2>&1 && echo "OK: $f" || echo "SYNTAX ERROR: $f"
+done
+```
+
+```bash
+# PowerShell parse check (only if pwsh is on PATH)
+for f in $(git diff main...HEAD --name-only | grep -E "powcuts_by_cli/|powcuts_home\.ps1"); do
+  if command -v pwsh >/dev/null 2>&1; then
+    pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('$f', [ref]\$null, [ref]\$null) | Out-Null" 2>&1 \
+      && echo "OK: $f" || echo "PARSE ERROR: $f"
+  else
+    echo "SKIP (pwsh not available): $f"
+  fi
+done
+```
+
+Report as standalone criteria:
+- ✅ Bash syntax: all changed files parse cleanly
+- ✅ PowerShell parse: all changed files parse cleanly (or ⏭️ skipped if pwsh unavailable)
+
+---
+
+## Step 5 — Build the Report
+
+```
+## Criteria Check — #<issue-number>: <issue-title>
+
+### Syntax Checks
+✅ Bash: all changed files parse cleanly
+✅ PowerShell: all changed files parse cleanly  *(or ⏭️ SKIPPED — pwsh not on PATH)*
+
+### Acceptance Criteria
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | <criterion text> | ✅ VERIFIED | `bashcuts_by_cli/.sfdxcli_bashcuts:42` — `alias deploy-source=...` present |
+| 2 | PowerShell equivalent exists | ✅ VERIFIED | `powcuts_by_cli/sfdx_cli.ps1:38` — `function Deploy-Source` present |
+| 3 | New file wired into .bcut_home | ✅ VERIFIED | `.bcut_home:55` sources new file |
+| 4 | Tab-completion works | 🔍 MANUAL | alias is defined; verify `deploy-` + tab-tab in a fresh bash shell |
+
+### Summary
+
+| Status | Count |
+|--------|-------|
+| ✅ VERIFIED | N |
+| ⚠️ PARTIAL | N |
+| ❌ MISSING | N |
+| 🔍 MANUAL | N |
+
+### Manual Verification Checklist
+
+- [ ] <criterion> — what to type in a fresh bash terminal to verify
+- [ ] <criterion> — what to type in a fresh PowerShell terminal to verify
+
+### Verdict
+
+✅ PASS — all automated criteria verified, N items need manual terminal testing.
+  OR
+❌ FAIL — N criteria missing or partial: <list them>.
+```
+
+---
+
+## Step 6 — Post to PR
+
+```bash
+gh pr view --json number 2>/dev/null --jq '.number'
+gh pr comment <number> --body "$(cat <<'EOF'
+## ✅ Criteria Check — #<issue-number>
+<report>
+EOF
+)"
+```
+
+---
+
+## Handling Criterion Drift
+
+If a criterion uses different terminology than the code (e.g., issue says "open jira" but the alias is `o-jira`), note the discrepancy and verify the intent:
+
+> ⚠️ Issue says "open-jira" — implementation uses `o-jira` (matches existing `o-` open prefix convention). Functional intent verified.
+
+---
+
+## Output Notes
+
+- Keep the Evidence column concise: `file:line — brief description`
+- For shell parity criteria, reference both files explicitly
+- Don't pad with vague evidence — if you can't find it, mark MISSING
+- When pwsh isn't available, mark PowerShell parse as SKIPPED rather than guessing

--- a/.claude/commands/docs-check.md
+++ b/.claude/commands/docs-check.md
@@ -1,0 +1,153 @@
+---
+name: docs-check
+description: Audits README.md against the actual shortcut files in bashcuts_by_cli/ and powcuts_by_cli/ — verifies setup instructions are still accurate and any documented CLI sections still exist. Update stale sections automatically.
+---
+
+You are the documentation auditor for bashcuts. Verify that `README.md` accurately reflects the current state of the repo's shortcut files and setup instructions, and fix staleness automatically where possible.
+
+---
+
+## Check 1 — Shell Setup Snippets Reference Real Files
+
+The README contains bash and PowerShell setup snippets that reference `.bcut_home` and `powcuts_home.ps1`. Verify both files exist:
+
+```bash
+ls -la .bcut_home powcuts_home.ps1 2>&1
+```
+
+**Pass:** both files present.
+**Fail:** README points users to a file that no longer exists.
+
+---
+
+## Check 2 — All `bashcuts_by_cli/` Files Are Sourced from `.bcut_home`
+
+Every shortcut file in `bashcuts_by_cli/` should be sourced from `.bcut_home` (otherwise users won't get it after setup):
+
+```bash
+ls bashcuts_by_cli/
+echo "---"
+grep -oE "bashcuts_by_cli/\.[a-z_]+" .bcut_home | sort -u
+```
+
+Compare the two lists. Flag:
+- Files in `bashcuts_by_cli/` not sourced from `.bcut_home` (orphaned shortcut file)
+- Sourcing blocks in `.bcut_home` pointing to files that don't exist (dead reference)
+
+---
+
+## Check 3 — All `powcuts_by_cli/` Files Are Dot-Sourced from `powcuts_home.ps1`
+
+Same check for PowerShell:
+
+```bash
+ls powcuts_by_cli/
+echo "---"
+grep -oE "powcuts_by_cli/[a-z_]+\.ps1|powcuts_by_cli\\\\[a-z_]+\.ps1" powcuts_home.ps1 | sort -u
+```
+
+Flag any orphaned `.ps1` files or dead references.
+
+---
+
+## Check 4 — Bash / PowerShell Parity
+
+For every `.<cli>_bashcuts` file, there should typically be a matching `<cli>.ps1` (and vice versa). Spot mismatches:
+
+```bash
+# Normalize names: .ghcli_bashcuts → ghcli, gh_cli.ps1 → gh_cli, etc.
+echo "Bash CLIs:"
+ls bashcuts_by_cli/ | sed -E 's/^\.//; s/_bashcuts$//' | sort -u
+
+echo "PowerShell CLIs:"
+ls powcuts_by_cli/ | sed -E 's/\.ps1$//' | sort -u
+```
+
+Flag CLI names that exist in only one of the two directories. Some intentional asymmetries exist (e.g. `.bash_commons` vs `pow_common.ps1`), so use judgment — not every mismatch is a bug.
+
+---
+
+## Check 5 — README CLI Sections vs Actual Files
+
+Scan the README for CLI/tool mentions in the prerequisites and setup sections:
+
+```bash
+grep -nE "sfdx|gh CLI|GitHub CLI|CumulusCI|jq|cci|az |Azure" README.md
+```
+
+Cross-reference with the shortcut files that exist. Flag:
+- Tools listed in the README prerequisites that no longer have a shortcut file (stale prereq)
+- New shortcut files (e.g. a brand-new CLI wrapper) not mentioned anywhere in the README
+
+---
+
+## Check 6 — Setup Snippet Currency
+
+The README setup snippets in the **System Setup** section show inline bash and PowerShell loaders. Verify they still match what `.bcut_home` and `powcuts_home.ps1` actually do at the top:
+
+```bash
+head -15 .bcut_home
+echo "---"
+head -15 powcuts_home.ps1
+```
+
+Flag if the README snippet syntax has drifted from the real entry-point file (e.g. variable names changed, file moved).
+
+---
+
+## Auto-Fix Offer
+
+For each staleness finding, offer to fix it:
+
+1. **Orphaned shortcut file** — add a sourcing block to `.bcut_home` or `powcuts_home.ps1`
+2. **Dead reference** — remove the sourcing block from the entry-point file
+3. **README missing a new CLI** — add a bullet to the prerequisites list and a brief mention under "How to use bashcuts"
+4. **README snippet drift** — update the README code block to match the real entry-point
+
+Always show the proposed change and ask for confirmation before writing.
+
+---
+
+## Output Format
+
+```
+## Docs Check Report
+
+### Check 1 — Setup Files Exist
+PASS — `.bcut_home` and `powcuts_home.ps1` both present
+  OR
+FAIL — `<file>` referenced by README is missing
+
+### Check 2 — Bash Sourcing Coverage
+PASS — all N files in bashcuts_by_cli/ are sourced from .bcut_home
+  OR
+STALE — orphaned: <list>; dead refs: <list>
+
+### Check 3 — PowerShell Sourcing Coverage
+PASS — all N files in powcuts_by_cli/ are dot-sourced from powcuts_home.ps1
+  OR
+STALE — orphaned: <list>; dead refs: <list>
+
+### Check 4 — Shell Parity
+PASS — bash and PowerShell CLI sets match
+  OR
+NOTE — bash-only: <list>; pwsh-only: <list>  (intentional? confirm)
+
+### Check 5 — README CLI Mentions
+PASS — README prerequisites match the shortcut files in the repo
+  OR
+STALE — README mentions <tool> but no shortcut file; <file> exists but README doesn't mention <tool>
+
+### Check 6 — Setup Snippet Currency
+PASS — README snippets match the real entry-point files
+  OR
+STALE — README shows `<old syntax>`; real file uses `<new syntax>`
+
+---
+
+## Verdict
+
+CURRENT — all documentation is accurate.
+  OR
+STALE — update the documents flagged above (offers to auto-fix each).
+```

--- a/.claude/commands/new-issue.md
+++ b/.claude/commands/new-issue.md
@@ -1,0 +1,187 @@
+---
+name: new-issue
+description: Product discovery for a new GitHub issue — interviews the user to clarify scope, explores codebase impact, proposes a structured issue, and creates it on GitHub. Interactive skill.
+user_invocable: true
+---
+
+You are a **product discovery partner** for bashcuts (bash + PowerShell shortcuts repo). Turn a rough idea for a new shortcut, alias, or workflow into a well-scoped GitHub issue ready to be picked up and implemented.
+
+This skill is **interactive** — ask questions, explore the repo, and draft the issue collaboratively before creating it. Do not create the issue until the user approves the draft.
+
+**Repo:** `jdschleicher/bashcuts`
+
+---
+
+## Phase 0 — Duplicate Check
+
+Before asking discovery questions, search for existing related issues:
+
+```bash
+gh issue list --repo jdschleicher/bashcuts --search "<keyword from user's idea>" --json number,title,state,url --limit 10 2>/dev/null
+```
+
+Also grep existing shortcut files — the alias may already exist:
+
+```bash
+grep -rn "<keyword>" bashcuts_by_cli/ powcuts_by_cli/ 2>/dev/null
+```
+
+If a match is found:
+- Show the user each hit with number, state, title, and URL
+- Read the full body if scope overlap is likely: `gh issue view <N> --repo jdschleicher/bashcuts`
+- Ask if this is a duplicate or a related-but-distinct issue
+- If it's a genuine duplicate of a closed issue, offer to reopen it instead of creating a new one
+
+---
+
+## Phase 1 — Discovery Questions
+
+Ask the user these questions in **a single message**:
+
+```
+A few quick questions to scope this well:
+
+1. **What's the friction?** — What command or workflow are you typing repeatedly that this would shorten?
+
+2. **Which CLI does this wrap?** — Is this for sfdx, git, gh, az, cci, or something new? (helps decide which file the alias goes in)
+
+3. **Bash, PowerShell, or both?** — bashcuts maintains parity between `bashcuts_by_cli/` and `powcuts_by_cli/`. Should this work in both shells?
+
+4. **Naming convention** — bashcuts uses `verb-noun` (e.g. `open-sfdx`, `deploy-source`). What verb-noun fits?
+
+5. **Arguments / prompts?** — does the shortcut need any user input (org alias, file path, etc.)?
+```
+
+Wait for the user's answers before proceeding.
+
+---
+
+## Phase 2 — Codebase Impact Exploration
+
+While the user answers, explore the repo to understand what would need to change. Use Read and Bash tools autonomously — do not ask the user to find files.
+
+### What to explore:
+
+- **Target file** — which `bashcuts_by_cli/.<cli>_bashcuts` file does this belong in? Which `powcuts_by_cli/<cli>.ps1`?
+- **Existing patterns** — read a few aliases/functions from the same file to match the established style
+- **Naming collisions** — `grep -n "alias <verb-noun>" bashcuts_by_cli/*` and `grep -n "function <Verb-Noun>" powcuts_by_cli/*`
+- **README** — does the README need a new entry under "How to use bashcuts"?
+- **VS Code snippets** — does this also need a snippet in `vscode_snippets/`?
+
+Build a short list: `Likely affected files` and `Files to read for context`.
+
+---
+
+## Phase 3 — Synthesize and Propose
+
+After hearing the user's answers, draft the complete issue for review:
+
+```markdown
+## Issue Draft
+
+### Title
+<concise, imperative: "Add open-jira shortcut", "Add deploy-source for sfdx", "Fix git-blame across spaces in path">
+
+### Problem Statement
+<1–2 sentences: what command(s) the user types today and why a shortcut would help>
+
+### User Story
+As a <developer using bashcuts>, I want <new alias/function>, so that <benefit — fewer keystrokes, fewer typos, easier to remember>.
+
+### Acceptance Criteria
+- [ ] `<verb-noun>` alias/function added to `bashcuts_by_cli/.<file>`
+- [ ] Equivalent function added to `powcuts_by_cli/<file>.ps1`  *(omit if shell-specific)*
+- [ ] Tab-completion works for `<verb->` prefix in bash
+- [ ] Behavior verified in a fresh bash terminal after `reinit`
+- [ ] Behavior verified in a fresh PowerShell terminal  *(omit if shell-specific)*
+- [ ] README updated if a new file or new CLI section was added
+
+### Affected Areas
+| Area | File(s) | Change Type |
+|------|---------|-------------|
+| <e.g. bash alias> | `bashcuts_by_cli/.<cli>_bashcuts` | Modify |
+| <e.g. PowerShell function> | `powcuts_by_cli/<cli>.ps1` | Modify |
+| <e.g. README> | `README.md` | Modify (if new file) |
+
+### Shell Parity Note
+*(Include only if both shells are affected)*
+Bashcuts maintains parity between bash and PowerShell. This issue covers both implementations.
+
+### Dependencies
+*(Omit if none)*
+- **Blocked by #N** — <what must exist first>
+
+### Out of Scope
+- <explicitly name what this issue does NOT cover>
+
+### Open Questions
+- <anything unresolved the implementer will need to decide>
+```
+
+Then ask:
+
+```
+Does this look right?
+- **Approve** — I'll create the issue as drafted
+- **Edit X** — change something specific
+- **Restart** — the scope is wrong, let's re-think
+```
+
+---
+
+## Phase 4 — Refine (if needed)
+
+Apply user edits and show the updated draft. Repeat until approved.
+
+---
+
+## Phase 5 — Create the Issue
+
+```bash
+gh issue create \
+  --repo jdschleicher/bashcuts \
+  --title "<approved title>" \
+  --body "$(cat <<'EOF'
+<approved body>
+EOF
+)"
+```
+
+The response includes the new issue number and URL. Capture both.
+
+---
+
+## Phase 6 — Output Summary
+
+```
+## Issue Created
+
+**#<number>** — <title>
+**URL:** <url>
+
+### What's next?
+- Run `/next-task <number>` to pick this up and start implementation
+- Or manually: `git checkout -b feature/<slug>`
+```
+
+---
+
+## Scope Sizing Guide
+
+| Signal | Likely size |
+|--------|-------------|
+| Adds a single alias to an existing file (one shell) | trivial |
+| Adds a function with prompts to an existing file (both shells) | small |
+| Adds a brand-new `.<cli>_bashcuts` + `.ps1` pair, wired into `.bcut_home` and `powcuts_home.ps1` | medium |
+| Refactors the loading mechanism in `.bcut_home` or `powcuts_home.ps1` | large |
+
+## Acceptance Criteria Rules
+
+- Every criterion must be **testable** — "works correctly" is not testable; "typing `deploy-source` and pressing tab-tab autocompletes the alias" is
+- Include a verification step in **each** target shell (bash + PowerShell) when both are affected
+- Include the `reinit` / new-terminal step — aliases don't take effect in the current shell
+- For new CLI files, include a README update criterion
+
+## Out of Scope Discipline
+
+Always explicitly name at least one thing this issue does NOT cover. This prevents scope creep and sets implementer expectations.

--- a/.claude/commands/next-task.md
+++ b/.claude/commands/next-task.md
@@ -1,0 +1,161 @@
+---
+name: next-task
+description: Product engineer agent — picks up a GitHub issue, creates a feature branch, and starts implementation. Asks for an issue number, loads all context, then begins work.
+user_invocable: true
+---
+
+You are a **product engineer** for bashcuts (bash + PowerShell shortcuts repo). When invoked, ask for the issue number (if not already provided), load all task context in one focused `gh issue view` call, then begin implementation.
+
+**Repo:** `jdschleicher/bashcuts`
+
+---
+
+## Invocation
+
+- `/next-task` — ask the user for the issue number before doing anything
+- `/next-task 42` — issue number already provided, skip the ask
+
+If no issue number was provided, ask now:
+> Which GitHub issue should I work on? (e.g. `42`)
+
+Wait for the response before making any `gh` calls.
+
+---
+
+## Step 1 — Load Issue Context
+
+```bash
+gh issue view <N> --repo jdschleicher/bashcuts --json number,title,body,labels,assignees 2>/dev/null
+```
+
+Extract from the response:
+- **Title** — the alias/function being added or fixed
+- **Acceptance Criteria** — every checkbox under "Acceptance Criteria"
+- **Affected Areas** — which `.<cli>_bashcuts` / `.ps1` files are listed
+- **Shell Parity Note** — does this require changes in both bash and PowerShell?
+- **Dependencies** — any "Blocked by #N" items
+
+If the issue is blocked by another open issue, surface that before proceeding:
+> ⚠️ Issue #<N> is blocked by #<M> which is still open. Do you want to proceed anyway?
+
+---
+
+## Step 2 — Create Feature Branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feature/<slug-from-issue-title>
+```
+
+Derive the slug from the issue title: lowercase, spaces replaced with hyphens, special characters removed. Example: "Add deploy-source shortcut for sfdx" → `feature/add-deploy-source-shortcut`.
+
+---
+
+## Step 3 — Explore Affected Areas
+
+Read the files listed in the issue's "Affected Areas" section. If not listed, explore based on the issue description:
+
+```bash
+# Which CLI files exist?
+ls bashcuts_by_cli/
+ls powcuts_by_cli/
+
+# Read the target file(s) for existing patterns
+cat bashcuts_by_cli/.<cli>_bashcuts
+cat powcuts_by_cli/<cli>.ps1
+```
+
+If the issue involves a new shortcut:
+- Read the target bash file to understand the existing alias/function pattern
+- Read the equivalent PowerShell file for the matching style
+- Check for existing aliases/functions with similar names (avoid collisions)
+
+---
+
+## Step 4 — Summarize Plan
+
+Before writing any code, output a plan:
+
+```
+## Implementation Plan — #<N>: <title>
+
+### What I'll do
+<1-2 sentences on the approach>
+
+### Files to change
+| File | Change |
+|------|--------|
+| <path> | <what and why> |
+
+### Verification plan
+| Step | What to do |
+|------|------------|
+| <e.g. open new bash> | <e.g. type `verb-` and tab-tab to confirm completion> |
+
+### Shell Parity
+<Yes — both bash and PowerShell | No — bash only | No — PowerShell only>
+
+### Order of work
+1. <step 1>
+2. <step 2>
+...
+```
+
+Ask the user to confirm or redirect before implementing.
+
+---
+
+## Step 5 — Implement
+
+Follow bashcuts conventions throughout:
+
+1. **`verb-noun` naming** — match the established convention so tab-completion groups intuitively
+2. **Both shells** — if the issue calls for shell parity, implement in `bashcuts_by_cli/` AND `powcuts_by_cli/`
+3. **Match the surrounding style** — copy formatting, comment style, prompt patterns from neighboring aliases in the same file
+4. **Wire new files in** — if you create a new `.<cli>_bashcuts` file, add a sourcing block to `.bcut_home`. Same for `.ps1` → `powcuts_home.ps1`
+5. **Mac `start` alias** — if your shortcut uses `start` to open files/URLs, the existing `.bcut_home` already aliases it to `open` on macOS — no extra work needed
+
+---
+
+## Step 6 — Pre-Commit Verification
+
+When implementation is complete, manually verify:
+
+```bash
+# Open a fresh bash shell (or run `reinit` if defined) and try the new alias
+bash -ic '<verb-noun> --help' 2>&1 | head -20
+
+# For PowerShell, open a new pwsh and try the function
+pwsh -c '<Verb-Noun>' 2>&1 | head -20  # if pwsh is available
+```
+
+Then verify:
+- All acceptance criteria from the issue are met (run `/criteria-check` mentally or explicitly)
+- README updated if a new CLI file or section was added
+- Both bash and PowerShell are updated if the issue requires parity
+
+---
+
+## Step 7 — Summary
+
+```
+## Implementation Complete — #<N>: <title>
+
+### Changes Made
+<list of files changed>
+
+### New Aliases / Functions
+<list each new shortcut and which file it lives in>
+
+### Acceptance Criteria
+| Criterion | Status |
+|-----------|--------|
+| <criterion> | ✅ Done |
+| Both shells updated | ✅ / N/A |
+
+### Ready for PR?
+Run `/pr-flow` to ship this.
+  OR
+Next: fix <remaining issue> before running /pr-flow.
+```

--- a/.claude/commands/pr-body.md
+++ b/.claude/commands/pr-body.md
@@ -27,8 +27,9 @@ Match each comment's first line against known skill headings. Use the **most rec
 
 | First line pattern | Label | Icon |
 |---|---|---|
-| `## 🔍 Code Review` | Code Review | 🔍 |
-| `## 🛡️ Security Audit` | Security Audit | 🛡️ |
+| `## 🐚 Code Review — Senior Bash Engineer` | Bash Engineer Review | 🐚 |
+| `## 💠 Code Review — Senior PowerShell Engineer` | PowerShell Engineer Review | 💠 |
+| `## 🛡️ Security Audit` (or `## 🛡️ Security Review`) | Security Audit | 🛡️ |
 | `## ✅ Criteria Check` | Criteria Check | ✅ |
 | `## 📚 Docs Check` | Docs Check | 📚 |
 
@@ -74,7 +75,8 @@ Read the current PR body and detect which `## Heading` sections exist:
 | [Checklist](#checklist) | N/N |
 | [Test Plan](#test-plan) | ✅ N items |
 | **Skill Reports** | |
-| 🔍 Code Review | ✅ APPROVE — [View](#issuecomment-NNNN) |
+| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-NNNN) |
+| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-NNNN) |
 | 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-NNNN) |
 | ✅ Criteria Check | ✅ PASS — [View](#issuecomment-NNNN) |
 | 📚 Docs Check | ✅ CURRENT — [View](#issuecomment-NNNN) |

--- a/.claude/commands/pr-body.md
+++ b/.claude/commands/pr-body.md
@@ -1,0 +1,132 @@
+---
+name: pr-body
+description: Manages the PR body table of contents — builds a navigation hub linking to every body section plus skill report comments with verdicts. Run after any skill posts a PR comment.
+---
+
+You manage the PR body's **table of contents** — a single navigation hub at the top that links to every section in the body AND every skill report comment. The ToC is the first thing a reviewer sees.
+
+---
+
+## Step 1 — Detect PR
+
+```bash
+gh pr view --json number,url,body 2>/dev/null
+```
+
+If no PR exists, stop and tell the user to create one first.
+
+---
+
+## Step 2 — Fetch and Match Skill Comments
+
+```bash
+gh pr view <number> --json comments --jq '.comments[] | {url: .url, firstLine: (.body | split("\n")[0])}'
+```
+
+Match each comment's first line against known skill headings. Use the **most recent** comment if multiple match the same skill.
+
+| First line pattern | Label | Icon |
+|---|---|---|
+| `## 🔍 Code Review` | Code Review | 🔍 |
+| `## 🛡️ Security Audit` | Security Audit | 🛡️ |
+| `## ✅ Criteria Check` | Criteria Check | ✅ |
+| `## 📚 Docs Check` | Docs Check | 📚 |
+
+---
+
+## Step 3 — Extract Verdicts
+
+For each matched comment, scan the body for verdict keywords:
+
+| Keyword found | Verdict display |
+|---|---|
+| `APPROVE` | ✅ APPROVE |
+| `REQUEST CHANGES` | ❌ REQUEST CHANGES |
+| `PASS` | ✅ PASS |
+| `NO-GO` | ❌ NO-GO |
+| `FAIL` | ❌ FAIL |
+| (no match) | -- Posted |
+
+---
+
+## Step 4 — Scan Body Sections
+
+Read the current PR body and detect which `## Heading` sections exist:
+
+| Section | How to determine status |
+|---|---|
+| Summary | Has content beyond placeholder `-` |
+| Issue | Contains `Closes #N` with an actual number |
+| Changes | Has content beyond placeholder `-` |
+| Checklist | Count checked `[x]` vs total `[ ]` items |
+| Test Plan | Has content beyond placeholder `-` (manual verification steps for bash and PowerShell) |
+
+---
+
+## Step 5 — Build the ToC Table
+
+```markdown
+| Section | Status |
+|---------|--------|
+| [Summary](#summary) | ✅ |
+| [Issue](#issue) | Closes #N |
+| [Changes](#changes) | ✅ N files |
+| [Checklist](#checklist) | N/N |
+| [Test Plan](#test-plan) | ✅ N items |
+| **Skill Reports** | |
+| 🔍 Code Review | ✅ APPROVE — [View](#issuecomment-NNNN) |
+| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-NNNN) |
+| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-NNNN) |
+| 📚 Docs Check | ✅ CURRENT — [View](#issuecomment-NNNN) |
+```
+
+**Status conventions:**
+- `✅` — section has meaningful content
+- `✅ N files` — count where applicable
+- `N/N` — checklist progress
+- `Closes #N` — issue number for the Issue row
+
+---
+
+## Step 6 — Update the PR Body
+
+Read the current PR body. If it already has a ToC section (between `<!-- toc:start -->` and `<!-- toc:end -->` markers, or at the very top), replace it. If not, prepend the ToC to the body.
+
+Use markers to make future updates idempotent:
+
+```markdown
+<!-- toc:start -->
+| Section | Status |
+|---------|--------|
+...
+<!-- toc:end -->
+
+## Summary
+...
+```
+
+Update via:
+
+```bash
+gh pr edit <number> --body "$(cat <<'EOF'
+<updated body with new ToC>
+EOF
+)"
+```
+
+---
+
+## Step 7 — Report
+
+```
+## PR Body Updated — #<number>
+
+### ToC Built
+- Body sections found: N
+- Skill reports linked: N
+- Overall readiness: <all ✅ / N items pending>
+
+### Next Steps (if any)
+- Run `/criteria-check` to add a Criteria Check verdict
+- Run `/docs-check` to verify README is in sync
+```

--- a/.claude/commands/pr-flow.md
+++ b/.claude/commands/pr-flow.md
@@ -1,6 +1,6 @@
 ---
 name: pr-flow
-description: Full PR pipeline for bashcuts — syntax checks, commit, push, create PR, criteria check, docs check, pr-body ToC. One command to ship.
+description: Full PR pipeline for bashcuts — syntax checks, commit, push, create PR, triple code review (bash + PowerShell + security), criteria check, docs check, pr-body ToC. One command to ship.
 ---
 
 You are the full PR pipeline orchestrator for bashcuts (bash + PowerShell shortcuts repo). Run every check in the correct order, gate on failures, and produce a fully reviewed, documented PR.
@@ -11,9 +11,10 @@ You are the full PR pipeline orchestrator for bashcuts (bash + PowerShell shortc
 
 1. **Phase 1** — Pre-commit checks (bash syntax, PowerShell parse, shell parity, sourcing wire-up)
 2. **Phase 2** — Commit, push, create PR
-3. **Phase 3** — Docs check (`/docs-check`)
-4. **Phase 4** — Criteria check (`/criteria-check`)
-5. **Phase 5** — PR body ToC (`/pr-body`)
+3. **Phase 3** — Triple code review (`/code-review` — bash + PowerShell + security in parallel)
+4. **Phase 4** — Docs check (`/docs-check`)
+5. **Phase 5** — Criteria check (`/criteria-check`)
+6. **Phase 6** — PR body ToC (`/pr-body`)
 
 Each phase gates on the previous. If Phase 1 fails, stop.
 
@@ -144,7 +145,20 @@ If a PR already exists, note its number and URL and continue.
 
 ---
 
-## Phase 3 — Docs Check
+## Phase 3 — Triple Code Review
+
+Invoke `/code-review`. This launches three reviewers in parallel:
+- 🐚 Senior Bash Engineer
+- 💠 Senior PowerShell Engineer
+- 🛡️ Senior Security Engineer (`/security-review`)
+
+Each posts its own comment to the PR. Wait for all three to complete.
+
+**Gate:** If any reviewer returns `REQUEST CHANGES` on a CRITICAL finding, surface it to the user and ask whether to proceed or fix first. HIGH/MEDIUM findings are non-blocking but should be summarized.
+
+---
+
+## Phase 4 — Docs Check
 
 Invoke `/docs-check` as an Agent. Wait for completion.
 
@@ -152,7 +166,7 @@ Invoke `/docs-check` as an Agent. Wait for completion.
 
 ---
 
-## Phase 4 — Criteria Check
+## Phase 5 — Criteria Check
 
 Invoke `/criteria-check`. Wait for completion.
 
@@ -160,7 +174,7 @@ If no Acceptance Criteria section exists in the linked issue, note it and contin
 
 ---
 
-## Phase 5 — PR Body ToC
+## Phase 6 — PR Body ToC
 
 Invoke `/pr-body` to aggregate all skill report verdicts and update the PR body navigation hub.
 
@@ -179,6 +193,9 @@ Invoke `/pr-body` to aggregate all skill report verdicts and update the PR body 
 | Sourcing Wire-up | ✅ WIRED |
 | Shell Parity | ✅ MATCHED / ⚠️ bash-only / ⚠️ pwsh-only |
 | Debug Artifacts | ✅ CLEAN |
+| 🐚 Bash Engineer Review | ✅ APPROVE / ❌ REQUEST CHANGES |
+| 💠 PowerShell Engineer Review | ✅ APPROVE / ❌ REQUEST CHANGES |
+| 🛡️ Security Audit | ✅ PASS / ❌ FAIL |
 | Docs Check | ✅ CURRENT / ⚠️ <stale items> |
 | Criteria Check | ✅ PASS / ⏭️ no AC section |
 | PR Body | ✅ Updated |

--- a/.claude/commands/pr-flow.md
+++ b/.claude/commands/pr-flow.md
@@ -1,0 +1,194 @@
+---
+name: pr-flow
+description: Full PR pipeline for bashcuts — syntax checks, commit, push, create PR, criteria check, docs check, pr-body ToC. One command to ship.
+---
+
+You are the full PR pipeline orchestrator for bashcuts (bash + PowerShell shortcuts repo). Run every check in the correct order, gate on failures, and produce a fully reviewed, documented PR.
+
+**Repo:** `jdschleicher/bashcuts`
+
+## Overview
+
+1. **Phase 1** — Pre-commit checks (bash syntax, PowerShell parse, shell parity, sourcing wire-up)
+2. **Phase 2** — Commit, push, create PR
+3. **Phase 3** — Docs check (`/docs-check`)
+4. **Phase 4** — Criteria check (`/criteria-check`)
+5. **Phase 5** — PR body ToC (`/pr-body`)
+
+Each phase gates on the previous. If Phase 1 fails, stop.
+
+---
+
+## Phase 1 — Pre-Commit Checks
+
+Run these checks inline with Bash tools. Do NOT invoke `/docs-check` or other skills here — execute each check directly.
+
+**1a. Identify changed shell files:**
+```bash
+git diff --name-only main...HEAD 2>/dev/null
+git diff --name-only HEAD 2>/dev/null
+```
+
+**1b. Bash syntax:**
+```bash
+for f in $(git diff --name-only main...HEAD 2>/dev/null; git diff --name-only HEAD 2>/dev/null) ; do
+  case "$f" in
+    bashcuts_by_cli/*|.bcut_home)
+      bash -n "$f" 2>&1 && echo "OK: $f" || echo "SYNTAX ERROR: $f"
+      ;;
+  esac
+done | sort -u
+```
+Pass: every changed bash file parses with no syntax errors.
+
+**1c. PowerShell parse (only if pwsh is on PATH):**
+```bash
+if command -v pwsh >/dev/null 2>&1; then
+  for f in $(git diff --name-only main...HEAD 2>/dev/null; git diff --name-only HEAD 2>/dev/null) ; do
+    case "$f" in
+      powcuts_by_cli/*|powcuts_home.ps1)
+        pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('$f', [ref]\$null, [ref]\$null) | Out-Null" 2>&1 \
+          && echo "OK: $f" || echo "PARSE ERROR: $f"
+        ;;
+    esac
+  done | sort -u
+else
+  echo "SKIPPED — pwsh not on PATH"
+fi
+```
+Pass: every changed `.ps1` file parses, or pwsh unavailable (skipped, not failed).
+
+**1d. Sourcing wire-up — new files must be loaded:**
+
+For every brand-new file under `bashcuts_by_cli/`, verify a matching sourcing block exists in `.bcut_home`:
+```bash
+git diff --name-only --diff-filter=A main...HEAD 2>/dev/null | grep "^bashcuts_by_cli/" | while read f; do
+  base=$(basename "$f")
+  grep -q "$base" .bcut_home && echo "WIRED: $f" || echo "ORPHAN: $f (not sourced from .bcut_home)"
+done
+```
+
+Same for PowerShell:
+```bash
+git diff --name-only --diff-filter=A main...HEAD 2>/dev/null | grep "^powcuts_by_cli/" | while read f; do
+  base=$(basename "$f")
+  grep -q "$base" powcuts_home.ps1 && echo "WIRED: $f" || echo "ORPHAN: $f (not dot-sourced from powcuts_home.ps1)"
+done
+```
+Pass: zero ORPHAN entries.
+
+**1e. Shell parity (warning, not blocker):**
+```bash
+git diff --name-only main...HEAD 2>/dev/null | grep -E "^bashcuts_by_cli/|^powcuts_by_cli/" || true
+```
+If only one shell's files changed, surface it as a warning — the user may have intentionally made a shell-specific change, but flag it so they can confirm.
+
+**1f. Debug / leftover artifacts:**
+```bash
+git diff main...HEAD -- bashcuts_by_cli/ powcuts_by_cli/ .bcut_home powcuts_home.ps1 2>/dev/null \
+  | grep -E "^\+" \
+  | grep -iE "TODO|FIXME|XXX|console\.log|Write-Debug|set -x" || true
+```
+Pass: zero matches (or only intentional ones the user accepts).
+
+**Gate:** If 1b, 1c, or 1d fails, stop. Tell the user what failed. Do not proceed to Phase 2.
+
+---
+
+## Phase 2 — Commit, Push, and PR
+
+```bash
+git status
+git branch --show-current
+```
+
+**2a. Commit (if uncommitted changes):**
+Stage changed files by name (not `git add .`). Ask the user for a commit message or draft one. Commit.
+
+**2b. Push:**
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+**2c. Create PR (if none exists):**
+```bash
+gh pr view --repo jdschleicher/bashcuts --json number,url 2>/dev/null
+```
+If no PR:
+1. Extract issue number from branch name if present
+2. Look up issue title: `gh issue view <N> --repo jdschleicher/bashcuts --json title`
+3. Create PR:
+   ```bash
+   gh pr create \
+     --repo jdschleicher/bashcuts \
+     --title "<title>" \
+     --body "$(cat <<'EOF'
+   ## Summary
+   <brief description>
+
+   ## Issue
+   Closes #<N>
+
+   ## Changes
+   <list changed shortcut files / new aliases or functions>
+
+   ## Test Plan
+   - [ ] Open a fresh bash terminal — `<verb>-` + tab-tab autocompletes the new alias/function
+   - [ ] Run the new alias/function and confirm expected behavior
+   - [ ] Open a fresh PowerShell terminal — `<Verb-Noun>` runs without parse errors  *(if PowerShell parity)*
+   EOF
+   )"
+   ```
+
+If a PR already exists, note its number and URL and continue.
+
+---
+
+## Phase 3 — Docs Check
+
+Invoke `/docs-check` as an Agent. Wait for completion.
+
+**Gate:** If `STALE` findings exist (e.g. orphaned shortcut file, dead sourcing reference), surface them and ask whether to proceed or fix first. Cosmetic README drift is non-blocking; orphaned files in `bashcuts_by_cli/` or `powcuts_by_cli/` are blocking (users won't get the new shortcut).
+
+---
+
+## Phase 4 — Criteria Check
+
+Invoke `/criteria-check`. Wait for completion.
+
+If no Acceptance Criteria section exists in the linked issue, note it and continue.
+
+---
+
+## Phase 5 — PR Body ToC
+
+Invoke `/pr-body` to aggregate all skill report verdicts and update the PR body navigation hub.
+
+---
+
+## Final Summary
+
+```
+## PR Flow Complete — PR #<number>
+
+### Phase Results
+| Phase | Result |
+|-------|--------|
+| Bash Syntax | ✅ PASS |
+| PowerShell Parse | ✅ PASS / ⏭️ SKIPPED |
+| Sourcing Wire-up | ✅ WIRED |
+| Shell Parity | ✅ MATCHED / ⚠️ bash-only / ⚠️ pwsh-only |
+| Debug Artifacts | ✅ CLEAN |
+| Docs Check | ✅ CURRENT / ⚠️ <stale items> |
+| Criteria Check | ✅ PASS / ⏭️ no AC section |
+| PR Body | ✅ Updated |
+
+### PR
+**#<number>** — <title>
+**URL:** <url>
+
+### Verdict
+✅ READY TO MERGE
+  OR
+⚠️ NEEDS ATTENTION — <list blocking issues>
+```

--- a/.claude/commands/project-sync.md
+++ b/.claude/commands/project-sync.md
@@ -1,0 +1,108 @@
+---
+name: project-sync
+description: Syncs GitHub issues and PRs for the current task — ensures the current branch has an issue, the PR references it, and the issue state is correct.
+user_invocable: true
+---
+
+You are the project tracking sync agent for bashcuts. Ensure alignment between the GitHub issue, PR, and branch for the current task.
+
+**Repo:** `jdschleicher/bashcuts`
+
+---
+
+## Step 1 — Identify Current Task
+
+```bash
+git branch --show-current
+```
+
+Extract an issue number from the branch name if present (e.g., `feature/42-add-deploy-source` → issue `42`, or check the PR body).
+
+If no issue number can be found from the branch:
+```bash
+gh pr view --repo jdschleicher/bashcuts --json body --jq '.body' 2>/dev/null | grep -o "Closes #[0-9]*" | head -1
+```
+
+---
+
+## Step 2 — Verify Issue Exists and is Open
+
+```bash
+gh issue view <N> --repo jdschleicher/bashcuts --json number,title,state,url 2>/dev/null
+```
+
+**If no issue found:** Offer to create one via `/new-issue`.
+**If issue is closed:** Ask the user whether to reopen it or create a new one.
+
+---
+
+## Step 3 — Verify PR References the Issue
+
+```bash
+gh pr view --repo jdschleicher/bashcuts --json number,url,body 2>/dev/null
+```
+
+Check the PR body for `Closes #<N>`. If missing, offer to add it:
+
+```bash
+gh pr edit <PR_number> --repo jdschleicher/bashcuts --body "$(gh pr view <PR_number> --json body --jq '.body') 
+
+Closes #<N>"
+```
+
+---
+
+## Step 4 — Verify PR Title Matches Issue
+
+Compare the PR title against the issue title. They don't need to be identical, but the PR title should convey the same intent. Flag if they seem unrelated.
+
+---
+
+## Step 5 — Check for Missing Labels
+
+```bash
+gh issue view <N> --repo jdschleicher/bashcuts --json labels --jq '.labels[].name' 2>/dev/null
+```
+
+If the issue has no labels, offer to add appropriate ones (e.g., `enhancement`, `bug`, `bash`, `powershell`, `vscode-snippets`).
+
+---
+
+## Step 6 — Verify Branch is Pushed
+
+```bash
+git branch -r | grep $(git branch --show-current) || echo "Branch not pushed to remote"
+```
+
+If not pushed:
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+---
+
+## Step 7 — Report
+
+```
+## Project Sync Report
+
+### Issue
+#<N> — <title>
+State: open ✅
+URL: <url>
+Labels: <labels or "none">
+
+### PR
+#<PR_number> — <PR title>
+References issue: Yes (Closes #N) ✅ / No ❌
+
+### Branch
+<branch-name>
+Pushed to remote: Yes ✅ / No ❌
+
+### Actions Taken
+- <any fixes applied automatically>
+
+### Remaining Manual Steps
+- <anything that needs user action>
+```

--- a/.claude/commands/senior-bash-engineer.md
+++ b/.claude/commands/senior-bash-engineer.md
@@ -1,0 +1,203 @@
+---
+name: senior-bash-engineer
+description: Senior bash engineer review — quoting, POSIX vs bashism, error handling, alias vs function choice, naming convention, and macOS portability across changed bash files.
+---
+
+You are a **senior bash engineer** reviewing changes to bashcuts. Bashcuts ships shell aliases and functions sourced into the user's interactive shell (`.bashrc` / `.bash_profile`). A bug here means every user of the repo gets a broken shell — be thorough.
+
+---
+
+## Determine Changed Files
+
+```bash
+git diff main...HEAD --name-only 2>/dev/null | grep -E "^bashcuts_by_cli/|^\.bcut_home$" || git diff HEAD~1 --name-only | grep -E "^bashcuts_by_cli/|^\.bcut_home$"
+```
+
+If no bash files changed, skip with verdict `APPROVE — no bash files in this diff`.
+
+Read each changed file in full. Also read one or two surrounding files in `bashcuts_by_cli/` for the established style.
+
+---
+
+## Check 1 — Syntax [CRITICAL if violated]
+
+```bash
+for f in $(git diff main...HEAD --name-only | grep -E "^bashcuts_by_cli/|^\.bcut_home$"); do
+  bash -n "$f" 2>&1 && echo "OK: $f" || echo "SYNTAX ERROR: $f"
+done
+```
+
+**Flag:** any `SYNTAX ERROR` as **[CRITICAL]** — sourcing the file will break the user's shell.
+
+---
+
+## Check 2 — Unquoted Variable Expansions [HIGH]
+
+Unquoted `$var` or `$(...)` expansions break on paths with spaces (Windows users with `C:\Program Files`, macOS `~/Library/Application Support`, etc).
+
+```bash
+git diff main...HEAD -- 'bashcuts_by_cli/*' '.bcut_home' \
+  | grep "^+" | grep -v "^+++" \
+  | grep -nE '\$\{?[A-Za-z_][A-Za-z0-9_]*\}?[^"]' \
+  | grep -vE '"\$|=\$' || true
+```
+
+For each match, verify whether quoting is missing in a context where it matters (command arguments, conditionals, paths). False positives are common — use judgment, but flag real ones as **[HIGH]**.
+
+The README explicitly warns about path-with-spaces; new code must respect that.
+
+---
+
+## Check 3 — Naming Convention [MEDIUM]
+
+Bashcuts uses `verb-noun` for aliases and functions so tab-tab autocompletion groups intuitively. Examples: `open-sfdx`, `deploy-source`, `o-jira`.
+
+```bash
+git diff main...HEAD -- 'bashcuts_by_cli/*' \
+  | grep "^+alias \|^+function " \
+  | grep -v "^+++" || true
+```
+
+**Flag** as **[MEDIUM]**:
+- Aliases without a hyphen (`deploysource` instead of `deploy-source`)
+- Aliases that don't follow the established prefix in the file (e.g. an `o-` "open" file getting a non-`o-` alias)
+- camelCase or snake_case names (the convention is kebab-case)
+
+---
+
+## Check 4 — Alias vs Function Choice [MEDIUM]
+
+- `alias` — for fixed commands or simple substitutions with no arguments interpolated mid-command
+- function — for anything that takes positional args, prompts the user, has conditionals, or uses `$1`, `$2`, `$@`
+
+```bash
+git diff main...HEAD -- 'bashcuts_by_cli/*' \
+  | grep "^+alias " | grep -v "^+++" \
+  | grep -E '\$1|\$2|\$@|\$\*' || true
+```
+
+**Flag** as **[MEDIUM]**: `alias` definitions that try to use positional parameters (they don't expand inside an alias the way users expect — use a function instead).
+
+---
+
+## Check 5 — Error Handling for Prompts [MEDIUM]
+
+The README notes that "Many of the shortcuts provide prompts to support populated necessary arguments/flags." When a function uses `read` to prompt the user, an empty response should be handled gracefully (not silently passed as an empty argument to a destructive command).
+
+```bash
+git diff main...HEAD -- 'bashcuts_by_cli/*' \
+  | grep -A 3 "^+read " || true
+```
+
+**Flag** as **[MEDIUM]**: `read` prompts feeding a destructive command (`rm`, `git reset --hard`, `gh pr close`, `sfdx force:org:delete`) without checking for empty input.
+
+---
+
+## Check 6 — macOS `start` Compatibility [HIGH]
+
+The README flags this explicitly: macOS doesn't have `start`, and `.bcut_home` aliases it to `open` on Darwin. New code that uses `start` must rely on that alias being in effect — not redefine it, not assume Linux/Windows-only `start` semantics.
+
+```bash
+git diff main...HEAD -- 'bashcuts_by_cli/*' '.bcut_home' \
+  | grep "^+" | grep -v "^+++" | grep -E "\bstart\b" || true
+```
+
+**Flag** as **[HIGH]**: any `start` invocation that passes flags only valid on one platform (e.g. Windows `start /B`, macOS `open -a "App"`) without a Darwin/Linux conditional.
+
+---
+
+## Check 7 — Bashism vs POSIX [LOW]
+
+Bashcuts targets bash specifically (the README says so), so bashisms are fine. But flag uses of features that don't work in older bash versions still common on macOS (default `/bin/bash` is 3.2):
+
+```bash
+git diff main...HEAD -- 'bashcuts_by_cli/*' '.bcut_home' \
+  | grep "^+" | grep -v "^+++" \
+  | grep -E "declare -A|mapfile|readarray|\\\$\\\{[A-Za-z_]+\\\^\\\^\\\}|\\\$\\\{[A-Za-z_]+,,\\\}" || true
+```
+
+Matches use bash 4+ features (associative arrays, `mapfile`, `${var^^}` upper-casing). **Flag** as **[LOW]** with a note: macOS users on stock `/bin/bash` won't get these. Most users have a newer bash installed, so this is informational, not blocking.
+
+---
+
+## Check 8 — Sourcing Wire-Up [HIGH]
+
+If any new file was added under `bashcuts_by_cli/`, `.bcut_home` must source it — otherwise users won't get the new shortcuts after `reinit`.
+
+```bash
+git diff --name-only --diff-filter=A main...HEAD | grep "^bashcuts_by_cli/" | while read f; do
+  base=$(basename "$f")
+  grep -q "$base" .bcut_home && echo "WIRED: $f" || echo "ORPHAN: $f"
+done
+```
+
+**Flag** any `ORPHAN` as **[HIGH]**.
+
+---
+
+## Check 9 — Side Effects on Source [HIGH]
+
+Files in `bashcuts_by_cli/` are sourced into the user's interactive shell. Anything that runs at source time runs every time the user opens a terminal.
+
+```bash
+git diff main...HEAD -- 'bashcuts_by_cli/*' '.bcut_home' \
+  | grep "^+" | grep -v "^+++" \
+  | grep -vE "^\+#|^\+\s*$|^\+alias |^\+function |^\+\}|^\+\s*\}" \
+  | grep -E "^\+(echo|curl|wget|git |sfdx |gh |npm |sleep)" || true
+```
+
+**Flag** as **[HIGH]**: top-level statements that produce output, hit the network, or take more than negligible time. Bashcuts already does some `echo`s at source time (the README shows "bashrc loaded") — that's the established pattern, but new ones add noise.
+
+---
+
+## Check 10 — Quoting in `[ ]` and `[[ ]]` [MEDIUM]
+
+```bash
+git diff main...HEAD -- 'bashcuts_by_cli/*' '.bcut_home' \
+  | grep "^+" | grep -v "^+++" \
+  | grep -E "\[ +\\\$[A-Za-z_]+ |\\\$[A-Za-z_]+ +-(eq|ne|lt|gt|le|ge|z|n) " || true
+```
+
+Single-bracket `[ ]` performs word splitting on unquoted variables — empty values cause syntax errors. **Flag** as **[MEDIUM]** unless surrounded by `[[ ]]` (which doesn't have this issue).
+
+---
+
+## Output Format
+
+```
+## 🐚 Code Review — Senior Bash Engineer
+
+### Summary
+<1-2 sentences: what bash files changed and overall assessment>
+
+### Findings
+
+| Severity | Location | Issue |
+|----------|----------|-------|
+| [CRITICAL/HIGH/MEDIUM/LOW] | file:line | description + suggested fix |
+
+### Sourcing Wire-Up
+WIRED — all new files are sourced from .bcut_home
+  OR
+ORPHAN — <list of files not sourced>
+
+### Naming Convention
+PASS — all new aliases/functions follow verb-noun
+  OR
+DRIFT — <list of off-convention names>
+
+### Verdict
+APPROVE — no blocking issues
+  OR
+REQUEST CHANGES — <N> critical/high issues require fixes
+```
+
+---
+
+## Post to PR (if a PR exists)
+
+```bash
+gh pr view --json number 2>/dev/null --jq '.number'
+```
+
+If a PR number is returned, post the report as a comment with the heading `## 🐚 Code Review — Senior Bash Engineer`.

--- a/.claude/commands/senior-powershell-engineer.md
+++ b/.claude/commands/senior-powershell-engineer.md
@@ -1,0 +1,222 @@
+---
+name: senior-powershell-engineer
+description: Senior PowerShell engineer review — approved verbs, parameter binding, error handling, output streams, and naming convention across changed .ps1 files.
+---
+
+You are a **senior PowerShell engineer** reviewing changes to bashcuts. Bashcuts ships PowerShell functions dot-sourced into the user's `$profile` — a bug here breaks every PowerShell terminal session for users of this repo.
+
+---
+
+## Determine Changed Files
+
+```bash
+git diff main...HEAD --name-only 2>/dev/null | grep -E "^powcuts_by_cli/|^powcuts_home\.ps1$" || git diff HEAD~1 --name-only | grep -E "^powcuts_by_cli/|^powcuts_home\.ps1$"
+```
+
+If no PowerShell files changed, skip with verdict `APPROVE — no PowerShell files in this diff`.
+
+Read each changed file in full. Read one or two surrounding files in `powcuts_by_cli/` for the established style.
+
+---
+
+## Check 1 — Parse [CRITICAL if violated]
+
+```bash
+if command -v pwsh >/dev/null 2>&1; then
+  for f in $(git diff main...HEAD --name-only | grep -E "^powcuts_by_cli/|^powcuts_home\.ps1$"); do
+    pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('$f', [ref]\$null, [ref]\$null) | Out-Null" 2>&1 \
+      && echo "OK: $f" || echo "PARSE ERROR: $f"
+  done
+else
+  echo "SKIPPED — pwsh not on PATH; rely on visual review for syntax"
+fi
+```
+
+**Flag:** any `PARSE ERROR` as **[CRITICAL]** — dot-sourcing the file will break the user's PowerShell session.
+
+---
+
+## Check 2 — Approved Verbs [HIGH]
+
+PowerShell convention: function names use `Verb-Noun`, where Verb is from `Get-Verb`. Non-approved verbs trigger a warning whenever the user dot-sources the profile.
+
+```bash
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' \
+  | grep "^+function " | grep -v "^+++" || true
+```
+
+For each new function, verify the verb is approved. Common acceptable verbs: `Get`, `Set`, `New`, `Remove`, `Open`, `Start`, `Stop`, `Invoke`, `Test`, `Show`, `Find`, `Add`, `Clear`, `Copy`, `Move`, `Rename`, `Update`, `Use`, `Build`, `Deploy`, `Publish`, `Push`, `Pull`, `Sync`, `Read`, `Write`, `Watch`, `Connect`, `Disconnect`, `Enable`, `Disable`.
+
+**Flag** as **[HIGH]**: function names like `RunFoo`, `DoBar`, `Bashcuts-Foo` (no verb), or domain-specific words used as verbs.
+
+---
+
+## Check 3 — Naming Parity with Bash Counterpart [MEDIUM]
+
+If a bash counterpart exists in `bashcuts_by_cli/`, the PowerShell function should mirror its name. Bash uses `verb-noun` lowercase; PowerShell should use `Verb-Noun` PascalCase with the same words.
+
+Bash `deploy-source` ↔ PowerShell `Deploy-Source`. Bash `o-jira` ↔ PowerShell `Open-Jira` (or `O-Jira` if preserving the short prefix is intentional).
+
+```bash
+git diff main...HEAD --name-only | grep "^powcuts_by_cli/" | while read f; do
+  base=$(basename "$f" .ps1)
+  case "$base" in
+    pow_common|pow_open|pow_az_cli) echo "INFRA: $f — no direct bash counterpart expected" ;;
+    *) echo "Check parity for: $f against bashcuts_by_cli/.${base}_bashcuts" ;;
+  esac
+done
+```
+
+**Flag** as **[MEDIUM]**: PowerShell functions with no matching bash alias when the issue called for shell parity.
+
+---
+
+## Check 4 — `Write-Host` Misuse [HIGH]
+
+`Write-Host` writes to the host UI but does not produce pipeline output — it cannot be captured, redirected, or composed. Use it only for user-facing status messages, never for the function's actual return value.
+
+```bash
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' \
+  | grep "^+" | grep -v "^+++" | grep -E "Write-Host" || true
+```
+
+**Flag** as **[HIGH]**: `Write-Host` used to emit data the caller would want to consume (paths, IDs, JSON). The bashcuts pattern is mostly interactive shortcuts where status messaging is fine — use judgment, but flag clear misuses.
+
+For data, prefer `Write-Output`, plain expressions, or `return`.
+
+---
+
+## Check 5 — Aliases Inside Scripts [MEDIUM]
+
+Aliases (`ls`, `cat`, `?`, `%`) and partial cmdlet names are unreliable across PowerShell versions and host configs. Inside script files, prefer full cmdlet names.
+
+```bash
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' \
+  | grep "^+" | grep -v "^+++" \
+  | grep -E "(\| *(\?|%|select|ft|fl|measure|sort|group)\b)|(^\+ *(ls|cat|cd|cp|mv|rm|cls|gci|gc) )" || true
+```
+
+**Flag** as **[MEDIUM]**: `?` (Where-Object), `%` (ForEach-Object), `select` (Select-Object), `ls`/`gci` (Get-ChildItem), `cat`/`gc` (Get-Content) used inside committed `.ps1` files. They're fine in interactive use, not in shipped scripts.
+
+---
+
+## Check 6 — Error Handling [MEDIUM]
+
+External commands (`sfdx`, `gh`, `git`, `cci`) signal failure via exit code, not via PowerShell exceptions. Functions that chain commands need to check `$LASTEXITCODE` or set `$ErrorActionPreference`.
+
+```bash
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' \
+  | grep "^+" | grep -v "^+++" \
+  | grep -E "(sfdx |gh |git |cci |npm |az )" || true
+```
+
+**Flag** as **[MEDIUM]**: a function that runs a destructive external command (`gh pr close`, `git push --force`, `sfdx force:org:delete`) and continues afterward without checking `$LASTEXITCODE`.
+
+---
+
+## Check 7 — Param Block & CmdletBinding [LOW]
+
+Functions taking arguments are easier to use and document with a proper `param()` block:
+
+```powershell
+function Deploy-Source {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [string]$TargetOrg
+    )
+    ...
+}
+```
+
+```bash
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' \
+  | grep -A 5 "^+function " | grep -v "^+++" || true
+```
+
+**Flag** as **[LOW]** (informational): new functions that take arguments via `$args` or positional `$args[0]` instead of a named `param()` block. Existing bashcuts functions vary on this, so don't insist — just suggest.
+
+---
+
+## Check 8 — Dot-Sourcing Wire-Up [HIGH]
+
+If any new `.ps1` was added under `powcuts_by_cli/`, `powcuts_home.ps1` must dot-source it.
+
+```bash
+git diff --name-only --diff-filter=A main...HEAD | grep "^powcuts_by_cli/" | while read f; do
+  base=$(basename "$f")
+  grep -q "$base" powcuts_home.ps1 && echo "WIRED: $f" || echo "ORPHAN: $f"
+done
+```
+
+**Flag** any `ORPHAN` as **[HIGH]**.
+
+---
+
+## Check 9 — Cross-Platform Path Separators [MEDIUM]
+
+The README shows the PowerShell snippet using `\` separators (`C:\git\bashcuts`), aimed at Windows. New code should not assume `\` if it builds paths from input — use `Join-Path` or `[IO.Path]::Combine` for portability.
+
+```bash
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' \
+  | grep "^+" | grep -v "^+++" | grep -E '"[A-Za-z]:\\\\|"\\\\' || true
+```
+
+**Flag** as **[MEDIUM]**: hard-coded Windows-style paths in a function meant to work cross-platform. Existing bashcuts content may be Windows-first — use judgment.
+
+---
+
+## Check 10 — Profile Side Effects [HIGH]
+
+Files in `powcuts_by_cli/` are dot-sourced into the user's profile. Top-level statements run on every PowerShell startup.
+
+```bash
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' 'powcuts_home.ps1' \
+  | grep "^+" | grep -v "^+++" \
+  | grep -vE "^\+#|^\+\s*$|^\+function |^\+param\(|^\+\}|^\+\s*\}" \
+  | grep -E "^\+(Write-Host|Invoke-WebRequest|Invoke-RestMethod|git |sfdx |gh |npm |Start-Sleep)" || true
+```
+
+**Flag** as **[HIGH]**: top-level statements that produce output, hit the network, or block. The existing entry-point already does a `Write-Host` "PowerShell bashcuts exists" — that's the established pattern. New unconditional output is noise.
+
+---
+
+## Output Format
+
+```
+## 💠 Code Review — Senior PowerShell Engineer
+
+### Summary
+<1-2 sentences: what .ps1 files changed and overall assessment>
+
+### Findings
+
+| Severity | Location | Issue |
+|----------|----------|-------|
+| [CRITICAL/HIGH/MEDIUM/LOW] | file:line | description + suggested fix |
+
+### Dot-Sourcing Wire-Up
+WIRED — all new .ps1 files are dot-sourced from powcuts_home.ps1
+  OR
+ORPHAN — <list of files not dot-sourced>
+
+### Approved Verbs
+PASS — all new function names use approved verbs
+  OR
+DRIFT — <list of off-convention names + suggested approved verb>
+
+### Verdict
+APPROVE — no blocking issues
+  OR
+REQUEST CHANGES — <N> critical/high issues require fixes
+```
+
+---
+
+## Post to PR (if a PR exists)
+
+```bash
+gh pr view --json number 2>/dev/null --jq '.number'
+```
+
+If a PR number is returned, post the report as a comment with the heading `## 💠 Code Review — Senior PowerShell Engineer`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,208 @@
+# Claude Code Assistant Instructions — bashcuts
+
+## AI Context & Project Overview
+
+You are assisting with **bashcuts**, a personal collection of **bash aliases / functions** and **PowerShell functions** that get sourced into the user's interactive shell (`.bashrc` / `$profile`). The point is to turn long, frequently-used CLI invocations (sfdx, gh, git, az, cci, jira, etc.) into tab-tab-completable `verb-noun` shortcuts.
+
+There is **no compiler, no test runner, and no lint step**. Quality gates are: bash parses cleanly, PowerShell parses cleanly, files are wired into the entry points, and the user verifies behavior in a fresh terminal.
+
+### Key Project Files
+
+- `.bcut_home` — bash entry point; `source`-s every file under `bashcuts_by_cli/`. The user wires this into their `.bashrc` once
+- `powcuts_home.ps1` — PowerShell entry point; dot-sources every file under `powcuts_by_cli/`. The user wires this into their `$profile` once
+- `bashcuts_by_cli/.<cli>_bashcuts` — one file per CLI/tool, contains `alias` and function definitions
+- `powcuts_by_cli/<cli>.ps1` — PowerShell counterparts; contains `function Verb-Noun { … }` definitions
+- `vscode_snippets/*.code-snippets` — VS Code snippet JSON files synced via VS Code Settings Sync
+- `README.md` — end-user setup and usage guide
+
+## Primary Objectives
+
+1. **Maintain bash + PowerShell parity** — when you add a shortcut for a CLI to one shell, add the equivalent to the other unless the user explicitly says shell-specific
+2. **`verb-noun` naming** — every alias/function is `verb-noun` (lowercase in bash, PascalCase in PowerShell) so users can tab-tab to discover them by prefix
+3. **Wire new files into the entry points** — a brand-new `bashcuts_by_cli/.foo_bashcuts` is dead weight unless `.bcut_home` sources it; same for `.ps1` ↔ `powcuts_home.ps1`
+4. **Match the surrounding style** — read the file you're editing first; bashcuts content varies in formatting and prompt patterns, follow what's already there
+
+## Quick Command Reference
+
+```bash
+# Verify a bash file parses (no syntax errors)
+bash -n bashcuts_by_cli/.<file>
+
+# Verify a PowerShell file parses (if pwsh is on PATH)
+pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/<file>.ps1', [ref]$null, [ref]$null) | Out-Null"
+
+# Confirm a new bash file is sourced from .bcut_home
+grep "<filename>" .bcut_home
+
+# Confirm a new .ps1 is dot-sourced from powcuts_home.ps1
+grep "<filename>" powcuts_home.ps1
+
+# Reload bash shortcuts in the current shell (after editing)
+reinit   # if defined in the user's environment, otherwise open a new shell
+
+# Open the file containing aliases for a given CLI (uses the o- "open" prefix)
+o-sfdx   o-git   o-gh   o-az   o-cci
+```
+
+## CRITICAL RULES — NO EXCEPTIONS
+
+### After Every Code Change
+
+1. **Bash parse** — `bash -n` every changed file under `bashcuts_by_cli/` and `.bcut_home`. Zero errors. A syntax error here breaks every user's shell on next source.
+2. **PowerShell parse** — parse every changed file under `powcuts_by_cli/` and `powcuts_home.ps1` (skip if `pwsh` is unavailable). Zero errors.
+3. **Sourcing wire-up** — for any newly-added shell file, confirm it's sourced from the matching entry point.
+4. **Side-effect audit** — anything outside an `alias` or `function` body runs at source time, on every shell startup. Don't add `echo`s, network calls, or sleeps without a deliberate reason.
+5. **Verification plan** — describe what to type in a fresh bash and/or PowerShell terminal to confirm the change works (the user will run this; you cannot).
+
+### Naming Mandates
+
+- **Bash:** `lowercase-verb-noun` (`deploy-source`, `open-jira`, `o-sfdx`). Prefer the prefix already used in the target file (`o-` for opens, `g-` if a file uses it).
+- **PowerShell:** `Verb-Noun` PascalCase, with **approved verbs** (`Get-Verb`). Common acceptable verbs: `Get`, `Set`, `New`, `Open`, `Start`, `Stop`, `Invoke`, `Test`, `Show`, `Find`, `Add`, `Remove`, `Build`, `Deploy`, `Publish`, `Push`, `Pull`, `Sync`, `Connect`, `Watch`. Non-approved verbs trigger a warning every time the user dot-sources their profile.
+- **Mirror across shells:** bash `deploy-source` ↔ PowerShell `Deploy-Source`. Same words.
+
+### Code Style Mandates
+
+- **alias vs function (bash)** — use `alias` only for fixed substitutions. The moment you need `$1`, `$2`, `$@`, `read`, conditionals, or anything multi-line, use a function. Aliases don't expand positional parameters the way callers expect.
+- **No `Write-Host` for data (PowerShell)** — `Write-Host` cannot be captured or piped. Use it only for user-facing status messages. For values the caller might want to consume, use `Write-Output`, plain expressions, or `return`.
+- **No in-script aliases (PowerShell)** — inside committed `.ps1` files prefer full cmdlet names (`Where-Object` over `?`, `ForEach-Object` over `%`, `Get-ChildItem` over `ls`/`gci`).
+- **Quote variable expansions (bash)** — paths with spaces (`C:\Program Files`, `~/Library/Application Support`) break unquoted `$var`. The README explicitly warns about path-with-spaces; new code must respect that.
+- **macOS `start`** — `.bcut_home` aliases `start` to `open` on Darwin. Code that uses `start` to open files/URLs is fine; **don't redefine `start` and don't pass platform-specific flags** (e.g. Windows `start /B`, mac `open -a "App"`) without an OS conditional.
+- **No comments for self-evident code** — only comment where the logic is genuinely non-obvious.
+
+## Project Structure
+
+```
+.
+├── .bcut_home                          # Bash entry point — sources every file under bashcuts_by_cli/
+├── powcuts_home.ps1                    # PowerShell entry point — dot-sources every file under powcuts_by_cli/
+├── README.md                           # End-user setup + usage guide
+├── bashcuts_by_cli/                    # Bash shortcut files, one per CLI/tool
+│   ├── .bash_commons                   # Shared helpers used by other files
+│   ├── .sfdxcli_bashcuts                # Salesforce sfdx
+│   ├── .gitcli_bashcuts                # git
+│   ├── .ghcli_bashcuts                 # GitHub CLI (gh)
+│   ├── .ccicli_bashcuts                # CumulusCI (cci)
+│   ├── .az_bashcuts                    # Azure CLI
+│   ├── .open_bashcuts                  # "o-" open shortcuts (open files / URLs)
+│   ├── .robot_bashcuts                 # Robot Framework helpers
+│   └── .support_bashcuts               # Misc support
+├── powcuts_by_cli/                     # PowerShell counterparts
+│   ├── pow_common.ps1                  # Shared helpers
+│   ├── pow_open.ps1                    # "Open-" shortcuts
+│   ├── sfdx_cli.ps1
+│   ├── git_common.ps1
+│   ├── pow_az_cli.ps1
+│   ├── pester.ps1                      # Pester test helpers
+│   └── jira_automations.ps1
+└── vscode_snippets/                    # VS Code snippets synced via VS Code Settings Sync
+    ├── Apex.code-snippets
+    ├── azure-cli.code-snippets
+    ├── lwc.code-snippets
+    └── powershell.code-snippets
+```
+
+Note the asymmetric naming: bash files use a `.<cli>_bashcuts` dotfile pattern, PowerShell uses `<cli>.ps1`. Some bash files have no dedicated PowerShell counterpart and vice-versa (e.g. `.bash_commons` ↔ `pow_common.ps1`, `.support_bashcuts` has no pwsh equivalent). That's intentional — only enforce parity when the issue calls for it or when adding a new CLI wrapper.
+
+## Architecture Patterns
+
+### Shell Load Flow
+
+```
+User opens a terminal
+  → ~/.bashrc sources $PATH_TO_BASHCUTS/bashcuts/.bcut_home
+    → .bcut_home runs an `if [ -f … ]; then source …` block per file under bashcuts_by_cli/
+      → each .<cli>_bashcuts defines aliases + functions in the user's interactive shell
+
+User opens a PowerShell terminal
+  → $profile dot-sources $path_to_bashcuts\powcuts_home.ps1
+    → powcuts_home.ps1 dot-sources each .ps1 under powcuts_by_cli/
+      → each <cli>.ps1 defines functions in the user's session
+```
+
+### Key Design Decisions
+
+- **Sourced into the interactive shell, not run as a script.** Top-level code runs on every shell startup. Anything that isn't an `alias`/`function` definition is a side effect. The existing entry points already do `echo "bashrc loaded"` and `Write-Host "powershell starting"` — that's the established pattern, but new unconditional output is noise.
+- **Path-with-spaces is unsupported by design.** The README tells users to clone bashcuts into a path without spaces. `.bcut_home` uses unquoted `$PATH_TO_BASHCUTS/bashcuts/...` because of this. When adding new code, still quote your own variables — but don't try to "fix" the entry-point path handling unless the user asks.
+- **`reinit` reloads in the current shell** — modifying a file requires re-sourcing or opening a new shell. The README points users at this. Tell users which one they need to do after a change.
+- **`o-` is the open prefix** — `o-sfdx`, `o-git`, etc. open the underlying shortcut file in the editor (commonly VS Code) so the user can browse/edit shortcuts without leaving the terminal. Honor that prefix when adding open shortcuts.
+
+### Tab-Completion Convention
+
+Tab-tab on `verb-` shows every alias/function with that verb. This is why naming must be `verb-noun` — it's the discovery mechanism. Examples: `o-` → opens, `deploy-` → deployments, `get-` → gets. A new shortcut should slot into an existing verb prefix when it makes sense; only invent a new verb when none of the existing ones fit.
+
+## Implementation Checklist
+
+When implementing a new feature or fixing a bug:
+
+- [ ] Read the target file(s) before making changes — match the existing style
+- [ ] If adding a CLI wrapper, implement in **both** `bashcuts_by_cli/` (bash) and `powcuts_by_cli/` (PowerShell) — unless the issue says shell-specific
+- [ ] If you create a new file under `bashcuts_by_cli/`, add a sourcing block to `.bcut_home`
+- [ ] If you create a new file under `powcuts_by_cli/`, add a dot-sourcing block to `powcuts_home.ps1`
+- [ ] `bash -n` every changed bash file — zero syntax errors
+- [ ] Parse every changed `.ps1` (or note pwsh unavailable)
+- [ ] Update README if you added a new CLI section, new prerequisite tool, or changed the setup snippets
+- [ ] Provide a verification plan: what to type in a fresh bash terminal and/or PowerShell terminal to confirm the new shortcut works
+
+## Common Tasks
+
+### Adding a New CLI Shortcut to an Existing File
+
+1. Identify the target file (`bashcuts_by_cli/.<cli>_bashcuts` and `powcuts_by_cli/<cli>.ps1`)
+2. Choose a `verb-noun` name; check for collisions: `grep "alias <verb-noun>=" bashcuts_by_cli/*` and `grep "function <Verb-Noun>" powcuts_by_cli/*`
+3. Add the alias/function in both files, matching the established style of neighboring entries
+4. `bash -n` and `pwsh` parse the changed files
+5. Provide the user a verification plan — open a new bash terminal, tab-tab on the verb prefix, run the shortcut
+
+### Adding a Wrapper for a Brand-New CLI
+
+1. Create `bashcuts_by_cli/.<newcli>_bashcuts` and `powcuts_by_cli/<newcli>.ps1`
+2. Add a sourcing block to `.bcut_home` (mirror the existing `if [ -f … ]; then source …; else echo "missing …"; fi` pattern)
+3. Add a dot-sourcing block to `powcuts_home.ps1` (mirror the existing `Get-Content`/`if`/`. <path>` pattern)
+4. Add the new CLI to the README's prerequisites bullet list
+5. Add a brief mention under "How to use bashcuts" so `o-<newcli>` discovery makes sense
+
+### Fixing a Bug in an Existing Shortcut
+
+1. Reproduce the failure path mentally (or ask the user for the exact command they typed and the error)
+2. Read the function/alias and any helpers it calls (`.bash_commons` for bash, `pow_common.ps1` for PowerShell)
+3. Apply the minimum fix — bashcuts grows by accretion; resist refactoring neighboring shortcuts
+4. Provide a verification plan that exercises the fixed path
+
+### Adding or Updating a VS Code Snippet
+
+1. Edit the relevant `vscode_snippets/<lang>.code-snippets` JSON file
+2. Validate the JSON parses (`python -c "import json,sys; json.load(open(sys.argv[1]))" vscode_snippets/<file>.code-snippets`)
+3. Tell the user that their editor will pick the change up via Settings Sync — no shell `reinit` needed
+
+## Slash Commands (`.claude/commands/`)
+
+This repo defines its own Claude Code slash commands:
+
+| Command | What it does |
+|---|---|
+| `/new-issue` | Interactive product discovery → drafts and creates a GitHub issue |
+| `/next-task <N>` | Picks up an issue, creates a feature branch, plans the work |
+| `/project-sync` | Aligns issue ↔ PR ↔ branch on GitHub |
+| `/criteria-check` | Verifies issue acceptance criteria against the code |
+| `/docs-check` | Audits README + sourcing wire-up |
+| `/code-review` | Runs `senior-bash-engineer` + `senior-powershell-engineer` + `/security-review` in parallel |
+| `/senior-bash-engineer` | Solo bash review (called by `/code-review`) |
+| `/senior-powershell-engineer` | Solo PowerShell review (called by `/code-review`) |
+| `/pr-body` | Builds / refreshes the PR body table of contents |
+| `/pr-flow` | Full pipeline: parse-checks → commit → push → PR → code-review → docs-check → criteria-check → pr-body |
+
+Use them. `/pr-flow` is the standard "ship it" command.
+
+## Remember
+
+- **Both shells** — new CLI wrappers go in `bashcuts_by_cli/` AND `powcuts_by_cli/` unless the issue is shell-specific
+- **Wire it up** — a new file in `bashcuts_by_cli/` must be sourced from `.bcut_home`; a new `.ps1` must be dot-sourced from `powcuts_home.ps1`
+- **`verb-noun`** — every alias/function name; bash lowercase, PowerShell PascalCase with an approved verb
+- **Side effects on source** — anything outside `alias`/`function` runs on every shell startup; don't add noise
+- **Mac `start`** — already aliased to `open` on Darwin in `.bcut_home`; don't redefine
+- **Path-with-spaces** — clone path is unsupported per README; quote your own variables but don't try to "fix" the entry points
+- **No tests / no compiler** — your gates are `bash -n`, `pwsh` parse, sourcing wire-up, and a verification plan the user can run
+
+---
+
+_This document is optimized for Claude Code. Refer to `README.md` for end-user setup and usage._


### PR DESCRIPTION
## Summary
- Adds 7 slash commands under `.claude/commands/` for use with Claude Code
- 5 generic workflow skills ported from `jdschleicher/salesforce-data-treecipe` with treecipe-specific bits (FakerJS/Snowfakery, jest, vsce, src/treecipe paths) stripped and the repo slug swapped to `jdschleicher/bashcuts`
- 2 skills (`docs-check`, `pr-flow`) rewritten from scratch for a shell-script repo with no compile/test/lint pipeline — they instead validate bash syntax, PowerShell parse, sourcing wire-up in `.bcut_home` / `powcuts_home.ps1`, and shell parity between `bashcuts_by_cli/` and `powcuts_by_cli/`

## Files Added
| File | Adaptation |
|---|---|
| `new-issue.md` | bashcuts framing, shell-parity discovery questions |
| `next-task.md` | branch + implement workflow for shortcut files |
| `project-sync.md` | repo slug swap + bash/powershell labels |
| `pr-body.md` | slimmer skill ToC (only skills present in this repo) |
| `criteria-check.md` | greps shell files instead of TS; pwsh parse check; no jest |
| `docs-check.md` | README sourcing audit (no CHANGELOG/CLAUDE.md/package.json) |
| `pr-flow.md` | bash syntax + pwsh parse + sourcing wire-up gate (no compile/lint/test) |

## Skills Intentionally Skipped
Treecipe-specific (TypeScript, XML, vsce, faker backends, CodeTour): `code-review`, `contract-test`, `debug-audit`, `debug-tour`, `deploy-check`, `diagram-check`, `generate-tour`, `perf-review`, `pr-diagram`, `pre-commit`, `supply-chain-check`, `jidoka`. Already a Claude Code built-in: `security-review`.

## Test Plan
- [ ] In a Claude Code session inside this repo, type `/` and confirm the 7 new commands appear
- [ ] Run `/docs-check` against `main` and confirm it reports CURRENT (or accurate staleness)
- [ ] Run `/criteria-check` on a branch with a linked issue and confirm shell-file evidence rendering
- [ ] On a feature branch, run `/pr-flow` end-to-end and confirm Phase 1 gates work (bash syntax, pwsh parse, sourcing wire-up)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2ZbKbx8f8W2jwqHnHjM1Y)_