### PR TITLE
Add Azure DevOps work-item shortcuts with guided setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 * [Choose which Prerequisite CLI's and Other Tools to Install](#tools-used)
 * [System Setup for bash and PowerShell Profiles](#system-setup)
 * [How to use bashcuts](#how-to)
+* [Azure DevOps work-item shortcuts](#azure-devops)
 
 <br>
 
@@ -17,6 +18,8 @@
 - GitHub CLI: https://cli.github.com/
 - CumulusCI: https://cumulusci.readthedocs.io/en/stable/
 - jQ: https://stedolan.github.io/jq/
+- Azure CLI (only if you use the Azure DevOps work-item shortcuts): https://aka.ms/installazurecli
+  - plus the `azure-devops` extension: `az extension add --name azure-devops`
 - sfdx plugins:
   - sfdx scanner: https://forcedotcom.github.io/sfdx-scanner/
   - sfdx texei: https://github.com/texei/texei-sfdx-plugin
@@ -149,4 +152,41 @@ For windows machines, the snippets are stored in an expected directory, so we ca
 
 ![image](https://github.com/jdschleicher/bashcuts/assets/3968818/00f97b96-60a3-488a-9eca-71202fd922d2)
 
+***
+
+<br>
+
+# <a name="azure-devops"></a>Azure DevOps work-item shortcuts
+
+PowerShell shortcuts in `powcuts_by_cli/azdevops_workitems.ps1` provide guided setup and work-item navigation against an Azure DevOps organization. Future commands in this batch will add cached lists of items assigned to you, items you've been mentioned in, an Epic→Feature→User Story tree view, and an interactive new-user-story creator with parent-feature and iteration pickers.
+
+### Prerequisites
+
+- Azure CLI: https://aka.ms/installazurecli
+- `azure-devops` CLI extension: `az extension add --name azure-devops` (`Connect-AzDevOps` will offer to install this for you on first run)
+- An active `az login` session (`Connect-AzDevOps` will offer to start one for you on first run)
+
+### Profile environment variables
+
+Add this block to your PowerShell `$profile` and reload (open a new terminal). Replace each value with what's appropriate for your organization:
+
+```powershell
+$env:AZ_DEVOPS_ORG = 'https://dev.azure.com/myorg'
+$env:AZ_PROJECT    = 'My Project'
+$env:AZ_USER_EMAIL = 'user@example.com'
+$env:AZ_AREA       = 'My Project\My Team'
+$env:AZ_ITERATION  = 'My Project\Sprint 42'
+```
+
+### First run
+
+In a fresh PowerShell terminal:
+
+```powershell
+Connect-AzDevOps
+```
+
+This walks through six checks (Azure CLI present, `azure-devops` extension installed, env vars set, `az login` session active, `az devops` defaults configured, smoke `az boards query` succeeds) and prints a clear `READY` or `NOT READY` verdict at the end. It will offer to install the extension and run `az login` for you if either is missing.
+
+After `Connect-AzDevOps` reports `READY` once, later commands in the AzDevOps batch use the silent `Test-AzDevOpsAuth` check at startup to confirm the environment is still good before they hit the cache.
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -1,0 +1,206 @@
+# ============================================================================
+# Azure DevOps Work-Item Shortcuts
+# ============================================================================
+#
+# Foundation file for Azure DevOps work-item navigation shortcuts.
+#
+# User-facing functions:
+#   Connect-AzDevOps   - interactive first-run auth + setup helper (run once
+#                        on a fresh machine, or any time auth feels stale)
+#   Test-AzDevOpsAuth  - silent yes/no auth assertion intended for callers
+#                        in later AzDevOps commands; returns $true / $false
+#
+# Diagnostic helpers (also exposed for direct use):
+#   Test-AzDevOpsCliPresent          - is the `az` CLI on PATH?
+#   Test-AzDevOpsExtensionInstalled  - is the `azure-devops` extension installed?
+#   Get-AzDevOpsMissingEnvVars       - returns array of required env vars not set
+#   Test-AzDevOpsLoggedIn            - does `az account show` succeed?
+#   Invoke-AzDevOpsSmokeQuery        - runs WIQL "items assigned to me",
+#                                       returns count or $null on failure
+#
+# Expected $profile environment variables (set these once in your $profile):
+#
+#   $env:AZ_DEVOPS_ORG = 'https://dev.azure.com/myorg'   # full org URL
+#   $env:AZ_PROJECT    = 'My Project'                    # project name
+#   $env:AZ_USER_EMAIL = 'user@example.com'              # your AAD email
+#   $env:AZ_AREA       = 'My Project\My Team'            # default area path
+#   $env:AZ_ITERATION  = 'My Project\Sprint 42'          # default iteration
+#
+# Prereqs:
+#   - Azure CLI        : https://aka.ms/installazurecli
+#   - azure-devops ext : az extension add --name azure-devops
+#
+# First-run:
+#   PS> Connect-AzDevOps
+# ============================================================================
+
+
+function Test-AzDevOpsCliPresent {
+    return [bool](Get-Command az -ErrorAction SilentlyContinue)
+}
+
+
+function Test-AzDevOpsExtensionInstalled {
+    $name = az extension list --query "[?name=='azure-devops'].name" -o tsv 2>$null
+    return ($LASTEXITCODE -eq 0 -and $name -eq 'azure-devops')
+}
+
+
+function Get-AzDevOpsMissingEnvVars {
+    $missing = @()
+    if (-not $env:AZ_DEVOPS_ORG) { $missing += 'AZ_DEVOPS_ORG' }
+    if (-not $env:AZ_PROJECT)    { $missing += 'AZ_PROJECT' }
+    return ,$missing
+}
+
+
+function Test-AzDevOpsLoggedIn {
+    $null = az account show 2>$null
+    return ($LASTEXITCODE -eq 0)
+}
+
+
+function Invoke-AzDevOpsSmokeQuery {
+    $wiql = 'Select [System.Id] From WorkItems Where [System.AssignedTo] = @Me'
+    $json = az boards query --wiql $wiql --output json 2>$null
+    if ($LASTEXITCODE -ne 0) { return $null }
+    try {
+        $items = $json | ConvertFrom-Json
+        return @($items).Count
+    } catch {
+        return $null
+    }
+}
+
+
+function Test-AzDevOpsAuth {
+    if (-not (Test-AzDevOpsCliPresent))                { return $false }
+    if ((Get-AzDevOpsMissingEnvVars).Count -gt 0)      { return $false }
+    if ($null -eq (Invoke-AzDevOpsSmokeQuery))         { return $false }
+    return $true
+}
+
+
+function Connect-AzDevOps {
+
+    Write-Host ""
+    Write-Host "Connect-AzDevOps" -ForegroundColor Cyan
+    Write-Host "================" -ForegroundColor Cyan
+
+    # Step 1 of 6 - az CLI on PATH
+    Write-Host ""
+    Write-Host "Step 1 of 6 - Azure CLI" -ForegroundColor White
+    if (-not (Test-AzDevOpsCliPresent)) {
+        Write-Host "  X az CLI not on PATH" -ForegroundColor Red
+        if ($IsWindows) {
+            Write-Host "    Install via: winget install Microsoft.AzureCLI"
+            Write-Host "    Or see: https://aka.ms/installazurecli"
+        } elseif ($IsMacOS) {
+            Write-Host "    Install via: brew install azure-cli"
+            Write-Host "    Or see: https://aka.ms/installazurecli-mac"
+        } else {
+            Write-Host "    See: https://learn.microsoft.com/cli/azure/install-azure-cli-linux"
+        }
+        Write-Host ""
+        Write-Host "NOT READY - blocked at step 1: az CLI missing" -ForegroundColor Red
+        return
+    }
+    $azVersion = (az version --output json 2>$null | ConvertFrom-Json).'azure-cli'
+    Write-Host "  OK  az CLI present (v$azVersion)" -ForegroundColor Green
+
+    # Step 2 of 6 - azure-devops extension
+    Write-Host ""
+    Write-Host "Step 2 of 6 - azure-devops extension" -ForegroundColor White
+    if (-not (Test-AzDevOpsExtensionInstalled)) {
+        Write-Host "  !  azure-devops extension not installed" -ForegroundColor Yellow
+        $resp = Read-Host "    Install now? [Y/n]"
+        if ($resp -match '^(n|no)$') {
+            Write-Host "    Hint: az extension add --name azure-devops"
+            Write-Host ""
+            Write-Host "NOT READY - blocked at step 2: extension missing" -ForegroundColor Red
+            return
+        }
+        az extension add --name azure-devops 2>&1 | Out-Host
+        if (-not (Test-AzDevOpsExtensionInstalled)) {
+            Write-Host ""
+            Write-Host "NOT READY - blocked at step 2: extension install failed" -ForegroundColor Red
+            return
+        }
+    }
+    Write-Host "  OK  azure-devops extension installed" -ForegroundColor Green
+
+    # Step 3 of 6 - profile env vars
+    Write-Host ""
+    Write-Host "Step 3 of 6 - Profile environment variables" -ForegroundColor White
+    $missing = Get-AzDevOpsMissingEnvVars
+    if ($missing.Count -gt 0) {
+        Write-Host "  X Missing env vars: $($missing -join ', ')" -ForegroundColor Red
+        Write-Host ""
+        Write-Host "    Add this block to your `$profile and reload (open a new terminal):" -ForegroundColor Yellow
+        Write-Host "    ---------------------------------------------------------------"
+        Write-Host "    `$env:AZ_DEVOPS_ORG = 'https://dev.azure.com/myorg'"
+        Write-Host "    `$env:AZ_PROJECT    = 'My Project'"
+        Write-Host "    `$env:AZ_USER_EMAIL = 'user@example.com'"
+        Write-Host "    `$env:AZ_AREA       = 'My Project\My Team'"
+        Write-Host "    `$env:AZ_ITERATION  = 'My Project\Sprint 42'"
+        Write-Host "    ---------------------------------------------------------------"
+        Write-Host "    See README section 'Azure DevOps work-item shortcuts' for details."
+        Write-Host ""
+        Write-Host "NOT READY - blocked at step 3: env vars missing" -ForegroundColor Red
+        return
+    }
+    Write-Host "  OK  AZ_DEVOPS_ORG = $env:AZ_DEVOPS_ORG" -ForegroundColor Green
+    Write-Host "  OK  AZ_PROJECT    = $env:AZ_PROJECT" -ForegroundColor Green
+
+    # Step 4 of 6 - az login session
+    Write-Host ""
+    Write-Host "Step 4 of 6 - Azure login session" -ForegroundColor White
+    if (-not (Test-AzDevOpsLoggedIn)) {
+        Write-Host "  !  No active az login session" -ForegroundColor Yellow
+        $resp = Read-Host "    Run 'az login' now? [Y/n]"
+        if ($resp -match '^(n|no)$') {
+            Write-Host "    Hint: az login"
+            Write-Host ""
+            Write-Host "NOT READY - blocked at step 4: not logged in" -ForegroundColor Red
+            return
+        }
+        az login | Out-Host
+        if (-not (Test-AzDevOpsLoggedIn)) {
+            Write-Host ""
+            Write-Host "NOT READY - blocked at step 4: az login failed" -ForegroundColor Red
+            return
+        }
+    }
+    $account = az account show --output json 2>$null | ConvertFrom-Json
+    Write-Host "  OK  Logged in as $($account.user.name) (sub: $($account.name))" -ForegroundColor Green
+
+    # Step 5 of 6 - configure az devops defaults
+    Write-Host ""
+    Write-Host "Step 5 of 6 - Configure az devops defaults" -ForegroundColor White
+    $configOutput = az devops configure --defaults "organization=$env:AZ_DEVOPS_ORG" "project=$env:AZ_PROJECT" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  X az devops configure failed" -ForegroundColor Red
+        Write-Host "    $configOutput"
+        Write-Host ""
+        Write-Host "NOT READY - blocked at step 5: configure failed" -ForegroundColor Red
+        return
+    }
+    Write-Host "  OK  Defaults set: org=$env:AZ_DEVOPS_ORG project=$env:AZ_PROJECT" -ForegroundColor Green
+
+    # Step 6 of 6 - smoke test boards query
+    Write-Host ""
+    Write-Host "Step 6 of 6 - Smoke test (az boards query)" -ForegroundColor White
+    $count = Invoke-AzDevOpsSmokeQuery
+    if ($null -eq $count) {
+        Write-Host "  X Smoke query failed" -ForegroundColor Red
+        Write-Host "    Try: az boards query --wiql 'Select [System.Id] From WorkItems Where [System.AssignedTo] = @Me'"
+        Write-Host ""
+        Write-Host "NOT READY - blocked at step 6: smoke query failed" -ForegroundColor Red
+        return
+    }
+    Write-Host "  OK  Smoke test passed ($count items assigned to you)" -ForegroundColor Green
+
+    # Final verdict
+    Write-Host ""
+    Write-Host "READY - Azure DevOps connection verified for project=$env:AZ_PROJECT in org=$env:AZ_DEVOPS_ORG" -ForegroundColor Green
+}

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -11,8 +11,9 @@
 #                        in later AzDevOps commands; returns $true / $false
 #
 # Step functions invoked by Connect-AzDevOps (also exposed for direct use,
-# e.g. to debug a single failing step). Each returns a result object
-# @{ Ok = <bool>; FailMessage = <string> } and prints its own status:
+# e.g. to debug a single failing step). Each returns a [PSCustomObject]
+# with Ok (bool) and FailMessage (string or $null) properties, and prints
+# its own status:
 #   Confirm-AzDevOpsCli              - step 1 (CLI on PATH + version echo)
 #   Confirm-AzDevOpsExtension        - step 2 (azure-devops extension; offers install)
 #   Confirm-AzDevOpsEnvVars          - step 3 (required $profile env vars set)
@@ -97,7 +98,8 @@ function Test-AzDevOpsAuth {
 
 # ---------------------------------------------------------------------------
 # Step functions invoked by Connect-AzDevOps. Each owns its print + I/O for
-# one step and returns @{ Ok = <bool>; FailMessage = <string> }.
+# one step and returns a [PSCustomObject] with Ok (bool) and FailMessage
+# (string or $null) properties.
 # ---------------------------------------------------------------------------
 
 function Confirm-AzDevOpsCli {
@@ -112,11 +114,11 @@ function Confirm-AzDevOpsCli {
         } else {
             Write-Host "    See: https://learn.microsoft.com/cli/azure/install-azure-cli-linux"
         }
-        return @{ Ok = $false; FailMessage = 'az CLI missing' }
+        return [PSCustomObject]@{ Ok = $false; FailMessage = 'az CLI missing' }
     }
     $azVersion = (az version --output json 2>$null | ConvertFrom-Json).'azure-cli'
     Write-Host "  OK  az CLI present (v$azVersion)" -ForegroundColor Green
-    return @{ Ok = $true }
+    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
 }
 
 
@@ -126,15 +128,15 @@ function Confirm-AzDevOpsExtension {
         $resp = Read-Host "    Install now? [Y/n]"
         if ($resp -match '^(n|no)$') {
             Write-Host "    Hint: az extension add --name azure-devops"
-            return @{ Ok = $false; FailMessage = 'extension missing' }
+            return [PSCustomObject]@{ Ok = $false; FailMessage = 'extension missing' }
         }
         az extension add --name azure-devops 2>&1 | Out-Host
         if (-not (Test-AzDevOpsExtensionInstalled)) {
-            return @{ Ok = $false; FailMessage = 'extension install failed' }
+            return [PSCustomObject]@{ Ok = $false; FailMessage = 'extension install failed' }
         }
     }
     Write-Host "  OK  azure-devops extension installed" -ForegroundColor Green
-    return @{ Ok = $true }
+    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
 }
 
 
@@ -152,11 +154,11 @@ function Confirm-AzDevOpsEnvVars {
         Write-Host "    `$env:AZ_ITERATION  = 'My Project\Sprint 42'"
         Write-Host "    ---------------------------------------------------------------"
         Write-Host "    See README section 'Azure DevOps work-item shortcuts' for details."
-        return @{ Ok = $false; FailMessage = 'env vars missing' }
+        return [PSCustomObject]@{ Ok = $false; FailMessage = 'env vars missing' }
     }
     Write-Host "  OK  AZ_DEVOPS_ORG = $env:AZ_DEVOPS_ORG" -ForegroundColor Green
     Write-Host "  OK  AZ_PROJECT    = $env:AZ_PROJECT" -ForegroundColor Green
-    return @{ Ok = $true }
+    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
 }
 
 
@@ -166,16 +168,16 @@ function Confirm-AzDevOpsLogin {
         $resp = Read-Host "    Run 'az login' now? [Y/n]"
         if ($resp -match '^(n|no)$') {
             Write-Host "    Hint: az login"
-            return @{ Ok = $false; FailMessage = 'not logged in' }
+            return [PSCustomObject]@{ Ok = $false; FailMessage = 'not logged in' }
         }
         az login | Out-Host
         if (-not (Test-AzDevOpsLoggedIn)) {
-            return @{ Ok = $false; FailMessage = 'az login failed' }
+            return [PSCustomObject]@{ Ok = $false; FailMessage = 'az login failed' }
         }
     }
     $account = az account show --output json 2>$null | ConvertFrom-Json
     Write-Host "  OK  Logged in as $($account.user.name) (sub: $($account.name))" -ForegroundColor Green
-    return @{ Ok = $true }
+    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
 }
 
 
@@ -184,10 +186,10 @@ function Set-AzDevOpsDefaults {
     if ($LASTEXITCODE -ne 0) {
         Write-Host "  X az devops configure failed" -ForegroundColor Red
         Write-Host "    $configOutput"
-        return @{ Ok = $false; FailMessage = 'configure failed' }
+        return [PSCustomObject]@{ Ok = $false; FailMessage = 'configure failed' }
     }
     Write-Host "  OK  Defaults set: org=$env:AZ_DEVOPS_ORG project=$env:AZ_PROJECT" -ForegroundColor Green
-    return @{ Ok = $true }
+    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
 }
 
 
@@ -196,10 +198,10 @@ function Confirm-AzDevOpsSmokeQuery {
     if ($null -eq $count) {
         Write-Host "  X Smoke query failed" -ForegroundColor Red
         Write-Host "    Try: az boards query --wiql 'Select [System.Id] From WorkItems Where [System.AssignedTo] = @Me'"
-        return @{ Ok = $false; FailMessage = 'smoke query failed' }
+        return [PSCustomObject]@{ Ok = $false; FailMessage = 'smoke query failed' }
     }
     Write-Host "  OK  Smoke test passed ($count items assigned to you)" -ForegroundColor Green
-    return @{ Ok = $true }
+    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
 }
 
 
@@ -214,6 +216,9 @@ function Connect-AzDevOps {
     Write-Host "Connect-AzDevOps" -ForegroundColor Cyan
     Write-Host "================" -ForegroundColor Cyan
 
+    # $steps is a closed internal array of step descriptors. Each Action is a
+    # hardcoded scriptblock invoking a known function; nothing here accepts
+    # untrusted input, so & $step.Action below has no injection surface.
     $steps = @(
         @{ Num = 1; Name = 'Azure CLI';                     Action = { Confirm-AzDevOpsCli } },
         @{ Num = 2; Name = 'azure-devops extension';        Action = { Confirm-AzDevOpsExtension } },

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -10,7 +10,17 @@
 #   Test-AzDevOpsAuth  - silent yes/no auth assertion intended for callers
 #                        in later AzDevOps commands; returns $true / $false
 #
-# Diagnostic helpers (also exposed for direct use):
+# Step functions invoked by Connect-AzDevOps (also exposed for direct use,
+# e.g. to debug a single failing step). Each returns a result object
+# @{ Ok = <bool>; FailMessage = <string> } and prints its own status:
+#   Confirm-AzDevOpsCli              - step 1 (CLI on PATH + version echo)
+#   Confirm-AzDevOpsExtension        - step 2 (azure-devops extension; offers install)
+#   Confirm-AzDevOpsEnvVars          - step 3 (required $profile env vars set)
+#   Confirm-AzDevOpsLogin            - step 4 (az login session; offers login)
+#   Set-AzDevOpsDefaults             - step 5 (az devops configure --defaults)
+#   Confirm-AzDevOpsSmokeQuery       - step 6 (az boards query smoke test)
+#
+# Silent diagnostic helpers (pure checks, no I/O — used by Test-AzDevOpsAuth):
 #   Test-AzDevOpsCliPresent          - is the `az` CLI on PATH?
 #   Test-AzDevOpsExtensionInstalled  - is the `azure-devops` extension installed?
 #   Get-AzDevOpsMissingEnvVars       - returns array of required env vars not set
@@ -34,6 +44,10 @@
 #   PS> Connect-AzDevOps
 # ============================================================================
 
+
+# ---------------------------------------------------------------------------
+# Silent diagnostic helpers (no I/O; safe for Test-AzDevOpsAuth callers)
+# ---------------------------------------------------------------------------
 
 function Test-AzDevOpsCliPresent {
     return [bool](Get-Command az -ErrorAction SilentlyContinue)
@@ -81,15 +95,12 @@ function Test-AzDevOpsAuth {
 }
 
 
-function Connect-AzDevOps {
+# ---------------------------------------------------------------------------
+# Step functions invoked by Connect-AzDevOps. Each owns its print + I/O for
+# one step and returns @{ Ok = <bool>; FailMessage = <string> }.
+# ---------------------------------------------------------------------------
 
-    Write-Host ""
-    Write-Host "Connect-AzDevOps" -ForegroundColor Cyan
-    Write-Host "================" -ForegroundColor Cyan
-
-    # Step 1 of 6 - az CLI on PATH
-    Write-Host ""
-    Write-Host "Step 1 of 6 - Azure CLI" -ForegroundColor White
+function Confirm-AzDevOpsCli {
     if (-not (Test-AzDevOpsCliPresent)) {
         Write-Host "  X az CLI not on PATH" -ForegroundColor Red
         if ($IsWindows) {
@@ -101,37 +112,33 @@ function Connect-AzDevOps {
         } else {
             Write-Host "    See: https://learn.microsoft.com/cli/azure/install-azure-cli-linux"
         }
-        Write-Host ""
-        Write-Host "NOT READY - blocked at step 1: az CLI missing" -ForegroundColor Red
-        return
+        return @{ Ok = $false; FailMessage = 'az CLI missing' }
     }
     $azVersion = (az version --output json 2>$null | ConvertFrom-Json).'azure-cli'
     Write-Host "  OK  az CLI present (v$azVersion)" -ForegroundColor Green
+    return @{ Ok = $true }
+}
 
-    # Step 2 of 6 - azure-devops extension
-    Write-Host ""
-    Write-Host "Step 2 of 6 - azure-devops extension" -ForegroundColor White
+
+function Confirm-AzDevOpsExtension {
     if (-not (Test-AzDevOpsExtensionInstalled)) {
         Write-Host "  !  azure-devops extension not installed" -ForegroundColor Yellow
         $resp = Read-Host "    Install now? [Y/n]"
         if ($resp -match '^(n|no)$') {
             Write-Host "    Hint: az extension add --name azure-devops"
-            Write-Host ""
-            Write-Host "NOT READY - blocked at step 2: extension missing" -ForegroundColor Red
-            return
+            return @{ Ok = $false; FailMessage = 'extension missing' }
         }
         az extension add --name azure-devops 2>&1 | Out-Host
         if (-not (Test-AzDevOpsExtensionInstalled)) {
-            Write-Host ""
-            Write-Host "NOT READY - blocked at step 2: extension install failed" -ForegroundColor Red
-            return
+            return @{ Ok = $false; FailMessage = 'extension install failed' }
         }
     }
     Write-Host "  OK  azure-devops extension installed" -ForegroundColor Green
+    return @{ Ok = $true }
+}
 
-    # Step 3 of 6 - profile env vars
-    Write-Host ""
-    Write-Host "Step 3 of 6 - Profile environment variables" -ForegroundColor White
+
+function Confirm-AzDevOpsEnvVars {
     $missing = Get-AzDevOpsMissingEnvVars
     if ($missing.Count -gt 0) {
         Write-Host "  X Missing env vars: $($missing -join ', ')" -ForegroundColor Red
@@ -145,62 +152,88 @@ function Connect-AzDevOps {
         Write-Host "    `$env:AZ_ITERATION  = 'My Project\Sprint 42'"
         Write-Host "    ---------------------------------------------------------------"
         Write-Host "    See README section 'Azure DevOps work-item shortcuts' for details."
-        Write-Host ""
-        Write-Host "NOT READY - blocked at step 3: env vars missing" -ForegroundColor Red
-        return
+        return @{ Ok = $false; FailMessage = 'env vars missing' }
     }
     Write-Host "  OK  AZ_DEVOPS_ORG = $env:AZ_DEVOPS_ORG" -ForegroundColor Green
     Write-Host "  OK  AZ_PROJECT    = $env:AZ_PROJECT" -ForegroundColor Green
+    return @{ Ok = $true }
+}
 
-    # Step 4 of 6 - az login session
-    Write-Host ""
-    Write-Host "Step 4 of 6 - Azure login session" -ForegroundColor White
+
+function Confirm-AzDevOpsLogin {
     if (-not (Test-AzDevOpsLoggedIn)) {
         Write-Host "  !  No active az login session" -ForegroundColor Yellow
         $resp = Read-Host "    Run 'az login' now? [Y/n]"
         if ($resp -match '^(n|no)$') {
             Write-Host "    Hint: az login"
-            Write-Host ""
-            Write-Host "NOT READY - blocked at step 4: not logged in" -ForegroundColor Red
-            return
+            return @{ Ok = $false; FailMessage = 'not logged in' }
         }
         az login | Out-Host
         if (-not (Test-AzDevOpsLoggedIn)) {
-            Write-Host ""
-            Write-Host "NOT READY - blocked at step 4: az login failed" -ForegroundColor Red
-            return
+            return @{ Ok = $false; FailMessage = 'az login failed' }
         }
     }
     $account = az account show --output json 2>$null | ConvertFrom-Json
     Write-Host "  OK  Logged in as $($account.user.name) (sub: $($account.name))" -ForegroundColor Green
+    return @{ Ok = $true }
+}
 
-    # Step 5 of 6 - configure az devops defaults
-    Write-Host ""
-    Write-Host "Step 5 of 6 - Configure az devops defaults" -ForegroundColor White
+
+function Set-AzDevOpsDefaults {
     $configOutput = az devops configure --defaults "organization=$env:AZ_DEVOPS_ORG" "project=$env:AZ_PROJECT" 2>&1
     if ($LASTEXITCODE -ne 0) {
         Write-Host "  X az devops configure failed" -ForegroundColor Red
         Write-Host "    $configOutput"
-        Write-Host ""
-        Write-Host "NOT READY - blocked at step 5: configure failed" -ForegroundColor Red
-        return
+        return @{ Ok = $false; FailMessage = 'configure failed' }
     }
     Write-Host "  OK  Defaults set: org=$env:AZ_DEVOPS_ORG project=$env:AZ_PROJECT" -ForegroundColor Green
+    return @{ Ok = $true }
+}
 
-    # Step 6 of 6 - smoke test boards query
-    Write-Host ""
-    Write-Host "Step 6 of 6 - Smoke test (az boards query)" -ForegroundColor White
+
+function Confirm-AzDevOpsSmokeQuery {
     $count = Invoke-AzDevOpsSmokeQuery
     if ($null -eq $count) {
         Write-Host "  X Smoke query failed" -ForegroundColor Red
         Write-Host "    Try: az boards query --wiql 'Select [System.Id] From WorkItems Where [System.AssignedTo] = @Me'"
-        Write-Host ""
-        Write-Host "NOT READY - blocked at step 6: smoke query failed" -ForegroundColor Red
-        return
+        return @{ Ok = $false; FailMessage = 'smoke query failed' }
     }
     Write-Host "  OK  Smoke test passed ($count items assigned to you)" -ForegroundColor Green
+    return @{ Ok = $true }
+}
 
-    # Final verdict
+
+# ---------------------------------------------------------------------------
+# Connect-AzDevOps — thin orchestrator that runs each step in order and
+# bails on the first failure with a clear NOT READY verdict.
+# ---------------------------------------------------------------------------
+
+function Connect-AzDevOps {
+
+    Write-Host ""
+    Write-Host "Connect-AzDevOps" -ForegroundColor Cyan
+    Write-Host "================" -ForegroundColor Cyan
+
+    $steps = @(
+        @{ Num = 1; Name = 'Azure CLI';                     Action = { Confirm-AzDevOpsCli } },
+        @{ Num = 2; Name = 'azure-devops extension';        Action = { Confirm-AzDevOpsExtension } },
+        @{ Num = 3; Name = 'Profile environment variables'; Action = { Confirm-AzDevOpsEnvVars } },
+        @{ Num = 4; Name = 'Azure login session';           Action = { Confirm-AzDevOpsLogin } },
+        @{ Num = 5; Name = 'Configure az devops defaults';  Action = { Set-AzDevOpsDefaults } },
+        @{ Num = 6; Name = 'Smoke test (az boards query)';  Action = { Confirm-AzDevOpsSmokeQuery } }
+    )
+
+    foreach ($step in $steps) {
+        Write-Host ""
+        Write-Host "Step $($step.Num) of $($steps.Count) - $($step.Name)" -ForegroundColor White
+        $result = & $step.Action
+        if (-not $result.Ok) {
+            Write-Host ""
+            Write-Host "NOT READY - blocked at step $($step.Num): $($result.FailMessage)" -ForegroundColor Red
+            return
+        }
+    }
+
     Write-Host ""
     Write-Host "READY - Azure DevOps connection verified for project=$env:AZ_PROJECT in org=$env:AZ_DEVOPS_ORG" -ForegroundColor Green
 }

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -48,3 +48,10 @@ if ($jira_setup -ne $NULL) {
 } else {
     Write-Host "no jira_automations.ps1"
 }
+
+$azdevops_workitems = Get-Content "$path_to_bashcuts\powcuts_by_cli\azdevops_workitems.ps1"
+if ($azdevops_workitems -ne $NULL) {
+ . "$path_to_bashcuts\powcuts_by_cli\azdevops_workitems.ps1"
+} else {
+    Write-Host "no azdevops_workitems.ps1"
+}


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #7 |
| [Key Changes](#key-changes) | ✅ 3 files |
| [Implementation Details](#implementation-details) | ✅ |
| [Intentional Deviations from Issue Text](#intentional-deviations-from-issue-text) | ✅ |
| [Open-Question Resolution](#open-question-resolution) | ✅ |
| [Test Plan](#test-plan) | 0/8 |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4391097380) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4391102304) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4391111804) |
| 📚 Docs Check | ✅ CURRENT — [View](#issuecomment-4391118540) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4391126384) |
<!-- toc:end -->

## Summary
Introduces PowerShell shortcuts for Azure DevOps work-item navigation with an interactive first-run setup helper. This adds foundation functions for authentication, environment validation, and smoke testing against Azure DevOps organizations — the foundation for the cache (#8) and work-item commands (#9–#13) that follow.

## Issue
Closes #7

## Key Changes

- **New module**: `powcuts_by_cli/azdevops_workitems.ps1`
  - `Connect-AzDevOps` — interactive 6-step setup wizard: validates Azure CLI presence, installs the `azure-devops` extension if needed, checks environment variables, initiates `az login` if needed, configures `az devops` defaults, and runs a smoke test query
  - `Test-AzDevOpsAuth` — silent yes/no authentication check intended for use by downstream commands in #8–#13
  - Diagnostic helpers: `Test-AzDevOpsCliPresent`, `Test-AzDevOpsExtensionInstalled`, `Get-AzDevOpsMissingEnvVars`, `Test-AzDevOpsLoggedIn`, `Invoke-AzDevOpsSmokeQuery`

- **Updated**: `powcuts_home.ps1`
  - Loads the new `azdevops_workitems.ps1` module on profile initialization (matches the existing `Get-Content … -ne $NULL` dot-source pattern)

- **Updated**: `README.md`
  - TOC entry for the new section
  - Documents Azure CLI and `azure-devops` extension as prerequisites
  - New &#34;Azure DevOps work-item shortcuts&#34; section with setup instructions, the env-var block to paste into `$profile`, and the `Connect-AzDevOps` first-run workflow

## Implementation Details

The `Connect-AzDevOps` function provides a guided 6-step validation flow with clear visual feedback (`OK` in green, `X` errors in red, `!` warnings in yellow). Each step can fail gracefully with helpful hints for remediation. The function offers to automatically install missing dependencies (the `azure-devops` extension, `az login` session) rather than blocking on them. Downstream commands will use the lightweight `Test-AzDevOpsAuth` function to silently verify the environment is ready before executing.

## Intentional Deviations from Issue Text

These were agreed in the planning phase before implementation:

1. **6 steps instead of 5** — added explicit `azure-devops` extension check (step 2) and env-var pre-check (step 3). Without the extension, step 6&#39;s smoke query would fail with an opaque error; without env vars, step 5&#39;s `az devops configure` would silently set defaults to empty strings. Both pre-checks give clearer fail-fast signals.
2. **`Test-AzDevOpsAuth` checks env vars instead of &#34;step 2 (login)&#34; verbatim** — login is implicitly verified by the smoke query (which fails without it), and an explicit env-var check gives a faster, clearer failure when the user hasn&#39;t set up their `$profile` yet. Functional intent (CLI present + auth working + can-query) is preserved.

## Open-Question Resolution

The issue&#39;s open question asked whether `Connect-AzDevOps` should write a `config.json` to the cache directory. **Deferred to #8** — that&#39;s the cache-issue&#39;s natural responsibility and `Connect` stays a pure auth helper.

## Test Plan
- [ ] `pwsh -NoProfile -Command &#34;[System.Management.Automation.Language.Parser]::ParseFile(&#39;powcuts_by_cli/azdevops_workitems.ps1&#39;, [ref]\$null, [ref]\$null) \| Out-Null; &#39;OK&#39;&#34;` returns `OK` (zero parse errors)
- [ ] In a fresh PowerShell terminal: `Get-Command Connect-AzDevOps, Test-AzDevOpsAuth` lists both functions (confirms dot-source wire-up worked)
- [ ] `Connect-AzDevOps` walks 6 steps and prints a clear `READY` or `NOT READY` verdict
- [ ] With env vars unset: `Connect-AzDevOps` blocks at step 3 with the env-var block to paste into `$profile`
- [ ] With `az` not on PATH (or simulate): `Connect-AzDevOps` blocks at step 1 with an OS-specific install hint
- [ ] `Test-AzDevOpsAuth` returns `True` after a successful `Connect`, `False` otherwise — silent (no prompts)
- [ ] Same checks pass on macOS PowerShell Core (no Windows-only assumptions)
- [ ] Existing `az-create-userstory` in `pow_az_cli.ps1` still works (untouched per scope)