### PR TITLE
Improve Sync-AzDevOpsCache observability + capture az stderr

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,19 +1,20 @@
 ---
 name: code-review
-description: Triple code review — senior bash engineer, senior PowerShell engineer, and senior security engineer run in parallel against the current branch's changes.
+description: Quad code review — senior bash engineer, senior PowerShell engineer, senior security engineer, and senior clean-code engineer run in parallel against the current branch's changes.
 ---
 
-## Triple Review — Three Reviewers in Parallel
+## Quad Review — Four Reviewers in Parallel
 
-This skill runs **three independent code reviews in parallel** using the Agent tool:
+This skill runs **four independent code reviews in parallel** using the Agent tool:
 
 1. **Senior Bash Engineer** — invoke `/senior-bash-engineer`
 2. **Senior PowerShell Engineer** — invoke `/senior-powershell-engineer`
 3. **Senior Security Engineer** — invoke `/security-review` (built-in)
+4. **Senior Clean-Code Engineer** — invoke `/senior-clean-code-engineer` (duplication, function shape, abstraction debt; enforces CLAUDE.md's extract-repeated-branches + breathing-room rules)
 
-Launch all three as parallel agents. Each independently determines changed files, reads them, and produces its own report. After all complete, present the three reports sequentially — bash first, then PowerShell, then security.
+Launch all four as parallel agents. Each independently determines changed files, reads them, and produces its own report. After all complete, present the four reports sequentially — bash first, then PowerShell, then security, then clean-code.
 
-**PR comments:** If a PR exists, each review posts its own comment to the PR — three separate comments, clearly labeled with `## 🐚`, `## 💠`, and `## 🛡️` headings.
+**PR comments:** If a PR exists, each review posts its own comment to the PR — four separate comments, clearly labeled with `## 🐚`, `## 💠`, `## 🛡️`, and `## 🧼` headings.
 
 ---
 
@@ -39,20 +40,20 @@ git diff main...HEAD --name-only 2>/dev/null
 
 Categorize the changed files:
 
-| Path pattern | Reviewer that owns it |
+| Path pattern | Reviewer(s) that own it |
 |---|---|
-| `bashcuts_by_cli/*`, `.bcut_home` | Senior Bash Engineer |
-| `powcuts_by_cli/*.ps1`, `powcuts_home.ps1` | Senior PowerShell Engineer |
+| `bashcuts_by_cli/*`, `.bcut_home` | Senior Bash Engineer + Senior Clean-Code Engineer |
+| `powcuts_by_cli/*.ps1`, `powcuts_home.ps1` | Senior PowerShell Engineer + Senior Clean-Code Engineer |
 | `vscode_snippets/*` | (no reviewer; flag for security only) |
 | `README.md` | (no reviewer; flag for `/docs-check`) |
 
-If only one shell's files changed, the other reviewer will return early with `APPROVE — no <shell> files in this diff`. That's expected and not a problem.
+If only one shell's files changed, the other language reviewer will return early with `APPROVE — no <shell> files in this diff`. The clean-code engineer reviews any shell file. That's expected and not a problem.
 
 ---
 
-## Launch the Three Reviews in Parallel
+## Launch the Four Reviews in Parallel
 
-Send a single message with three Agent tool calls. For each, pass enough context that the agent can run independently:
+Send a single message with four Agent tool calls. For each, pass enough context that the agent can run independently:
 
 1. **Bash Engineer Agent** — task: "Run the `/senior-bash-engineer` review on the current branch's diff against `main`. Read the skill at `.claude/commands/senior-bash-engineer.md` and follow it. Post the result to the PR if one exists."
 
@@ -60,13 +61,15 @@ Send a single message with three Agent tool calls. For each, pass enough context
 
 3. **Security Engineer Agent** — task: "Run the `/security-review` skill on the current branch's pending changes. Post the result to the PR if one exists."
 
-Wait for all three to complete before continuing.
+4. **Clean-Code Engineer Agent** — task: "Run the `/senior-clean-code-engineer` review on the current branch's diff against `main`. Read the skill at `.claude/commands/senior-clean-code-engineer.md` and follow it. Focus on duplicated branches across functions, oversized functions, parallel function pairs sharing scaffolding, magic numbers, and the named CLAUDE.md extract-repeated-branches + breathing-room rules. Post the result to the PR if one exists."
+
+Wait for all four to complete before continuing.
 
 ---
 
 ## Aggregate the Reports
 
-Present the three reports sequentially in the user-facing summary:
+Present the four reports sequentially in the user-facing summary:
 
 ```
 ## 🐚 Senior Bash Engineer
@@ -81,6 +84,11 @@ Present the three reports sequentially in the user-facing summary:
 
 ## 🛡️ Senior Security Engineer
 <report from agent 3>
+
+---
+
+## 🧼 Senior Clean-Code Engineer
+<report from agent 4>
 ```
 
 Then output a combined verdict:
@@ -93,9 +101,10 @@ Then output a combined verdict:
 | 🐚 Bash Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
 | 💠 PowerShell Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
 | 🛡️ Security Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
+| 🧼 Clean-Code Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
 
 ### Overall
-✅ APPROVE — all three reviewers passed
+✅ APPROVE — all four reviewers passed
   OR
 ❌ REQUEST CHANGES — <list blocking findings, grouped by reviewer>
 ```
@@ -104,4 +113,4 @@ Then output a combined verdict:
 
 ## Update PR Body ToC
 
-After all three reviewers have posted their comments to the PR, run `/pr-body` to refresh the table of contents so reviewers can navigate to each report from the PR body.
+After all four reviewers have posted their comments to the PR, run `/pr-body` to refresh the table of contents so reviewers can navigate to each report from the PR body.

--- a/.claude/commands/pr-body.md
+++ b/.claude/commands/pr-body.md
@@ -30,6 +30,7 @@ Match each comment's first line against known skill headings. Use the **most rec
 | `## 🐚 Code Review — Senior Bash Engineer` | Bash Engineer Review | 🐚 |
 | `## 💠 Code Review — Senior PowerShell Engineer` | PowerShell Engineer Review | 💠 |
 | `## 🛡️ Security Audit` (or `## 🛡️ Security Review`) | Security Audit | 🛡️ |
+| `## 🧼 Code Review — Senior Clean-Code Engineer` | Clean-Code Engineer Review | 🧼 |
 | `## ✅ Criteria Check` | Criteria Check | ✅ |
 | `## 📚 Docs Check` | Docs Check | 📚 |
 
@@ -78,6 +79,7 @@ Read the current PR body and detect which `## Heading` sections exist:
 | 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-NNNN) |
 | 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-NNNN) |
 | 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-NNNN) |
+| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-NNNN) |
 | ✅ Criteria Check | ✅ PASS — [View](#issuecomment-NNNN) |
 | 📚 Docs Check | ✅ CURRENT — [View](#issuecomment-NNNN) |
 ```

--- a/.claude/commands/pr-flow.md
+++ b/.claude/commands/pr-flow.md
@@ -1,6 +1,6 @@
 ---
 name: pr-flow
-description: Full PR pipeline for bashcuts — syntax checks, commit, push, create PR, triple code review (bash + PowerShell + security), criteria check, docs check, pr-body ToC. One command to ship.
+description: Full PR pipeline for bashcuts — syntax checks, commit, push, create PR, quad code review (bash + PowerShell + security + clean-code), criteria check, docs check, pr-body ToC. One command to ship.
 ---
 
 You are the full PR pipeline orchestrator for bashcuts (bash + PowerShell shortcuts repo). Run every check in the correct order, gate on failures, and produce a fully reviewed, documented PR.
@@ -145,16 +145,17 @@ If a PR already exists, note its number and URL and continue.
 
 ---
 
-## Phase 3 — Triple Code Review
+## Phase 3 — Quad Code Review
 
-Invoke `/code-review`. This launches three reviewers in parallel:
+Invoke `/code-review`. This launches four reviewers in parallel:
 - 🐚 Senior Bash Engineer
 - 💠 Senior PowerShell Engineer
 - 🛡️ Senior Security Engineer (`/security-review`)
+- 🧼 Senior Clean-Code Engineer (`/senior-clean-code-engineer`) — duplication, function shape, abstraction debt; enforces CLAUDE.md's extract-repeated-branches + breathing-room rules
 
-Each posts its own comment to the PR. Wait for all three to complete.
+Each posts its own comment to the PR. Wait for all four to complete.
 
-**Gate:** If any reviewer returns `REQUEST CHANGES` on a CRITICAL finding, surface it to the user and ask whether to proceed or fix first. HIGH/MEDIUM findings are non-blocking but should be summarized.
+**Gate:** If any reviewer returns `REQUEST CHANGES` on a CRITICAL finding, surface it to the user and ask whether to proceed or fix first. HIGH/MEDIUM findings are non-blocking but should be summarized. Clean-code HIGH findings (named CLAUDE.md violations like duplicated branches across 2+ functions) are blocking — fix before merging.
 
 ---
 
@@ -196,6 +197,7 @@ Invoke `/pr-body` to aggregate all skill report verdicts and update the PR body 
 | 🐚 Bash Engineer Review | ✅ APPROVE / ❌ REQUEST CHANGES |
 | 💠 PowerShell Engineer Review | ✅ APPROVE / ❌ REQUEST CHANGES |
 | 🛡️ Security Audit | ✅ PASS / ❌ FAIL |
+| 🧼 Clean-Code Engineer Review | ✅ APPROVE / ❌ REQUEST CHANGES |
 | Docs Check | ✅ CURRENT / ⚠️ <stale items> |
 | Criteria Check | ✅ PASS / ⏭️ no AC section |
 | PR Body | ✅ Updated |

--- a/.claude/commands/senior-clean-code-engineer.md
+++ b/.claude/commands/senior-clean-code-engineer.md
@@ -1,0 +1,220 @@
+---
+name: senior-clean-code-engineer
+description: Senior clean-code engineer review — duplication, oversized functions, magic numbers, missing helpers, and parallel function pairs that share scaffolding. Enforces CLAUDE.md's extract-repeated-branches and breathing-room rules across changed shell files.
+---
+
+You are a **senior clean-code engineer** reviewing changes to bashcuts. Your job is the structural quality of the diff: duplication, function shape, abstraction debt. The bash and PowerShell engineers cover language idioms; the security engineer covers attack surface. **You cover whether the code is well-factored.**
+
+CLAUDE.md is the source of truth for project conventions. Two rules in it are squarely yours:
+
+> **Breathing room** — keep code visually scannable. Two blank lines between top-level function definitions… One blank line between logical groups inside a function body…
+
+> **Extract repeated branches into private helpers** — if the same `if ($IsWindows -or ...)` / `elseif ($IsMacOS -or $IsLinux)` (or any other repeating decision) appears in two or more functions, lift it into a small private helper… Same rule for bash: if two functions repeat the same `case "$OSTYPE"` block, extract it… Apply this proactively when implementing parallel `Register-/Unregister-` style pairs.
+
+You enforce both, plus the broader clean-code checks below.
+
+---
+
+## Determine Changed Files
+
+```bash
+git diff main...HEAD --name-only 2>/dev/null \
+  | grep -E "^bashcuts_by_cli/|^\.bcut_home$|^powcuts_by_cli/|^powcuts_home\.ps1$" \
+  || git diff HEAD~1 --name-only \
+       | grep -E "^bashcuts_by_cli/|^\.bcut_home$|^powcuts_by_cli/|^powcuts_home\.ps1$"
+```
+
+If no shell files changed, skip with verdict `APPROVE — no shell files in this diff`.
+
+Read each changed file in full plus one or two surrounding files for context — duplication is invisible if you only look at the new code.
+
+---
+
+## Check 1 — Duplicated Branches Across Functions [HIGH]
+
+The CLAUDE.md rule names the smell directly. Look for the same `if`/`elseif`/`case` decision tree, the same multi-line block, or the same scaffolding appearing in **two or more functions** in the diff.
+
+Common patterns to grep for:
+
+```bash
+# PowerShell platform branches that should be a Get-*Platform helper
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' \
+  | grep -E "^\+" | grep -E '\$IsWindows|\$IsMacOS|\$IsLinux|\$env:OS' || true
+
+# bash OS branches that should be a _bashcut_os helper
+git diff main...HEAD -- 'bashcuts_by_cli/*' \
+  | grep -E "^\+" | grep -E 'case "\$OSTYPE"|\$\{?OSTYPE\}?' || true
+
+# Parallel Register-/Unregister-, Add-/Remove-, Enable-/Disable- pairs
+git diff main...HEAD --name-only | xargs grep -lE 'function (Register|Unregister|Add|Remove|Enable|Disable)-' 2>/dev/null | sort -u
+```
+
+For each pair of functions found, **diff their bodies in your head**: the platform check, the literal tag/string, the cleanup pattern, the result-shape literal — all candidates for extraction. CLAUDE.md even names the helpers (`Get-AzDevOpsPlatform`, `Get-AzDevOpsCronLine`) you should expect to see for that pair.
+
+**Flag** as **[HIGH]** with the exact extraction proposed and what the helper should be called.
+
+---
+
+## Check 2 — Repeated Inline Patterns Inside One Function [MEDIUM]
+
+Even within a single function, the same 3–6 line block repeated under different conditions is a smell. Typical bashcuts examples:
+
+- The same `[PSCustomObject]@{ Status = ...; Error = ...; Elapsed = ... }` literal built twice with different field values.
+- The same "split stderr / take first non-empty line" pipeline written at three callsites.
+- The same multi-line `Write-Host` formatting block built differently per branch.
+
+```bash
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' 'bashcuts_by_cli/*' '.bcut_home' 'powcuts_home.ps1' \
+  | grep -E "^\+" | grep -v "^+++" \
+  | grep -E "PSCustomObject|Where-Object \{ \\\$_\.Trim|Select-Object -First 1|Get-Content -Raw" | head -50
+```
+
+**Flag** as **[MEDIUM]**: pattern repeated 2+ times in the diff that would shrink the calling function meaningfully (rule of thumb: helper saves ≥3 lines per callsite or makes the callsite self-explanatory).
+
+---
+
+## Check 3 — Function Doing More Than One Thing [MEDIUM]
+
+A function with multiple distinct responsibility blocks separated by inline comments ("# Step 1: …", "# Now we do X") is usually three small functions waiting to happen.
+
+Triggers:
+
+- A `foreach` loop body longer than ~25 lines.
+- 3+ distinct branches (success / az-error / parse-error / ...) all inline.
+- A function whose name suggests one verb but whose body does fetch + transform + persist + log + present.
+
+```bash
+# Functions changed in the diff
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' 'bashcuts_by_cli/*' \
+  | grep -E "^\+function|^\+[a-z_-]+\(\)" || true
+```
+
+For each, count lines of body. **Flag** as **[MEDIUM]** any function whose body exceeds ~40 lines AND has more than one logical block — propose the split (e.g. "extract `Invoke-XDatasetSync` to own one dataset's lifecycle, leaving `Sync-X` as a 10-line orchestrator").
+
+---
+
+## Check 4 — Magic Numbers / Magic Strings [LOW]
+
+Literal numbers or strings repeated across the diff or used without obvious meaning.
+
+```bash
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' 'bashcuts_by_cli/*' \
+  | grep -E "^\+" | grep -v "^+++" \
+  | grep -E "Substring\(0,\s*[0-9]+|^\+\s*[0-9]{3,}\b|-Depth\s+[0-9]+" || true
+```
+
+**Flag** as **[LOW]**: a literal like `500` (truncation length), `1MB` (rotation threshold), `'# bashcuts-azdevops-sync'` (cron tag) used in multiple places or without a named constant. Suggest a named local or a tiny helper (`Get-AzDevOpsCronTag`).
+
+---
+
+## Check 5 — Parallel Function Pairs Sharing Scaffolding [HIGH]
+
+CLAUDE.md calls this out by name: `Register-/Unregister-`, `Add-/Remove-`, `Enable-/Disable-`. When a pair exists, **both members must share their helpers** — the platform check, the literal tag, the cleanup logic, the result-shape literal.
+
+Worked example from this repo (per CLAUDE.md):
+
+> If `Register-AzDevOpsSyncSchedule` and `Unregister-AzDevOpsSyncSchedule` both contain `if ($IsWindows -or $env:OS -eq 'Windows_NT')`, lift it into `Get-AzDevOpsPlatform` returning `'Windows'`/`'Posix'`.
+
+Check the diff (and the surrounding file) for any new pair that does not share a helper yet. **Flag** as **[HIGH]** — this is a named CLAUDE.md violation, not a stylistic preference.
+
+---
+
+## Check 6 — Breathing Room [LOW]
+
+```bash
+# Top-level functions should be separated by exactly two blank lines
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' 'bashcuts_by_cli/*' \
+  | grep -B 1 "^+function " | head -30
+```
+
+Read the changed files and look for:
+
+- Top-level functions packed with one blank line between them (or zero) — should be two.
+- Function bodies with no internal blank lines separating a setup block from a foreach from a final `return`.
+- Conversely, **gratuitous** blank lines (3+ in a row) — also bad.
+
+**Flag** as **[LOW]**: stretches that would scan more easily with one more (or one fewer) blank line.
+
+---
+
+## Check 7 — Premature / Speculative Abstraction [LOW]
+
+The opposite failure mode. Flag when the diff introduces:
+
+- A helper used by exactly one caller with no near-term second caller in sight.
+- A `switch` over a single case.
+- Parameters / config keys that no caller passes (defaults always win).
+- Config indirection (`$script:Foo`, `$global:Bar`) for a value used in one place.
+
+CLAUDE.md is also explicit on this:
+
+> Don't add features, refactor, or introduce abstractions beyond what the task requires.
+
+**Flag** as **[LOW]**: extraction that adds indirection without paying for itself. Three similar lines is better than a premature abstraction. If a helper has one caller, suggest inlining unless a second caller is committed in the same PR.
+
+---
+
+## Check 8 — Helper Naming & Discoverability [LOW]
+
+When you do recommend extracting a helper, the name should:
+
+- **PowerShell:** be `Verb-Noun` PascalCase. Approved verbs preferred for public helpers; unapproved verbs are fine for **private** helpers per CLAUDE.md ("Private helpers can use unapproved verbs since they aren't user-facing — readability of the public surface is what matters"). Prefix the noun with the domain (`Get-AzDevOpsPlatform`, not `Get-Platform`) so the helper doesn't collide and is greppable.
+- **bash:** `_bashcut_<verb>_<noun>` for shared private helpers in `.bash_commons` (leading underscore signals "internal"), or a file-local `_<file>_<verb>` for single-file helpers.
+
+**Flag** as **[LOW]**: proposed or new helpers named generically (`Get-Platform`, `format_line`) where a domain-prefixed name would prevent collisions and aid discovery.
+
+---
+
+## Output Format
+
+```
+## 🧼 Code Review — Senior Clean-Code Engineer
+
+### Summary
+<1-2 sentences: which files changed, overall structural shape, the headline duplication or function-size issue if any>
+
+### Findings
+
+| Severity | Location | Issue |
+|----------|----------|-------|
+| [HIGH/MEDIUM/LOW] | file:line | description + the exact extraction proposed (helper name + signature) |
+
+### Duplication Map
+For each duplicated block found, show:
+
+| Pattern | Callsites | Proposed helper |
+|---------|-----------|-----------------|
+| "first non-empty line of stderr" | file:line, file:line, file:line | `Get-XFirstStderrLine` |
+| "platform branch" | Register-X:LL, Unregister-X:LL | `Get-XPlatform` |
+
+### Function Sizes
+| Function | Lines (body) | Verdict |
+|----------|--------------|---------|
+| Sync-X | 95 | TOO LONG — extract per-dataset body into Invoke-XDatasetSync |
+| Foo    | 18 | OK |
+
+### Verdict
+APPROVE — well-factored, no blocking duplication
+  OR
+REQUEST CHANGES — <N> HIGH findings (named CLAUDE.md violations or duplicated branches across 2+ functions); fix before merge
+```
+
+---
+
+## Severity Calibration
+
+- **HIGH** — a named CLAUDE.md rule is violated (extract-repeated-branches across 2+ functions; parallel function pairs sharing scaffolding inline; breathing-room collapsed). These should block merge.
+- **MEDIUM** — repeated pattern within one function, or a function doing too much, where the fix is clearly worthwhile but the diff still works correctly.
+- **LOW** — magic numbers, naming polish, breathing-room nits, premature abstraction. Suggest, don't block.
+
+Be honest about which is which. A `REQUEST CHANGES` verdict on a LOW-only set is annoying noise; an `APPROVE` on a HIGH violation negates the point of this review.
+
+---
+
+## Post to PR (if a PR exists)
+
+```bash
+gh pr view --json number 2>/dev/null --jq '.number'
+```
+
+If a PR number is returned, post the report as a comment with the heading `## 🧼 Code Review — Senior Clean-Code Engineer`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,9 +187,10 @@ This repo defines its own Claude Code slash commands:
 | `/project-sync` | Aligns issue ↔ PR ↔ branch on GitHub |
 | `/criteria-check` | Verifies issue acceptance criteria against the code |
 | `/docs-check` | Audits README + sourcing wire-up |
-| `/code-review` | Runs `senior-bash-engineer` + `senior-powershell-engineer` + `/security-review` in parallel |
+| `/code-review` | Runs `senior-bash-engineer` + `senior-powershell-engineer` + `/security-review` + `senior-clean-code-engineer` in parallel |
 | `/senior-bash-engineer` | Solo bash review (called by `/code-review`) |
 | `/senior-powershell-engineer` | Solo PowerShell review (called by `/code-review`) |
+| `/senior-clean-code-engineer` | Solo clean-code review — duplication, function shape, abstraction debt; enforces CLAUDE.md's extract-repeated-branches + breathing-room rules (called by `/code-review`) |
 | `/pr-body` | Builds / refreshes the PR body table of contents |
 | `/pr-flow` | Full pipeline: parse-checks → commit → push → PR → code-review → docs-check → criteria-check → pr-body |
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -102,6 +102,25 @@ function Test-AzDevOpsAuth {
 # (string or $null) properties.
 # ---------------------------------------------------------------------------
 
+function New-AzDevOpsStepResult {
+    param(
+        [Parameter(Mandatory)] [bool] $Ok,
+        $FailMessage = $null
+    )
+    return [PSCustomObject]@{ Ok = $Ok; FailMessage = $FailMessage }
+}
+
+
+function Read-AzDevOpsYesNo {
+    # Default-yes Y/n prompt used by Confirm-* steps that offer a remediation
+    # action. Returns $true when the user accepts (empty input or anything
+    # other than n/no), $false on explicit refusal.
+    param([Parameter(Mandatory)] [string] $Prompt)
+    $resp = Read-Host "    $Prompt [Y/n]"
+    return -not ($resp -match '^(n|no)$')
+}
+
+
 function Confirm-AzDevOpsCli {
     if (-not (Test-AzDevOpsCliPresent)) {
         Write-Host "  X az CLI not on PATH" -ForegroundColor Red
@@ -114,29 +133,28 @@ function Confirm-AzDevOpsCli {
         } else {
             Write-Host "    See: https://learn.microsoft.com/cli/azure/install-azure-cli-linux"
         }
-        return [PSCustomObject]@{ Ok = $false; FailMessage = 'az CLI missing' }
+        return New-AzDevOpsStepResult -Ok $false -FailMessage 'az CLI missing'
     }
     $azVersion = (az version --output json 2>$null | ConvertFrom-Json).'azure-cli'
     Write-Host "  OK  az CLI present (v$azVersion)" -ForegroundColor Green
-    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
+    return New-AzDevOpsStepResult -Ok $true
 }
 
 
 function Confirm-AzDevOpsExtension {
     if (-not (Test-AzDevOpsExtensionInstalled)) {
         Write-Host "  !  azure-devops extension not installed" -ForegroundColor Yellow
-        $resp = Read-Host "    Install now? [Y/n]"
-        if ($resp -match '^(n|no)$') {
+        if (-not (Read-AzDevOpsYesNo -Prompt 'Install now?')) {
             Write-Host "    Hint: az extension add --name azure-devops"
-            return [PSCustomObject]@{ Ok = $false; FailMessage = 'extension missing' }
+            return New-AzDevOpsStepResult -Ok $false -FailMessage 'extension missing'
         }
         az extension add --name azure-devops 2>&1 | Out-Host
         if (-not (Test-AzDevOpsExtensionInstalled)) {
-            return [PSCustomObject]@{ Ok = $false; FailMessage = 'extension install failed' }
+            return New-AzDevOpsStepResult -Ok $false -FailMessage 'extension install failed'
         }
     }
     Write-Host "  OK  azure-devops extension installed" -ForegroundColor Green
-    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
+    return New-AzDevOpsStepResult -Ok $true
 }
 
 
@@ -154,30 +172,29 @@ function Confirm-AzDevOpsEnvVars {
         Write-Host "    `$env:AZ_ITERATION  = 'My Project\Sprint 42'"
         Write-Host "    ---------------------------------------------------------------"
         Write-Host "    See README section 'Azure DevOps work-item shortcuts' for details."
-        return [PSCustomObject]@{ Ok = $false; FailMessage = 'env vars missing' }
+        return New-AzDevOpsStepResult -Ok $false -FailMessage 'env vars missing'
     }
     Write-Host "  OK  AZ_DEVOPS_ORG = $env:AZ_DEVOPS_ORG" -ForegroundColor Green
     Write-Host "  OK  AZ_PROJECT    = $env:AZ_PROJECT" -ForegroundColor Green
-    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
+    return New-AzDevOpsStepResult -Ok $true
 }
 
 
 function Confirm-AzDevOpsLogin {
     if (-not (Test-AzDevOpsLoggedIn)) {
         Write-Host "  !  No active az login session" -ForegroundColor Yellow
-        $resp = Read-Host "    Run 'az login' now? [Y/n]"
-        if ($resp -match '^(n|no)$') {
+        if (-not (Read-AzDevOpsYesNo -Prompt "Run 'az login' now?")) {
             Write-Host "    Hint: az login"
-            return [PSCustomObject]@{ Ok = $false; FailMessage = 'not logged in' }
+            return New-AzDevOpsStepResult -Ok $false -FailMessage 'not logged in'
         }
         az login | Out-Host
         if (-not (Test-AzDevOpsLoggedIn)) {
-            return [PSCustomObject]@{ Ok = $false; FailMessage = 'az login failed' }
+            return New-AzDevOpsStepResult -Ok $false -FailMessage 'az login failed'
         }
     }
     $account = az account show --output json 2>$null | ConvertFrom-Json
     Write-Host "  OK  Logged in as $($account.user.name) (sub: $($account.name))" -ForegroundColor Green
-    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
+    return New-AzDevOpsStepResult -Ok $true
 }
 
 
@@ -186,10 +203,10 @@ function Set-AzDevOpsDefaults {
     if ($LASTEXITCODE -ne 0) {
         Write-Host "  X az devops configure failed" -ForegroundColor Red
         Write-Host "    $configOutput"
-        return [PSCustomObject]@{ Ok = $false; FailMessage = 'configure failed' }
+        return New-AzDevOpsStepResult -Ok $false -FailMessage 'configure failed'
     }
     Write-Host "  OK  Defaults set: org=$env:AZ_DEVOPS_ORG project=$env:AZ_PROJECT" -ForegroundColor Green
-    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
+    return New-AzDevOpsStepResult -Ok $true
 }
 
 
@@ -198,10 +215,10 @@ function Confirm-AzDevOpsSmokeQuery {
     if ($null -eq $count) {
         Write-Host "  X Smoke query failed" -ForegroundColor Red
         Write-Host "    Try: az boards query --wiql 'Select [System.Id] From WorkItems Where [System.AssignedTo] = @Me'"
-        return [PSCustomObject]@{ Ok = $false; FailMessage = 'smoke query failed' }
+        return New-AzDevOpsStepResult -Ok $false -FailMessage 'smoke query failed'
     }
     Write-Host "  OK  Smoke test passed ($count items assigned to you)" -ForegroundColor Green
-    return [PSCustomObject]@{ Ok = $true; FailMessage = $null }
+    return New-AzDevOpsStepResult -Ok $true
 }
 
 
@@ -580,6 +597,16 @@ function Get-AzDevOpsPlatform {
 }
 
 
+function Get-AzDevOpsScheduledTaskName {
+    return 'BashcutsAzDevOpsSync'
+}
+
+
+function Get-AzDevOpsSyncIntervalHours {
+    return 5
+}
+
+
 function Get-AzDevOpsCronTag {
     return '# bashcuts-azdevops-sync'
 }
@@ -587,8 +614,9 @@ function Get-AzDevOpsCronTag {
 
 function Get-AzDevOpsCronLine {
     param([Parameter(Mandatory)] [string] $PwshPath)
-    $tag = Get-AzDevOpsCronTag
-    return "0 */5 * * * $PwshPath -Command `"Sync-AzDevOpsCache`" $tag"
+    $tag   = Get-AzDevOpsCronTag
+    $hours = Get-AzDevOpsSyncIntervalHours
+    return "0 */$hours * * * $PwshPath -Command `"Sync-AzDevOpsCache`" $tag"
 }
 
 
@@ -618,14 +646,15 @@ function Register-AzDevOpsSyncSchedule {
     # available; without -NoProfile, the scheduled invocation has the same
     # context as an interactive shell.
     $pwshPath = (Get-Process -Id $PID).Path
+    $hours    = Get-AzDevOpsSyncIntervalHours
 
     if ($platform -eq 'Windows') {
-        $taskName = 'BashcutsAzDevOpsSync'
+        $taskName = Get-AzDevOpsScheduledTaskName
         $action   = New-ScheduledTaskAction -Execute $pwshPath -Argument "-Command `"Sync-AzDevOpsCache`""
         $trigger  = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(5) `
-                        -RepetitionInterval (New-TimeSpan -Hours 5)
+                        -RepetitionInterval (New-TimeSpan -Hours $hours)
         Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Force | Out-Null
-        Write-Host "Registered: scheduled task '$taskName' (every 5 hours)" -ForegroundColor Green
+        Write-Host "Registered: scheduled task '$taskName' (every $hours hours)" -ForegroundColor Green
         return
     }
 
@@ -646,7 +675,7 @@ function Unregister-AzDevOpsSyncSchedule {
     $platform = Get-AzDevOpsPlatform
 
     if ($platform -eq 'Windows') {
-        $taskName = 'BashcutsAzDevOpsSync'
+        $taskName = Get-AzDevOpsScheduledTaskName
         if (Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue) {
             Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
             Write-Host "Unregistered: scheduled task '$taskName'" -ForegroundColor Green

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -341,6 +341,143 @@ function Invoke-AzDevOpsBoardsQuery {
 }
 
 
+# ---------------------------------------------------------------------------
+# Sync helpers — extracted so Sync-AzDevOpsCache stays a small orchestrator
+# and the duplicated "first stderr line" / "build error status" / "log raw
+# stderr" patterns live in one place each (per CLAUDE.md DRY rule).
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsFirstStderrLine {
+    param([string] $Stderr)
+    if (-not $Stderr) { return '' }
+    $line = $Stderr -split "`r?`n" | Where-Object { $_.Trim() } | Select-Object -First 1
+    if ($line) { return $line } else { return '' }
+}
+
+
+function New-AzDevOpsDatasetStatus {
+    param(
+        [Parameter(Mandatory)] [ValidateSet('ok', 'error')] [string] $Status,
+        [int]    $Rows,
+        [string] $Message,
+        [string] $Elapsed,
+        [int]    $MaxErrorChars = 500
+    )
+
+    if ($Status -eq 'ok') {
+        return [PSCustomObject]@{
+            Status  = 'ok'
+            Rows    = $Rows
+            Elapsed = $Elapsed
+        }
+    }
+
+    $msg = if ($Message) { $Message.TrimEnd() } else { '' }
+    if ($msg.Length -gt $MaxErrorChars) { $msg = $msg.Substring(0, $MaxErrorChars) }
+
+    return [PSCustomObject]@{
+        Status  = 'error'
+        Error   = $msg
+        Elapsed = $Elapsed
+    }
+}
+
+
+function Write-AzDevOpsSyncStderr {
+    param(
+        [Parameter(Mandatory)] [string] $DatasetName,
+        [Parameter(Mandatory)] [int]    $ExitCode,
+        [Parameter(Mandatory)] [string] $Elapsed,
+        [string] $Stderr
+    )
+
+    Write-AzDevOpsSyncLog "ERROR $DatasetName query failed (exit=$ExitCode, elapsed=$Elapsed)"
+    if (-not $Stderr) { return }
+
+    foreach ($line in ($Stderr -split "`r?`n")) {
+        if ($line.Trim()) {
+            Write-AzDevOpsSyncLog "  [$DatasetName] $line"
+        }
+    }
+}
+
+
+function Get-AzDevOpsSyncDatasets {
+    param([Parameter(Mandatory)] [PSCustomObject] $Paths)
+
+    # Mentions: WIQL has no first-class @-mention predicate. Best effort is
+    # [System.History] Contains 'literal'. Prefer "@<user-email>" when set,
+    # otherwise fall back to a bare "@" - the latter is noisy but at least
+    # populates the cache shape so downstream commands keep working.
+    $mentionsToken = if ($env:AZ_USER_EMAIL) { "@$env:AZ_USER_EMAIL" } else { '@' }
+
+    return @(
+        @{
+            Name  = 'assigned'
+            Label = 'System.AssignedTo = @Me'
+            Path  = $Paths.Assigned
+            Wiql  = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItems Where [System.AssignedTo] = @Me'
+        },
+        @{
+            Name  = 'mentions'
+            Label = "System.History Contains '$mentionsToken'"
+            Path  = $Paths.Mentions
+            Wiql  = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItems Where [System.History] Contains '$mentionsToken'"
+        },
+        @{
+            Name  = 'hierarchy'
+            Label = 'Epic/Feature/Story hierarchy in @Project'
+            Path  = $Paths.Hierarchy
+            Wiql  = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItemLinks Where [Source].[System.TeamProject] = @Project AND [Source].[System.WorkItemType] IN ('Epic', 'Feature', 'User Story') AND [Target].[System.WorkItemType] IN ('Epic', 'Feature', 'User Story') AND [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward' Mode (MustContain)"
+        }
+    )
+}
+
+
+function Invoke-AzDevOpsDatasetSync {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [string] $Label,
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [string] $Wiql
+    )
+
+    Write-Host "-> Querying $Name ($Label)..." -ForegroundColor Cyan
+
+    $sw      = [System.Diagnostics.Stopwatch]::StartNew()
+    $result  = Invoke-AzDevOpsBoardsQuery -Wiql $Wiql
+    $sw.Stop()
+    $elapsed = '{0:N1}s' -f $sw.Elapsed.TotalSeconds
+
+    if ($result.ExitCode -ne 0) {
+        $firstLine = Get-AzDevOpsFirstStderrLine -Stderr $result.Error
+        if (-not $firstLine) { $firstLine = "az exited with code $($result.ExitCode)" }
+
+        Write-Host "  X $Name - $firstLine (in $elapsed)" -ForegroundColor Red
+        Write-AzDevOpsSyncStderr -DatasetName $Name -ExitCode $result.ExitCode -Elapsed $elapsed -Stderr $result.Error
+
+        return New-AzDevOpsDatasetStatus -Status 'error' -Message $result.Error -Elapsed $elapsed
+    }
+
+    try {
+        $parsed = $result.Json | ConvertFrom-Json
+    } catch {
+        $msg = $_.Exception.Message
+        Write-Host "  X $Name - parse failed: $msg (in $elapsed)" -ForegroundColor Red
+        Write-AzDevOpsSyncLog "ERROR $Name parse failed (elapsed=$elapsed): $msg"
+        return New-AzDevOpsDatasetStatus -Status 'error' -Message "parse failed: $msg" -Elapsed $elapsed
+    }
+
+    $count  = @($parsed).Count
+    $pretty = $parsed | ConvertTo-Json -Depth 10
+    Write-AzDevOpsCacheFile -Path $Path -Content $pretty
+    Write-Host "  OK  $Name - $count rows in $elapsed" -ForegroundColor Green
+    Write-AzDevOpsSyncLog "$Name wrote $count rows in $elapsed"
+
+    return New-AzDevOpsDatasetStatus -Status 'ok' -Rows $count -Elapsed $elapsed
+}
+
+
 function Sync-AzDevOpsCache {
     if (-not (Test-AzDevOpsAuth)) {
         Write-Host "Sync-AzDevOpsCache aborted - Test-AzDevOpsAuth returned false. Run Connect-AzDevOps." -ForegroundColor Red
@@ -350,96 +487,21 @@ function Sync-AzDevOpsCache {
     $paths = Initialize-AzDevOpsCacheDir
     Write-AzDevOpsSyncLog 'sync started'
 
-    # Mentions: WIQL has no first-class @-mention predicate. Best effort is
-    # [System.History] Contains 'literal'. Prefer "@<user-email>" when set,
-    # otherwise fall back to a bare "@" - the latter is noisy but at least
-    # populates the cache shape so downstream commands keep working.
-    $mentionsToken = if ($env:AZ_USER_EMAIL) { "@$env:AZ_USER_EMAIL" } else { '@' }
-
-    $datasets = @(
-        @{
-            Name  = 'assigned'
-            Label = 'System.AssignedTo = @Me'
-            Path  = $paths.Assigned
-            Wiql  = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItems Where [System.AssignedTo] = @Me'
-        },
-        @{
-            Name  = 'mentions'
-            Label = "System.History Contains '$mentionsToken'"
-            Path  = $paths.Mentions
-            Wiql  = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItems Where [System.History] Contains '$mentionsToken'"
-        },
-        @{
-            Name  = 'hierarchy'
-            Label = 'Epic/Feature/Story hierarchy in @Project'
-            Path  = $paths.Hierarchy
-            Wiql  = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItemLinks Where [Source].[System.TeamProject] = @Project AND [Source].[System.WorkItemType] IN ('Epic', 'Feature', 'User Story') AND [Target].[System.WorkItemType] IN ('Epic', 'Feature', 'User Story') AND [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward' Mode (MustContain)"
-        }
-    )
+    $datasets = Get-AzDevOpsSyncDatasets -Paths $paths
 
     $counts   = [ordered]@{}
     $statuses = [ordered]@{}
     $errored  = 0
 
     foreach ($ds in $datasets) {
-        Write-Host "-> Querying $($ds.Name) ($($ds.Label))..." -ForegroundColor Cyan
+        $status = Invoke-AzDevOpsDatasetSync @ds
+        $statuses[$ds.Name] = $status
 
-        $sw      = [System.Diagnostics.Stopwatch]::StartNew()
-        $result  = Invoke-AzDevOpsBoardsQuery -Wiql $ds.Wiql
-        $sw.Stop()
-        $elapsed = '{0:N1}s' -f $sw.Elapsed.TotalSeconds
-
-        if ($result.ExitCode -ne 0) {
-            $stderr    = if ($result.Error) { $result.Error } else { '' }
-            $firstLine = ($stderr -split "`r?`n" | Where-Object { $_.Trim() } | Select-Object -First 1)
-            if (-not $firstLine) { $firstLine = "az exited with code $($result.ExitCode)" }
-
-            Write-Host "  X $($ds.Name) - $firstLine (in $elapsed)" -ForegroundColor Red
-            Write-AzDevOpsSyncLog "ERROR $($ds.Name) query failed (exit=$($result.ExitCode), elapsed=$elapsed)"
-            foreach ($line in ($stderr -split "`r?`n")) {
-                if ($line.Trim()) {
-                    Write-AzDevOpsSyncLog "  [$($ds.Name)] $line"
-                }
-            }
-
-            $truncated = $stderr.TrimEnd()
-            if ($truncated.Length -gt 500) { $truncated = $truncated.Substring(0, 500) }
-            $statuses[$ds.Name] = [PSCustomObject]@{
-                Status  = 'error'
-                Error   = $truncated
-                Elapsed = $elapsed
-            }
+        if ($status.Status -eq 'ok') {
+            $counts[$ds.Name] = $status.Rows
+        } else {
             $errored++
-            continue
         }
-
-        try {
-            $parsed = $result.Json | ConvertFrom-Json
-        } catch {
-            $msg = $_.Exception.Message
-            Write-Host "  X $($ds.Name) - parse failed: $msg (in $elapsed)" -ForegroundColor Red
-            Write-AzDevOpsSyncLog "ERROR $($ds.Name) parse failed (elapsed=$elapsed): $msg"
-            $statuses[$ds.Name] = [PSCustomObject]@{
-                Status  = 'error'
-                Error   = "parse failed: $msg"
-                Elapsed = $elapsed
-            }
-            $errored++
-            continue
-        }
-
-        $count  = @($parsed).Count
-        $pretty = $parsed | ConvertTo-Json -Depth 10
-        Write-AzDevOpsCacheFile -Path $ds.Path -Content $pretty
-
-        $counts[$ds.Name]   = $count
-        $statuses[$ds.Name] = [PSCustomObject]@{
-            Status  = 'ok'
-            Rows    = $count
-            Elapsed = $elapsed
-        }
-        Write-Host "  OK  $($ds.Name) - $count rows in $elapsed" -ForegroundColor Green
-        Write-AzDevOpsSyncLog "$($ds.Name) wrote $count rows in $elapsed"
     }
 
     $lastSync = [PSCustomObject]@{
@@ -495,7 +557,8 @@ function Get-AzDevOpsCacheStatus {
             Write-Host ""
             Write-Host "Partial sync - $($errored.Count) dataset(s) errored:" -ForegroundColor Yellow
             foreach ($e in $errored) {
-                $msg = if ($e.Value.Error) { $e.Value.Error -split "`r?`n" | Select-Object -First 1 } else { '(no error text)' }
+                $msg = Get-AzDevOpsFirstStderrLine -Stderr $e.Value.Error
+                if (-not $msg) { $msg = '(no error text)' }
                 Write-Host "  X $($e.Name): $msg" -ForegroundColor Red
             }
             Write-Host "  See $($paths.Log) for full az stderr" -ForegroundColor Yellow
@@ -504,17 +567,61 @@ function Get-AzDevOpsCacheStatus {
 }
 
 
+# ---------------------------------------------------------------------------
+# Scheduling helpers — shared by Register-/Unregister-AzDevOpsSyncSchedule
+# so the platform branch and the cron-tag filter live in one place each
+# (CLAUDE.md explicitly names Get-AzDevOpsPlatform / Get-AzDevOpsCronLine).
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsPlatform {
+    if ($IsWindows -or ($env:OS -eq 'Windows_NT')) { return 'Windows' }
+    if ($IsMacOS -or $IsLinux)                     { return 'Posix' }
+    return 'Unknown'
+}
+
+
+function Get-AzDevOpsCronTag {
+    return '# bashcuts-azdevops-sync'
+}
+
+
+function Get-AzDevOpsCronLine {
+    param([Parameter(Mandatory)] [string] $PwshPath)
+    $tag = Get-AzDevOpsCronTag
+    return "0 */5 * * * $PwshPath -Command `"Sync-AzDevOpsCache`" $tag"
+}
+
+
+function Get-AzDevOpsCrontabSplit {
+    # Reads the current crontab and partitions it into bashcuts-tagged lines
+    # vs everything else. Returns the non-bashcuts lines plus a HadBashcuts
+    # flag so Unregister doesn't have to re-grep to know whether it changed
+    # anything. crontab returning no output / nonzero is normalized to empty.
+    $tag         = Get-AzDevOpsCronTag
+    $existingRaw = crontab -l 2>$null
+
+    if (-not $existingRaw) {
+        return [PSCustomObject]@{ Other = @(); HadBashcuts = $false }
+    }
+
+    $allLines    = @($existingRaw -split "`n" | Where-Object { $_ })
+    $otherLines  = @($allLines | Where-Object { $_ -notmatch [regex]::Escape($tag) })
+    $hadBashcuts = ($otherLines.Count -lt $allLines.Count)
+
+    return [PSCustomObject]@{ Other = $otherLines; HadBashcuts = $hadBashcuts }
+}
+
+
 function Register-AzDevOpsSyncSchedule {
-    $isWin    = $IsWindows -or ($env:OS -eq 'Windows_NT')
-    $pwshPath = (Get-Process -Id $PID).Path
+    $platform = Get-AzDevOpsPlatform
     # Loads the user's $profile so $env:AZ_* and the dot-sourced module are
     # available; without -NoProfile, the scheduled invocation has the same
     # context as an interactive shell.
-    $command = 'Sync-AzDevOpsCache'
+    $pwshPath = (Get-Process -Id $PID).Path
 
-    if ($isWin) {
+    if ($platform -eq 'Windows') {
         $taskName = 'BashcutsAzDevOpsSync'
-        $action   = New-ScheduledTaskAction -Execute $pwshPath -Argument "-Command `"$command`""
+        $action   = New-ScheduledTaskAction -Execute $pwshPath -Argument "-Command `"Sync-AzDevOpsCache`""
         $trigger  = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(5) `
                         -RepetitionInterval (New-TimeSpan -Hours 5)
         Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Force | Out-Null
@@ -522,14 +629,10 @@ function Register-AzDevOpsSyncSchedule {
         return
     }
 
-    if ($IsMacOS -or $IsLinux) {
-        $tag         = '# bashcuts-azdevops-sync'
-        $cronLine    = "0 */5 * * * $pwshPath -Command `"$command`" $tag"
-        $existingRaw = crontab -l 2>$null
-        $existing    = if ($existingRaw) {
-            @($existingRaw -split "`n" | Where-Object { $_ -and ($_ -notmatch [regex]::Escape($tag)) })
-        } else { @() }
-        $newCron = (@($existing) + $cronLine) -join "`n"
+    if ($platform -eq 'Posix') {
+        $cronLine = Get-AzDevOpsCronLine -PwshPath $pwshPath
+        $split    = Get-AzDevOpsCrontabSplit
+        $newCron  = (@($split.Other) + $cronLine) -join "`n"
         $newCron | crontab -
         Write-Host "Registered: cron entry - $cronLine" -ForegroundColor Green
         return
@@ -540,9 +643,9 @@ function Register-AzDevOpsSyncSchedule {
 
 
 function Unregister-AzDevOpsSyncSchedule {
-    $isWin = $IsWindows -or ($env:OS -eq 'Windows_NT')
+    $platform = Get-AzDevOpsPlatform
 
-    if ($isWin) {
+    if ($platform -eq 'Windows') {
         $taskName = 'BashcutsAzDevOpsSync'
         if (Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue) {
             Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
@@ -553,16 +656,13 @@ function Unregister-AzDevOpsSyncSchedule {
         return
     }
 
-    if ($IsMacOS -or $IsLinux) {
-        $tag         = '# bashcuts-azdevops-sync'
-        $existingRaw = crontab -l 2>$null
-        $existing    = if ($existingRaw) { @($existingRaw -split "`n") } else { @() }
-        $filtered    = @($existing | Where-Object { $_ -and ($_ -notmatch [regex]::Escape($tag)) })
-        if ($filtered.Count -eq ($existing | Where-Object { $_ }).Count) {
+    if ($platform -eq 'Posix') {
+        $split = Get-AzDevOpsCrontabSplit
+        if (-not $split.HadBashcuts) {
             Write-Host "No bashcuts-azdevops-sync cron entry to remove" -ForegroundColor Yellow
             return
         }
-        ($filtered -join "`n") | crontab -
+        ($split.Other -join "`n") | crontab -
         Write-Host "Unregistered: removed bashcuts-azdevops-sync cron entry" -ForegroundColor Green
         return
     }

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -316,9 +316,28 @@ function Write-AzDevOpsSyncLog {
 
 function Invoke-AzDevOpsBoardsQuery {
     param([Parameter(Mandatory)] [string] $Wiql)
-    $json = az boards query --wiql $Wiql --output json 2>$null
-    if ($LASTEXITCODE -ne 0) { return $null }
-    return $json
+
+    # Redirecting stderr to a temp file (rather than $null or 2>&1) lets us
+    # keep stdout JSON parseable while still preserving the az error text for
+    # callers to surface to the user / log on failure.
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $json = az boards query --wiql $Wiql --output json 2>$stderrFile
+        $exit = $LASTEXITCODE
+        $stderr = if (Test-Path -LiteralPath $stderrFile) {
+            (Get-Content -LiteralPath $stderrFile -Raw)
+        } else { '' }
+    } finally {
+        Remove-Item -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+    }
+
+    if ($null -eq $stderr) { $stderr = '' }
+
+    return [PSCustomObject]@{
+        Json     = $json
+        Error    = $stderr
+        ExitCode = $exit
+    }
 }
 
 
@@ -339,51 +358,103 @@ function Sync-AzDevOpsCache {
 
     $datasets = @(
         @{
-            Name = 'assigned'
-            Path = $paths.Assigned
-            Wiql = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItems Where [System.AssignedTo] = @Me'
+            Name  = 'assigned'
+            Label = 'System.AssignedTo = @Me'
+            Path  = $paths.Assigned
+            Wiql  = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItems Where [System.AssignedTo] = @Me'
         },
         @{
-            Name = 'mentions'
-            Path = $paths.Mentions
-            Wiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItems Where [System.History] Contains '$mentionsToken'"
+            Name  = 'mentions'
+            Label = "System.History Contains '$mentionsToken'"
+            Path  = $paths.Mentions
+            Wiql  = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItems Where [System.History] Contains '$mentionsToken'"
         },
         @{
-            Name = 'hierarchy'
-            Path = $paths.Hierarchy
-            Wiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItemLinks Where [Source].[System.TeamProject] = @Project AND [Source].[System.WorkItemType] IN ('Epic', 'Feature', 'User Story') AND [Target].[System.WorkItemType] IN ('Epic', 'Feature', 'User Story') AND [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward' Mode (MustContain)"
+            Name  = 'hierarchy'
+            Label = 'Epic/Feature/Story hierarchy in @Project'
+            Path  = $paths.Hierarchy
+            Wiql  = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItemLinks Where [Source].[System.TeamProject] = @Project AND [Source].[System.WorkItemType] IN ('Epic', 'Feature', 'User Story') AND [Target].[System.WorkItemType] IN ('Epic', 'Feature', 'User Story') AND [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward' Mode (MustContain)"
         }
     )
 
-    $counts = [ordered]@{}
+    $counts   = [ordered]@{}
+    $statuses = [ordered]@{}
+    $errored  = 0
+
     foreach ($ds in $datasets) {
-        $json = Invoke-AzDevOpsBoardsQuery -Wiql $ds.Wiql
-        if ($null -eq $json) {
-            Write-Host "  X $($ds.Name) query failed" -ForegroundColor Red
-            Write-AzDevOpsSyncLog "ERROR $($ds.Name) query failed"
+        Write-Host "-> Querying $($ds.Name) ($($ds.Label))..." -ForegroundColor Cyan
+
+        $sw      = [System.Diagnostics.Stopwatch]::StartNew()
+        $result  = Invoke-AzDevOpsBoardsQuery -Wiql $ds.Wiql
+        $sw.Stop()
+        $elapsed = '{0:N1}s' -f $sw.Elapsed.TotalSeconds
+
+        if ($result.ExitCode -ne 0) {
+            $stderr    = if ($result.Error) { $result.Error } else { '' }
+            $firstLine = ($stderr -split "`r?`n" | Where-Object { $_.Trim() } | Select-Object -First 1)
+            if (-not $firstLine) { $firstLine = "az exited with code $($result.ExitCode)" }
+
+            Write-Host "  X $($ds.Name) - $firstLine (in $elapsed)" -ForegroundColor Red
+            Write-AzDevOpsSyncLog "ERROR $($ds.Name) query failed (exit=$($result.ExitCode), elapsed=$elapsed)"
+            foreach ($line in ($stderr -split "`r?`n")) {
+                if ($line.Trim()) {
+                    Write-AzDevOpsSyncLog "  [$($ds.Name)] $line"
+                }
+            }
+
+            $truncated = $stderr.TrimEnd()
+            if ($truncated.Length -gt 500) { $truncated = $truncated.Substring(0, 500) }
+            $statuses[$ds.Name] = [PSCustomObject]@{
+                Status  = 'error'
+                Error   = $truncated
+                Elapsed = $elapsed
+            }
+            $errored++
             continue
         }
+
         try {
-            $parsed = $json | ConvertFrom-Json
+            $parsed = $result.Json | ConvertFrom-Json
         } catch {
-            Write-Host "  X $($ds.Name) parse failed" -ForegroundColor Red
-            Write-AzDevOpsSyncLog "ERROR $($ds.Name) parse failed"
+            $msg = $_.Exception.Message
+            Write-Host "  X $($ds.Name) - parse failed: $msg (in $elapsed)" -ForegroundColor Red
+            Write-AzDevOpsSyncLog "ERROR $($ds.Name) parse failed (elapsed=$elapsed): $msg"
+            $statuses[$ds.Name] = [PSCustomObject]@{
+                Status  = 'error'
+                Error   = "parse failed: $msg"
+                Elapsed = $elapsed
+            }
+            $errored++
             continue
         }
+
         $count  = @($parsed).Count
         $pretty = $parsed | ConvertTo-Json -Depth 10
         Write-AzDevOpsCacheFile -Path $ds.Path -Content $pretty
-        $counts[$ds.Name] = $count
-        Write-Host "  OK  $($ds.Name) - $count rows" -ForegroundColor Green
-        Write-AzDevOpsSyncLog "$($ds.Name) wrote $count rows"
+
+        $counts[$ds.Name]   = $count
+        $statuses[$ds.Name] = [PSCustomObject]@{
+            Status  = 'ok'
+            Rows    = $count
+            Elapsed = $elapsed
+        }
+        Write-Host "  OK  $($ds.Name) - $count rows in $elapsed" -ForegroundColor Green
+        Write-AzDevOpsSyncLog "$($ds.Name) wrote $count rows in $elapsed"
     }
 
     $lastSync = [PSCustomObject]@{
         Timestamp = (Get-Date).ToString('o')
         Counts    = $counts
+        Datasets  = $statuses
     }
     Write-AzDevOpsCacheFile -Path $paths.LastSync -Content ($lastSync | ConvertTo-Json -Depth 5)
     Write-AzDevOpsSyncLog 'sync complete'
+
+    Write-Host ""
+    Write-Host "Cache: $($paths.Dir)" -ForegroundColor Cyan
+    if ($errored -gt 0) {
+        Write-Host "Partial sync - $errored of $($datasets.Count) dataset(s) failed. See $($paths.Log)" -ForegroundColor Yellow
+    }
 }
 
 
@@ -415,6 +486,19 @@ function Get-AzDevOpsCacheStatus {
     if ($info.Counts) {
         $info.Counts.PSObject.Properties | ForEach-Object {
             Write-Host "  $($_.Name): $($_.Value) rows"
+        }
+    }
+
+    if ($info.Datasets) {
+        $errored = @($info.Datasets.PSObject.Properties | Where-Object { $_.Value.Status -eq 'error' })
+        if ($errored.Count -gt 0) {
+            Write-Host ""
+            Write-Host "Partial sync - $($errored.Count) dataset(s) errored:" -ForegroundColor Yellow
+            foreach ($e in $errored) {
+                $msg = if ($e.Value.Error) { $e.Value.Error -split "`r?`n" | Select-Object -First 1 } else { '(no error text)' }
+                Write-Host "  X $($e.Name): $msg" -ForegroundColor Red
+            }
+            Write-Host "  See $($paths.Log) for full az stderr" -ForegroundColor Yellow
         }
     }
 }


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #16 |
| [Changes](#changes) | ✅ 1 file, 3 functions + 13 new private helpers |
| [Test Plan](#test-plan) | 0/7 |
| **Skill Reports** (latest — post clean-code follow-up `3eef582`) | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392982209) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392986709) |
| 🛡️ Security Audit | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392983934) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — **all prior residuals CLEARED** — [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392986572) |
| ✅ Criteria Check | ✅ PASS (8 verified, 3 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392319425) |
| 📚 Docs Check | ✅ CURRENT for this PR |
| **Prior review history** | |
| Pass 2 (post helper extraction `319251e`) | 🐚 [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392902861) · 💠 [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392909058) · 🛡️ [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392908407) · 🧼 [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392909441) |
| Pass 1 (initial observability commit `abcef2a`) | 🐚 [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392299338) · 💠 [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392306768) · 🛡️ [View](https://github.com/jdschleicher/bashcuts/pull/17#issuecomment-4392305788) |
<!-- toc:end -->

## Summary
Make `Sync-AzDevOpsCache` chatty during long-running `az boards query` round-trips and surface real `az` stderr when a dataset fails so the user can diagnose without re-running by hand.

Refactor follow-up (commit `319251e`): extracted 9 private helpers per CLAUDE.md's extract-repeated-branches rule so `Sync-AzDevOpsCache` is now a 25-line orchestrator and the `Register-`/`Unregister-AzDevOpsSyncSchedule` pair share their platform / cron-tag scaffolding.

Tooling follow-up (commit `0676385`): added a 4th `senior-clean-code-engineer` reviewer to `/code-review` so the kind of duplication this PR's first review missed gets caught automatically going forward.

Clean-code follow-up (commit `3eef582`): cleared the 1 MEDIUM + 3 LOW findings from the 🧼 review with 4 more private helpers — `New-AzDevOpsStepResult` (eliminates 14× `[PSCustomObject]@{ Ok; FailMessage }` literal across the Confirm-* functions), `Get-AzDevOpsScheduledTaskName`, `Get-AzDevOpsSyncIntervalHours` (single source of truth for the 5-hour interval used by both Windows scheduled-task and cron), and `Read-AzDevOpsYesNo` (default-yes Y/n prompt shared by Confirm-Extension + Confirm-Login).

## Issue
Closes #16

## Changes
- **`Invoke-AzDevOpsBoardsQuery`** — returns `[PSCustomObject]@{ Json; Error; ExitCode }`. Stderr is captured via temp-file (instead of being silently swallowed by `2>$null`) so callers can present it on failure.
- **`Sync-AzDevOpsCache`** —
  - Prints `-> Querying <name> (<filter>)...` before each dataset query (ASCII arrow for cross-platform safety).
  - Per-dataset stopwatch; success line shows rows + elapsed (`OK assigned - 12 rows in 3.4s`, tenths-of-second precision).
  - On failure: first non-empty stderr line in red on the terminal, full multi-line stderr appended to `sync.log` tagged with the dataset name; loop continues to remaining datasets.
  - `last-sync.json` now includes a `Datasets` field — per-dataset `{ Status: ok/error; Rows/Error; Elapsed }` with the error message truncated at 500 chars (full text always lives in `sync.log`).
  - Prints the cache directory path at the end and a `Partial sync` warning if any dataset errored.
- **`Get-AzDevOpsCacheStatus`** — reads the new `Datasets` field; if any dataset is `error`, prints a yellow partial-sync block listing failed datasets with the first error line and a hint pointing at `sync.log`.
- **13 private helpers** extracted across the refactor + clean-code commits — `Get-AzDevOpsFirstStderrLine`, `New-AzDevOpsDatasetStatus`, `Write-AzDevOpsSyncStderr`, `Get-AzDevOpsSyncDatasets`, `Invoke-AzDevOpsDatasetSync`, `Get-AzDevOpsPlatform`, `Get-AzDevOpsScheduledTaskName`, `Get-AzDevOpsSyncIntervalHours`, `Get-AzDevOpsCronTag`, `Get-AzDevOpsCronLine`, `Get-AzDevOpsCrontabSplit`, `New-AzDevOpsStepResult`, `Read-AzDevOpsYesNo`. Each named in CLAUDE.md or extracted to dedupe a 2+ callsite pattern.

## Test Plan
- [ ] Open a fresh PowerShell terminal, run `Sync-AzDevOpsCache`. Confirm a `-> Querying assigned (System.AssignedTo = @Me)...` line appears immediately, then `OK assigned - N rows in T.Ts`, etc., ending with `Cache: <path>`.
- [ ] Force a failure on one dataset (e.g. point `$env:AZ_PROJECT` at a project where the user lacks WIQL hierarchy permissions, or temporarily corrupt one WIQL string). Confirm the first stderr line appears in red on the terminal, the full stderr is appended to `sync.log` tagged with the dataset name, and the other datasets still complete.
- [ ] Run `Get-AzDevOpsCacheStatus` after the partial failure. Confirm the `Partial sync - N dataset(s) errored` block lists the failed dataset(s) with a hint pointing at `sync.log`.
- [ ] Restore working state, re-sync, run `Get-AzDevOpsCacheStatus`. Confirm no partial-sync block, all datasets show row counts.
- [ ] Verify on Windows.
- [ ] Verify on macOS (PowerShell Core).
- [ ] `pwsh -NoProfile` parses `powcuts_by_cli/azdevops_workitems.ps1` with zero errors.

https://claude.ai/code/session_011bdpvqsAMy1y3v9ujzYYt6

---
_Generated by [Claude Code](https://claude.ai/code/session_011bdpvqsAMy1y3v9ujzYYt6)_