### PR TITLE
feat(#9): Get-AzDevOpsAssigned and Open-AzDevOpsAssigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,18 @@ This walks through six checks (Azure CLI present, `azure-devops` extension insta
 
 After `Connect-AzDevOps` reports `READY` once, later commands in the AzDevOps batch use the silent `Test-AzDevOpsAuth` check at startup to confirm the environment is still good before they hit the cache.
 
+### Day-to-day work-item shortcuts
+
+These read the local cache populated by `Sync-AzDevOpsCache` (and the recurring `Register-AzDevOpsSyncSchedule` job). They never call `az` directly, so they return instantly.
+
+```powershell
+Get-AzDevOpsAssigned                       # everything assigned to you (excludes Closed/Removed)
+Get-AzDevOpsAssigned -State Active         # filter to a single state
+Get-AzDevOpsAssigned -State Active,New     # filter to multiple states
+Get-AzDevOpsAssigned | Format-Table -AutoSize
+
+Open-AzDevOpsAssigned 12345                # open one of your assigned items in the browser
+```
+
+If the cache is older than 6 hours, `Get-AzDevOpsAssigned` prints a one-line `WARNING stale (last sync: ...)` notice above the table and still returns the cached rows.
+

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For windows machines, the snippets are stored in an expected directory, so we ca
 
 # <a name="azure-devops"></a>Azure DevOps work-item shortcuts
 
-PowerShell shortcuts in `powcuts_by_cli/azdevops_workitems.ps1` provide guided setup and work-item navigation against an Azure DevOps organization. Future commands in this batch will add cached lists of items assigned to you, items you've been mentioned in, an Epic→Feature→User Story tree view, and an interactive new-user-story creator with parent-feature and iteration pickers.
+PowerShell shortcuts in `powcuts_by_cli/azdevops_workitems.ps1` provide guided setup and work-item navigation against an Azure DevOps organization. Today this includes a guided `Connect-AzDevOps` first-run helper, a cached background sync (`Sync-AzDevOpsCache` + `Register-AzDevOpsSyncSchedule`), and a list/open pair for items assigned to you (`Get-AzDevOpsAssigned`, `Open-AzDevOpsAssigned`). Future commands in this batch will add items you've been mentioned in, an Epic→Feature→User Story tree view, and an interactive new-user-story creator with parent-feature and iteration pickers.
 
 ### Prerequisites
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -341,7 +341,7 @@ function Sync-AzDevOpsCache {
         @{
             Name = 'assigned'
             Path = $paths.Assigned
-            Wiql = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItems Where [System.AssignedTo] = @Me'
+            Wiql = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.ChangedDate] From WorkItems Where [System.AssignedTo] = @Me'
         },
         @{
             Name = 'mentions'
@@ -387,18 +387,15 @@ function Sync-AzDevOpsCache {
 }
 
 
-function Get-AzDevOpsCacheStatus {
+function Get-AzDevOpsCacheAge {
     $paths = Get-AzDevOpsCachePaths
-    if (-not (Test-Path -LiteralPath $paths.LastSync)) {
-        Write-Host "No cache yet - run Sync-AzDevOpsCache" -ForegroundColor Yellow
-        return
-    }
+    if (-not (Test-Path -LiteralPath $paths.LastSync)) { return $null }
 
-    $info   = Get-Content -LiteralPath $paths.LastSync -Raw | ConvertFrom-Json
-    $synced = [datetime]$info.Timestamp
-    $age    = (Get-Date) - $synced
+    $info     = Get-Content -LiteralPath $paths.LastSync -Raw | ConvertFrom-Json
+    $synced   = [datetime]$info.Timestamp
+    $age      = (Get-Date) - $synced
 
-    $ageText = if ($age.TotalMinutes -lt 60) {
+    $ageText  = if ($age.TotalMinutes -lt 60) {
         "$([int]$age.TotalMinutes) min ago"
     } elseif ($age.TotalHours -lt 24) {
         "$([math]::Round($age.TotalHours, 1)) hours ago"
@@ -406,14 +403,31 @@ function Get-AzDevOpsCacheStatus {
         "$([int]$age.TotalDays) days ago"
     }
 
-    if ($age.TotalHours -lt 6) {
-        Write-Host "OK fresh - synced $ageText" -ForegroundColor Green
-    } else {
-        Write-Host "STALE - last synced $ageText" -ForegroundColor Yellow
+    return [PSCustomObject]@{
+        Synced  = $synced
+        Age     = $age
+        AgeText = $ageText
+        IsStale = ($age.TotalHours -ge 6)
+        Counts  = $info.Counts
+    }
+}
+
+
+function Get-AzDevOpsCacheStatus {
+    $cacheAge = Get-AzDevOpsCacheAge
+    if ($null -eq $cacheAge) {
+        Write-Host "No cache yet - run Sync-AzDevOpsCache" -ForegroundColor Yellow
+        return
     }
 
-    if ($info.Counts) {
-        $info.Counts.PSObject.Properties | ForEach-Object {
+    if ($cacheAge.IsStale) {
+        Write-Host "STALE - last synced $($cacheAge.AgeText)" -ForegroundColor Yellow
+    } else {
+        Write-Host "OK fresh - synced $($cacheAge.AgeText)" -ForegroundColor Green
+    }
+
+    if ($cacheAge.Counts) {
+        $cacheAge.Counts.PSObject.Properties | ForEach-Object {
             Write-Host "  $($_.Name): $($_.Value) rows"
         }
     }
@@ -484,4 +498,113 @@ function Unregister-AzDevOpsSyncSchedule {
     }
 
     Write-Host "Unsupported OS for Unregister-AzDevOpsSyncSchedule" -ForegroundColor Red
+}
+
+
+# ---------------------------------------------------------------------------
+# Cache consumers - read-only commands that surface cached work items
+#
+# Public functions:
+#   Get-AzDevOpsAssigned   - table of work items assigned to me
+#   Open-AzDevOpsAssigned  - open a single assigned item in the browser
+#
+# Both functions read $HOME/.bashcuts-cache/azure-devops/assigned.json (built
+# by Sync-AzDevOpsCache). They never call `az` directly - if the cache is
+# missing, they print a hint and bail.
+# ---------------------------------------------------------------------------
+
+function ConvertFrom-AzDevOpsAssignedItem {
+    param([Parameter(Mandatory)] $Raw)
+
+    $f = $Raw.fields
+    return [PSCustomObject]@{
+        Id         = if ($f.'System.Id') { [int]$f.'System.Id' } else { [int]$Raw.id }
+        Type       = $f.'System.WorkItemType'
+        State      = $f.'System.State'
+        Title      = $f.'System.Title'
+        Iteration  = $f.'System.IterationPath'
+        AssignedAt = if ($f.'System.ChangedDate') { [datetime]$f.'System.ChangedDate' } else { $null }
+    }
+}
+
+
+function Read-AzDevOpsAssignedCache {
+    $paths = Get-AzDevOpsCachePaths
+    if (-not (Test-Path -LiteralPath $paths.Dir) -or -not (Test-Path -LiteralPath $paths.Assigned)) {
+        Write-Host "No assigned-items cache at $($paths.Assigned)." -ForegroundColor Yellow
+        Write-Host "  Run: Sync-AzDevOpsCache              # one-shot refresh" -ForegroundColor Yellow
+        Write-Host "  Run: Register-AzDevOpsSyncSchedule   # recurring refresh (~5h)" -ForegroundColor Yellow
+        return $null
+    }
+
+    try {
+        $raw = Get-Content -LiteralPath $paths.Assigned -Raw | ConvertFrom-Json
+    } catch {
+        Write-Host "Could not parse $($paths.Assigned): $_" -ForegroundColor Red
+        return $null
+    }
+
+    return @($raw | ForEach-Object { ConvertFrom-AzDevOpsAssignedItem -Raw $_ })
+}
+
+
+function Get-AzDevOpsAssigned {
+    [CmdletBinding()]
+    param(
+        [string[]] $State
+    )
+
+    $items = Read-AzDevOpsAssignedCache
+    if ($null -eq $items) { return }
+
+    $cacheAge = Get-AzDevOpsCacheAge
+    if ($cacheAge -and $cacheAge.IsStale) {
+        Write-Host "WARNING stale (last sync: $($cacheAge.AgeText))" -ForegroundColor Yellow
+    }
+
+    $filtered = if ($State) {
+        $items | Where-Object { $_.State -in $State }
+    } else {
+        $items | Where-Object { $_.State -notin @('Closed', 'Removed') }
+    }
+
+    foreach ($item in $filtered) {
+        if ($item.Title -and $item.Title.Length -gt 80) {
+            $item.Title = $item.Title.Substring(0, 77) + '...'
+        }
+    }
+
+    return $filtered
+}
+
+
+function Open-AzDevOpsAssigned {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)] [int] $Id
+    )
+
+    $items = Read-AzDevOpsAssignedCache
+    if ($null -eq $items) { return }
+
+    $match = $items | Where-Object { $_.Id -eq $Id } | Select-Object -First 1
+    if (-not $match) {
+        Write-Host "Work item $Id is not in your assigned-items cache." -ForegroundColor Red
+        Write-Host "  Tip: run Get-AzDevOpsAssigned to list valid IDs, or Sync-AzDevOpsCache to refresh." -ForegroundColor Yellow
+        $global:LASTEXITCODE = 1
+        return
+    }
+
+    if (-not $env:AZ_DEVOPS_ORG -or -not $env:AZ_PROJECT) {
+        Write-Host "AZ_DEVOPS_ORG and AZ_PROJECT must both be set in your `$profile." -ForegroundColor Red
+        $global:LASTEXITCODE = 1
+        return
+    }
+
+    $org        = $env:AZ_DEVOPS_ORG.TrimEnd('/')
+    $projectEnc = [uri]::EscapeDataString($env:AZ_PROJECT)
+    $url        = "$org/$projectEnc/_workitems/edit/$Id"
+
+    Write-Host "Opening $url" -ForegroundColor Cyan
+    Start-Process $url
 }

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -554,11 +554,13 @@ function Get-AzDevOpsCacheAge {
     }
 
     return [PSCustomObject]@{
-        Synced  = $synced
-        Age     = $age
-        AgeText = $ageText
-        IsStale = ($age.TotalHours -ge 6)
-        Counts  = $info.Counts
+        Synced   = $synced
+        Age      = $age
+        AgeText  = $ageText
+        IsStale  = ($age.TotalHours -ge 6)
+        Counts   = $info.Counts
+        Datasets = $info.Datasets
+        LogPath  = $paths.Log
     }
 }
 
@@ -582,8 +584,8 @@ function Get-AzDevOpsCacheStatus {
         }
     }
 
-    if ($info.Datasets) {
-        $errored = @($info.Datasets.PSObject.Properties | Where-Object { $_.Value.Status -eq 'error' })
+    if ($cacheAge.Datasets) {
+        $errored = @($cacheAge.Datasets.PSObject.Properties | Where-Object { $_.Value.Status -eq 'error' })
         if ($errored.Count -gt 0) {
             Write-Host ""
             Write-Host "Partial sync - $($errored.Count) dataset(s) errored:" -ForegroundColor Yellow
@@ -592,7 +594,7 @@ function Get-AzDevOpsCacheStatus {
                 if (-not $msg) { $msg = '(no error text)' }
                 Write-Host "  X $($e.Name): $msg" -ForegroundColor Red
             }
-            Write-Host "  See $($paths.Log) for full az stderr" -ForegroundColor Yellow
+            Write-Host "  See $($cacheAge.LogPath) for full az stderr" -ForegroundColor Yellow
         }
     }
 }
@@ -781,13 +783,17 @@ function Get-AzDevOpsAssigned {
         $items | Where-Object { $_.State -notin @('Closed', 'Removed') }
     }
 
-    foreach ($item in $filtered) {
-        if ($item.Title -and $item.Title.Length -gt 80) {
-            $item.Title = $item.Title.Substring(0, 77) + '...'
-        }
-    }
+    $titleMaxLen = 80
 
-    return $filtered
+    return $filtered | Select-Object Id, Type, State,
+        @{ Name = 'Title'; Expression = {
+            if ($_.Title -and $_.Title.Length -gt $titleMaxLen) {
+                $_.Title.Substring(0, $titleMaxLen - 3) + '...'
+            } else {
+                $_.Title
+            }
+        } },
+        Iteration, AssignedAt
 }
 
 


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #9 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | 0/10 |
| [Shell Parity](#shell-parity) | PowerShell-only |
| **Skill Reports (latest)** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/18#issuecomment-4393017621) |
| 💠 PowerShell Engineer Review | ✅ APPROVE (re-verified) — [View](https://github.com/jdschleicher/bashcuts/pull/18#issuecomment-4393031015) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/18#issuecomment-4393021500) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE (re-verified) — [View](https://github.com/jdschleicher/bashcuts/pull/18#issuecomment-4393020876) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/18#issuecomment-4393036938) |

> Earlier review iteration (pre-merge with main): [💠 first PowerShell run](https://github.com/jdschleicher/bashcuts/pull/18#issuecomment-4393021500) flagged a HIGH and MEDIUM finding that were resolved in commit `6c45f90`.
<!-- toc:end -->

## Summary
Adds two PowerShell consumer functions that read the local Azure DevOps cache built by `Sync-AzDevOpsCache` (issue #8) and surface assigned work items without ever calling `az` directly.

## Issue
Closes #9

## Changes
- **`powcuts_by_cli/azdevops_workitems.ps1`**
  - `Get-AzDevOpsAssigned [-State <string[]>]` — returns typed objects (`Id`, `Type`, `State`, `Title` truncated to 80 chars via `Select-Object` projection, `Iteration`, `AssignedAt`); defaults to "open-ish" states (excludes `Closed`/`Removed`); accepts single or multiple states; prints a one-line stale warning above the table when the cache is older than 6h but still returns rows
  - `Open-AzDevOpsAssigned <Id>` — verifies the id is in the assigned cache before opening (prevents typos navigating to unrelated items); sets `$LASTEXITCODE = 1` on miss; URL-encodes `$env:AZ_PROJECT`; uses `Start-Process` for cross-platform open
  - Shared internal helpers: `Get-AzDevOpsCacheAge` (now also used by `Get-AzDevOpsCacheStatus` — DRY; returns `Datasets` and `LogPath` so the consumer's partial-sync error report keeps working), `ConvertFrom-AzDevOpsAssignedItem`, `Read-AzDevOpsAssignedCache`
  - `Get-AzDevOpsSyncDatasets` assigned WIQL extended with `[System.IterationPath]` and `[System.ChangedDate]` so the new table can populate `Iteration` and `AssignedAt` columns
- **`README.md`** — new "Day-to-day work-item shortcuts" subsection with usage examples; refreshed AzDevOps section intro to reflect shipped functionality

## Test Plan
- [ ] Open a fresh PowerShell terminal — `Get-AzDevOps` + tab-tab autocompletes `Get-AzDevOpsAssigned`; `Open-AzDevOps` + tab-tab autocompletes `Open-AzDevOpsAssigned`
- [ ] With no cache: `Get-AzDevOpsAssigned` prints the "run Sync-AzDevOpsCache" hint
- [ ] After `Sync-AzDevOpsCache`: `Get-AzDevOpsAssigned` returns a table in <500ms
- [ ] `Get-AzDevOpsAssigned -State Active` filters to a single state
- [ ] `Get-AzDevOpsAssigned -State Active,New` filters to multiple states
- [ ] `Get-AzDevOpsAssigned | Format-Table -AutoSize` renders cleanly (objects, not text)
- [ ] `Open-AzDevOpsAssigned <id>` opens the work item in the default browser
- [ ] `Open-AzDevOpsAssigned 999999` errors out and sets `$LASTEXITCODE` non-zero
- [ ] After 6h since last sync, `Get-AzDevOpsAssigned` prints a `WARNING stale (last sync: …)` line above the table
- [ ] Verified on macOS (PowerShell Core) — same checks pass

## Shell Parity
PowerShell-only, per issue #9 explicit note.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2jQeu6fhagLpdhxfseYra)_