### PR TITLE
feat(#10): Show-AzDevOpsTree — Epic/Feature/Story hierarchy view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,53 @@ o-sfdx   o-git   o-gh   o-az   o-cci
   }
   ```
   Reasons: each branch gets its own breakpoint line, adding a second statement to one branch is a one-line diff instead of restructuring, and the visual weight of the conditional matches its semantic weight. Same rule for bash — never compress `if condition; then x; else y; fi` to a single line; expand each branch to its own line.
+- **Name your magic strings, codepoints, and literal values** — never inline `[char]0x1F4E6`, raw escape sequences, or string literals whose intent isn't obvious at the call site. Hoist them into named locals (or `$script:`-scoped constants when reused across functions) whose names describe purpose. **Bad:**
+  ```powershell
+  switch ($Type) {
+      'Epic'       { return "$([char]0x1F4E6)" }
+      'Feature'    { return "$([char]0x1F3AF)" }
+      'User Story' { return "$([char]0x1F4DD)" }
+  }
+  ```
+  **Good:**
+  ```powershell
+  $iconEpic    = "$([char]0x1F4E6)"   # package
+  $iconFeature = "$([char]0x1F3AF)"   # bullseye
+  $iconStory   = "$([char]0x1F4DD)"   # memo
+
+  switch ($Type) {
+      'Epic' {
+          return $iconEpic
+      }
+      ...
+  }
+  ```
+  Reasons: a `0x1F4E6` literal tells the reader nothing; `$iconEpic` tells them everything. The named local is also the single point of change if the glyph needs swapping. Same rule for bash — define `local icon_epic=$'\xf0\x9f\x93\xa6'` (or assign once at the top of the function) rather than scattering raw bytes through a `case` statement. The em-dash `[char]0x2014` and the four-space tree indent `'    '` are likewise candidates for naming when they appear in two or more places.
+- **Switch branches expand across multiple lines, with breathing room between them** — no `'Epic' { return $x }` one-liners. Each `case` opens on its own line, the body is indented on the next line, the closing `}` lives on its own line, and a blank line separates branches. Same rationale as the multi-line `if`/`else` rule: per-branch breakpoints, one-line diff to add a second statement, and visual weight that matches the branch's semantic weight. **Bad:**
+  ```powershell
+  switch ($Type) {
+      'Epic'    { return $iconEpic }
+      'Feature' { return $iconFeature }
+      default   { return '*' }
+  }
+  ```
+  **Good:**
+  ```powershell
+  switch ($Type) {
+      'Epic' {
+          return $iconEpic
+      }
+
+      'Feature' {
+          return $iconFeature
+      }
+
+      default {
+          return $iconUnknown
+      }
+  }
+  ```
+  Same rule for bash `case ... esac` — never compress a case arm to `pattern) cmd ;;` on one line; expand to a multi-line block with a blank line between arms.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,26 @@ o-sfdx   o-git   o-gh   o-az   o-cci
   return $result
   ```
   Reasons: a named local makes the value inspectable in a debugger / `Set-PSBreakpoint`, surfaces the type at the assignment site, gives a single explicit exit point, and makes refactoring (logging, transforming, validating before return) a one-line edit instead of restructuring the return statement. Applies to pipeline expressions too — assign `$rows = $raw | ForEach-Object { … }` then `return $rows`. Allowed exceptions: trivial value literals (`return $null`, `return $true`, `return ''`), and explicit `return` of an already-named variable.
+- **Multi-line `if`/`elseif`/`else` blocks always — no inline shorthand** — every branch body lives on its own line with the body indented; never collapse a conditional to `if ($cond) { x } else { y }` on a single line. The `} else {` / `} elseif (...) {` joiners stay on the same line (existing project K&R style). Applies even when the conditional is the right-hand side of an assignment or a hashtable property value. **Bad:**
+  ```powershell
+  $key  = if ($null -ne $item.Parent) { $item.Parent } else { 0 }
+  Id    = if ($f.'System.Id') { [int]$f.'System.Id' } else { [int]$Raw.id }
+  ```
+  **Good:**
+  ```powershell
+  $key = if ($null -ne $item.Parent) {
+      $item.Parent
+  } else {
+      0
+  }
+
+  Id = if ($f.'System.Id') {
+      [int]$f.'System.Id'
+  } else {
+      [int]$Raw.id
+  }
+  ```
+  Reasons: each branch gets its own breakpoint line, adding a second statement to one branch is a one-line diff instead of restructuring, and the visual weight of the conditional matches its semantic weight. Same rule for bash — never compress `if condition; then x; else y; fi` to a single line; expand each branch to its own line.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,12 @@ o-sfdx   o-git   o-gh   o-az   o-cci
 - **No comments for self-evident code** — only comment where the logic is genuinely non-obvious.
 - **Breathing room** — keep code visually scannable. Two blank lines between top-level function definitions in a `.ps1` or `.<cli>_bashcuts` file. One blank line between logical groups inside a function body (e.g. before a `foreach`, before a final `return`, between a setup block and the work that uses it). A wall of code without spacing makes review and edits harder; don't be stingy with vertical whitespace.
 - **Extract repeated branches into private helpers** — if the same `if ($IsWindows -or ...)` / `elseif ($IsMacOS -or $IsLinux)` (or any other repeating decision) appears in two or more functions, lift it into a small private helper (e.g. `Get-AzDevOpsPlatform` returning `'Windows'`/`'Posix'`, or `Get-AzDevOpsCronLine` building the cron string). Same rule for bash: if two functions repeat the same `case "$OSTYPE"` block, extract it into `_bashcut_os` in `.bash_commons` or the file's local helper. Private helpers can use unapproved verbs since they aren't user-facing — readability of the public surface is what matters. Apply this proactively when implementing parallel `Register-/Unregister-` style pairs.
+- **Never `return` a function call directly** — capture the call's result in a named local variable on its own line, then `return $thatVariable`. This applies to both PowerShell and bash. **Bad:** `return Get-Something -Param $x` / `return Read-AzDevOpsJsonCache -Path $p ...`. **Good:**
+  ```powershell
+  $result = Get-Something -Param $x
+  return $result
+  ```
+  Reasons: a named local makes the value inspectable in a debugger / `Set-PSBreakpoint`, surfaces the type at the assignment site, gives a single explicit exit point, and makes refactoring (logging, transforming, validating before return) a one-line edit instead of restructuring the return statement. Applies to pipeline expressions too — assign `$rows = $raw | ForEach-Object { … }` then `return $rows`. Allowed exceptions: trivial value literals (`return $null`, `return $true`, `return ''`), and explicit `return` of an already-named variable.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For windows machines, the snippets are stored in an expected directory, so we ca
 
 # <a name="azure-devops"></a>Azure DevOps work-item shortcuts
 
-PowerShell shortcuts in `powcuts_by_cli/azdevops_workitems.ps1` provide guided setup and work-item navigation against an Azure DevOps organization. Today this includes a guided `Connect-AzDevOps` first-run helper, a cached background sync (`Sync-AzDevOpsCache` + `Register-AzDevOpsSyncSchedule`), and a list/open pair for items assigned to you (`Get-AzDevOpsAssigned`, `Open-AzDevOpsAssigned`). Future commands in this batch will add items you've been mentioned in, an Epic→Feature→User Story tree view, and an interactive new-user-story creator with parent-feature and iteration pickers.
+PowerShell shortcuts in `powcuts_by_cli/azdevops_workitems.ps1` provide guided setup and work-item navigation against an Azure DevOps organization. Today this includes a guided `Connect-AzDevOps` first-run helper, a cached background sync (`Sync-AzDevOpsCache` + `Register-AzDevOpsSyncSchedule`), a list/open pair for items assigned to you (`Get-AzDevOpsAssigned`, `Open-AzDevOpsAssigned`), and an Epic→Feature→User Story tree view (`Show-AzDevOpsTree`). Future commands in this batch will add items you've been mentioned in and an interactive new-user-story creator with parent-feature and iteration pickers.
 
 ### Prerequisites
 
@@ -201,7 +201,9 @@ Get-AzDevOpsAssigned -State Active,New     # filter to multiple states
 Get-AzDevOpsAssigned | Format-Table -AutoSize
 
 Open-AzDevOpsAssigned 12345                # open one of your assigned items in the browser
+
+Show-AzDevOpsTree                          # print the project's Epic -> Feature -> User Story tree
 ```
 
-If the cache is older than 6 hours, `Get-AzDevOpsAssigned` prints a one-line `WARNING stale (last sync: ...)` notice above the table and still returns the cached rows.
+If the cache is older than 6 hours, `Get-AzDevOpsAssigned` and `Show-AzDevOpsTree` each print a one-line `WARNING stale (last sync: ...)` notice above their output and still render the cached data.
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -936,15 +936,17 @@ function Format-AzDevOpsTreeNode {
         [Parameter(Mandatory)] [int] $Depth
     )
 
-    $indent = '    ' * $Depth
-    $icon   = Get-AzDevOpsTreeIcon -Type $Item.Type
+    $indent    = '    ' * $Depth
+    $icon      = Get-AzDevOpsTreeIcon -Type $Item.Type
+    $separator = "$([char]0x2014)"   # em-dash
 
     # User Story lines drop the type label per the issue spec; epics + features
     # keep it so '📦 Epic 1234' / '🎯 Feature 1240' read clearly.
     if ($Item.Type -eq 'User Story') {
-        return "$indent$icon $($Item.Id) $([char]0x2014) $($Item.Title) [$($Item.State)]"
+        return "$indent$icon $($Item.Id) $separator $($Item.Title) [$($Item.State)]"
     }
-    return "$indent$icon $($Item.Type) $($Item.Id) $([char]0x2014) $($Item.Title) [$($Item.State)]"
+
+    return "$indent$icon $($Item.Type) $($Item.Id) $separator $($Item.Title) [$($Item.State)]"
 }
 
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -771,16 +771,18 @@ function Read-AzDevOpsJsonCache {
         return $null
     }
 
-    return @($raw | ForEach-Object { & $Converter $_ })
+    $items = @($raw | ForEach-Object { & $Converter $_ })
+    return $items
 }
 
 
 function Read-AzDevOpsAssignedCache {
     $paths = Get-AzDevOpsCachePaths
-    return Read-AzDevOpsJsonCache `
+    $items = Read-AzDevOpsJsonCache `
         -Path        $paths.Assigned `
         -Description 'assigned-items' `
         -Converter   { param($r) ConvertFrom-AzDevOpsAssignedItem -Raw $r }
+    return $items
 }
 
 
@@ -884,10 +886,11 @@ function ConvertFrom-AzDevOpsHierarchyItem {
 
 function Read-AzDevOpsHierarchyCache {
     $paths = Get-AzDevOpsCachePaths
-    return Read-AzDevOpsJsonCache `
+    $items = Read-AzDevOpsJsonCache `
         -Path        $paths.Hierarchy `
         -Description 'hierarchy' `
         -Converter   { param($r) ConvertFrom-AzDevOpsHierarchyItem -Raw $r }
+    return $items
 }
 
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -868,19 +868,27 @@ function ConvertFrom-AzDevOpsHierarchyItem {
     param([Parameter(Mandatory)] $Raw)
 
     $f = $Raw.fields
+
     $parent = if ($null -ne $f.'System.Parent' -and "$($f.'System.Parent')" -ne '') {
         [int]$f.'System.Parent'
     } else {
         $null
     }
 
-    return [PSCustomObject]@{
-        Id     = if ($f.'System.Id') { [int]$f.'System.Id' } else { [int]$Raw.id }
+    $id = if ($f.'System.Id') {
+        [int]$f.'System.Id'
+    } else {
+        [int]$Raw.id
+    }
+
+    $item = [PSCustomObject]@{
+        Id     = $id
         Type   = $f.'System.WorkItemType'
         State  = $f.'System.State'
         Title  = $f.'System.Title'
         Parent = $parent
     }
+    return $item
 }
 
 
@@ -938,8 +946,15 @@ function Show-AzDevOpsTree {
 
     $byParent = @{}
     foreach ($item in $items) {
-        $key = if ($null -ne $item.Parent) { $item.Parent } else { 0 }
-        if (-not $byParent.ContainsKey($key)) { $byParent[$key] = @() }
+        $key = if ($null -ne $item.Parent) {
+            $item.Parent
+        } else {
+            0
+        }
+
+        if (-not $byParent.ContainsKey($key)) {
+            $byParent[$key] = @()
+        }
         $byParent[$key] += $item
     }
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -902,6 +902,15 @@ function Read-AzDevOpsHierarchyCache {
 }
 
 
+function Get-AzDevOpsTreeIndent {
+    param([Parameter(Mandatory)] [int] $Depth)
+
+    $indentUnit = '    '   # 4 spaces per tree level
+    $indent     = $indentUnit * $Depth
+    return $indent
+}
+
+
 function Get-AzDevOpsTreeIcon {
     param([Parameter(Mandatory)] [string] $Type)
 
@@ -936,7 +945,7 @@ function Format-AzDevOpsTreeNode {
         [Parameter(Mandatory)] [int] $Depth
     )
 
-    $indent    = '    ' * $Depth
+    $indent    = Get-AzDevOpsTreeIndent -Depth $Depth
     $icon      = Get-AzDevOpsTreeIcon -Type $Item.Type
     $separator = "$([char]0x2014)"   # em-dash
 
@@ -989,7 +998,8 @@ function Show-AzDevOpsTree {
         $features = @($children | Where-Object { $_.Type -eq 'Feature' } | Sort-Object Id)
 
         if ($features.Count -eq 0) {
-            Write-Output '    (no features)'
+            $featuresIndent = Get-AzDevOpsTreeIndent -Depth 1
+            Write-Output "$featuresIndent(no features)"
             continue
         }
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -905,11 +905,27 @@ function Read-AzDevOpsHierarchyCache {
 function Get-AzDevOpsTreeIcon {
     param([Parameter(Mandatory)] [string] $Type)
 
+    $iconEpic    = "$([char]0x1F4E6)"   # package
+    $iconFeature = "$([char]0x1F3AF)"   # bullseye
+    $iconStory   = "$([char]0x1F4DD)"   # memo
+    $iconUnknown = '*'
+
     switch ($Type) {
-        'Epic'       { return "$([char]0x1F4E6)" }   # package
-        'Feature'    { return "$([char]0x1F3AF)" }   # bullseye
-        'User Story' { return "$([char]0x1F4DD)" }   # memo
-        default      { return '*' }
+        'Epic' {
+            return $iconEpic
+        }
+
+        'Feature' {
+            return $iconFeature
+        }
+
+        'User Story' {
+            return $iconStory
+        }
+
+        default {
+            return $iconUnknown
+        }
     }
 }
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -746,23 +746,41 @@ function ConvertFrom-AzDevOpsAssignedItem {
 }
 
 
-function Read-AzDevOpsAssignedCache {
-    $paths = Get-AzDevOpsCachePaths
-    if (-not (Test-Path -LiteralPath $paths.Dir) -or -not (Test-Path -LiteralPath $paths.Assigned)) {
-        Write-Host "No assigned-items cache at $($paths.Assigned)." -ForegroundColor Yellow
+function Read-AzDevOpsJsonCache {
+    # Shared shape for every cache reader: missing-cache hint, ConvertFrom-Json
+    # with try/catch, then map each row through a per-dataset converter. Each
+    # caller supplies its own $Path, a short $Description for the hint line,
+    # and a scriptblock that turns one parsed row into a typed PSCustomObject.
+    param(
+        [Parameter(Mandatory)] [string]      $Path,
+        [Parameter(Mandatory)] [string]      $Description,
+        [Parameter(Mandatory)] [scriptblock] $Converter
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        Write-Host "No $Description cache at $Path." -ForegroundColor Yellow
         Write-Host "  Run: Sync-AzDevOpsCache              # one-shot refresh" -ForegroundColor Yellow
         Write-Host "  Run: Register-AzDevOpsSyncSchedule   # recurring refresh (~5h)" -ForegroundColor Yellow
         return $null
     }
 
     try {
-        $raw = Get-Content -LiteralPath $paths.Assigned -Raw | ConvertFrom-Json
+        $raw = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
     } catch {
-        Write-Host "Could not parse $($paths.Assigned): $_" -ForegroundColor Red
+        Write-Host "Could not parse ${Path}: $_" -ForegroundColor Red
         return $null
     }
 
-    return @($raw | ForEach-Object { ConvertFrom-AzDevOpsAssignedItem -Raw $_ })
+    return @($raw | ForEach-Object { & $Converter $_ })
+}
+
+
+function Read-AzDevOpsAssignedCache {
+    $paths = Get-AzDevOpsCachePaths
+    return Read-AzDevOpsJsonCache `
+        -Path        $paths.Assigned `
+        -Description 'assigned-items' `
+        -Converter   { param($r) ConvertFrom-AzDevOpsAssignedItem -Raw $r }
 }
 
 
@@ -866,21 +884,10 @@ function ConvertFrom-AzDevOpsHierarchyItem {
 
 function Read-AzDevOpsHierarchyCache {
     $paths = Get-AzDevOpsCachePaths
-    if (-not (Test-Path -LiteralPath $paths.Dir) -or -not (Test-Path -LiteralPath $paths.Hierarchy)) {
-        Write-Host "No hierarchy cache at $($paths.Hierarchy)." -ForegroundColor Yellow
-        Write-Host "  Run: Sync-AzDevOpsCache              # one-shot refresh" -ForegroundColor Yellow
-        Write-Host "  Run: Register-AzDevOpsSyncSchedule   # recurring refresh (~5h)" -ForegroundColor Yellow
-        return $null
-    }
-
-    try {
-        $raw = Get-Content -LiteralPath $paths.Hierarchy -Raw | ConvertFrom-Json
-    } catch {
-        Write-Host "Could not parse $($paths.Hierarchy): $_" -ForegroundColor Red
-        return $null
-    }
-
-    return @($raw | ForEach-Object { ConvertFrom-AzDevOpsHierarchyItem -Raw $_ })
+    return Read-AzDevOpsJsonCache `
+        -Path        $paths.Hierarchy `
+        -Description 'hierarchy' `
+        -Converter   { param($r) ConvertFrom-AzDevOpsHierarchyItem -Raw $r }
 }
 
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -445,7 +445,10 @@ function Get-AzDevOpsSyncDatasets {
             Name  = 'hierarchy'
             Label = 'Epic/Feature/Story hierarchy in @Project'
             Path  = $Paths.Hierarchy
-            Wiql  = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItemLinks Where [Source].[System.TeamProject] = @Project AND [Source].[System.WorkItemType] IN ('Epic', 'Feature', 'User Story') AND [Target].[System.WorkItemType] IN ('Epic', 'Feature', 'User Story') AND [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward' Mode (MustContain)"
+            # Flat work-items query (not link-mode): az boards query resolves
+            # System.Parent + the rest of the fields for each item in one shot,
+            # giving Show-AzDevOpsTree everything it needs without re-calling az.
+            Wiql  = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.Parent] From WorkItems Where [System.TeamProject] = @Project AND [System.WorkItemType] IN ('Epic', 'Feature', 'User Story')"
         }
     )
 }
@@ -826,4 +829,134 @@ function Open-AzDevOpsAssigned {
 
     Write-Host "Opening $url" -ForegroundColor Cyan
     Start-Process $url
+}
+
+
+# ---------------------------------------------------------------------------
+# Hierarchy tree view
+#
+# Public function:
+#   Show-AzDevOpsTree   - prints the project's Epic/Feature/User Story tree
+#                          from the cached hierarchy.json (no `az` calls)
+#
+# Reads $HOME/.bashcuts-cache/azure-devops/hierarchy.json (built by
+# Sync-AzDevOpsCache). The hierarchy WIQL selects [System.Parent] so each
+# item carries its parent link directly - no follow-up resolution needed.
+# ---------------------------------------------------------------------------
+
+function ConvertFrom-AzDevOpsHierarchyItem {
+    param([Parameter(Mandatory)] $Raw)
+
+    $f = $Raw.fields
+    $parent = if ($null -ne $f.'System.Parent' -and "$($f.'System.Parent')" -ne '') {
+        [int]$f.'System.Parent'
+    } else {
+        $null
+    }
+
+    return [PSCustomObject]@{
+        Id     = if ($f.'System.Id') { [int]$f.'System.Id' } else { [int]$Raw.id }
+        Type   = $f.'System.WorkItemType'
+        State  = $f.'System.State'
+        Title  = $f.'System.Title'
+        Parent = $parent
+    }
+}
+
+
+function Read-AzDevOpsHierarchyCache {
+    $paths = Get-AzDevOpsCachePaths
+    if (-not (Test-Path -LiteralPath $paths.Dir) -or -not (Test-Path -LiteralPath $paths.Hierarchy)) {
+        Write-Host "No hierarchy cache at $($paths.Hierarchy)." -ForegroundColor Yellow
+        Write-Host "  Run: Sync-AzDevOpsCache              # one-shot refresh" -ForegroundColor Yellow
+        Write-Host "  Run: Register-AzDevOpsSyncSchedule   # recurring refresh (~5h)" -ForegroundColor Yellow
+        return $null
+    }
+
+    try {
+        $raw = Get-Content -LiteralPath $paths.Hierarchy -Raw | ConvertFrom-Json
+    } catch {
+        Write-Host "Could not parse $($paths.Hierarchy): $_" -ForegroundColor Red
+        return $null
+    }
+
+    return @($raw | ForEach-Object { ConvertFrom-AzDevOpsHierarchyItem -Raw $_ })
+}
+
+
+function Get-AzDevOpsTreeIcon {
+    param([Parameter(Mandatory)] [string] $Type)
+
+    switch ($Type) {
+        'Epic'       { return "$([char]0x1F4E6)" }   # package
+        'Feature'    { return "$([char]0x1F3AF)" }   # bullseye
+        'User Story' { return "$([char]0x1F4DD)" }   # memo
+        default      { return '*' }
+    }
+}
+
+
+function Format-AzDevOpsTreeNode {
+    param(
+        [Parameter(Mandatory)] [PSCustomObject] $Item,
+        [Parameter(Mandatory)] [int] $Depth
+    )
+
+    $indent = '    ' * $Depth
+    $icon   = Get-AzDevOpsTreeIcon -Type $Item.Type
+
+    # User Story lines drop the type label per the issue spec; epics + features
+    # keep it so '📦 Epic 1234' / '🎯 Feature 1240' read clearly.
+    if ($Item.Type -eq 'User Story') {
+        return "$indent$icon $($Item.Id) $([char]0x2014) $($Item.Title) [$($Item.State)]"
+    }
+    return "$indent$icon $($Item.Type) $($Item.Id) $([char]0x2014) $($Item.Title) [$($Item.State)]"
+}
+
+
+function Show-AzDevOpsTree {
+    [CmdletBinding()]
+    param()
+
+    $items = Read-AzDevOpsHierarchyCache
+    if ($null -eq $items) { return }
+
+    $cacheAge = Get-AzDevOpsCacheAge
+    if ($cacheAge -and $cacheAge.IsStale) {
+        Write-Host "WARNING stale (last sync: $($cacheAge.AgeText))" -ForegroundColor Yellow
+    }
+
+    $byParent = @{}
+    foreach ($item in $items) {
+        $key = if ($null -ne $item.Parent) { $item.Parent } else { 0 }
+        if (-not $byParent.ContainsKey($key)) { $byParent[$key] = @() }
+        $byParent[$key] += $item
+    }
+
+    $epics = @($items | Where-Object { $_.Type -eq 'Epic' } | Sort-Object Id)
+    if ($epics.Count -eq 0) {
+        Write-Host "(no epics in hierarchy cache)" -ForegroundColor Yellow
+        return
+    }
+
+    foreach ($epic in $epics) {
+        Write-Output (Format-AzDevOpsTreeNode -Item $epic -Depth 0)
+
+        $children = @($byParent[$epic.Id])
+        $features = @($children | Where-Object { $_.Type -eq 'Feature' } | Sort-Object Id)
+
+        if ($features.Count -eq 0) {
+            Write-Output '    (no features)'
+            continue
+        }
+
+        foreach ($feature in $features) {
+            Write-Output (Format-AzDevOpsTreeNode -Item $feature -Depth 1)
+
+            $stories = @($byParent[$feature.Id] | Where-Object { $_.Type -eq 'User Story' } | Sort-Object Id)
+            foreach ($story in $stories) {
+                Write-Output (Format-AzDevOpsTreeNode -Item $story -Depth 2)
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #10 |
| [Changes](#changes) | ✅ 2 files |
| [Shell Parity](#shell-parity) | ✅ PowerShell-only (per issue) |
| [Test Plan](#test-plan) | 0/7 (manual, run on user's box) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/19#issuecomment-4393123863) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/19#issuecomment-4393132733) |
| 🛡️ Security Audit | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/19#issuecomment-4393127385) |
| 🧼 Clean-Code Engineer Review | ❌→✅ HIGH addressed in `0db224c` — [View](https://github.com/jdschleicher/bashcuts/pull/19#issuecomment-4393128709) |
| 📚 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/19#issuecomment-4393144603) |
| ✅ Criteria Check | ✅ PASS (9 verified · 3 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/19#issuecomment-4393149117) |
<!-- toc:end -->

## Summary
Adds `Show-AzDevOpsTree` — a one-shot PowerShell command that prints the project's Epic → Feature → User Story hierarchy as an indented tree, read entirely from the local cache (no `az` round-trips).

```
📦 Epic 1234 — Customer Portal Rewrite [Active]
    🎯 Feature 1240 — Login redesign [Active]
        📝 5012 — Add SSO option [Active]
    🎯 Feature 1241 — Account dashboard [New]
📦 Epic 1300 — Reporting overhaul [New]
    (no features)
```

## Issue
Closes #10

## Changes
- `powcuts_by_cli/azdevops_workitems.ps1`
  - **Hierarchy WIQL fix:** swapped from link-mode (`From WorkItemLinks ... Mode (MustContain)`) to a flat work-items query selecting `[System.Parent]`. The link-mode query returned only `{rel, source, target}` rows with IDs and no fields — the cache was unrenderable. The flat query gives `Show-AzDevOpsTree` titles, types, states, and parent links in one round-trip. (Technically a follow-up to #8.)
  - Added public `Show-AzDevOpsTree`
  - Added `Read-AzDevOpsHierarchyCache` + `ConvertFrom-AzDevOpsHierarchyItem` (mirrors the assigned-cache helpers)
  - Added private `Get-AzDevOpsTreeIcon` + `Format-AzDevOpsTreeNode` formatters
  - **Refactor (commit `0db224c`):** extracted shared `Read-AzDevOpsJsonCache` helper; `Read-AzDevOpsAssignedCache` and `Read-AzDevOpsHierarchyCache` collapse to thin wrappers (addresses clean-code reviewer's HIGH finding on duplicated cache-load scaffolding)
- `README.md` — added `Show-AzDevOpsTree` to the day-to-day section; dropped "tree view" from the "future commands" sentence; staleness note now covers both `Get-AzDevOpsAssigned` and `Show-AzDevOpsTree`.

## Shell Parity
PowerShell-only (per issue label and Affected Areas).

## Test Plan
- [ ] `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/azdevops_workitems.ps1', [ref]\$null, [ref]\$null)"` — zero parse errors
- [ ] In a fresh PowerShell terminal, run `Sync-AzDevOpsCache` — `hierarchy.json` populates with work items carrying `System.Parent`
- [ ] `Show-AzDevOpsTree` — renders the tree with 📦/🎯/📝 icons, ids, titles, and `[State]` per the example above
- [ ] An epic with no features prints `(no features)` at depth 1
- [ ] Backdate `last-sync.json` Timestamp by 8h, re-run — `WARNING stale (last sync: ...)` line appears above the tree
- [ ] Delete `hierarchy.json`, re-run — prints the same "run Sync-AzDevOpsCache" hint as `Get-AzDevOpsAssigned`
- [ ] Tab-tab on `Show-AzDevOps` lists `Show-AzDevOpsTree`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm2aPgLDXxtePLMdq3MJTu)_