### PR TITLE
feat(#11): Get-AzDevOpsMentions and Open-AzDevOpsMention

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For windows machines, the snippets are stored in an expected directory, so we ca
 
 # <a name="azure-devops"></a>Azure DevOps work-item shortcuts
 
-PowerShell shortcuts in `powcuts_by_cli/azdevops_workitems.ps1` provide guided setup and work-item navigation against an Azure DevOps organization. Today this includes a guided `Connect-AzDevOps` first-run helper, a cached background sync (`Sync-AzDevOpsCache` + `Register-AzDevOpsSyncSchedule`), a list/open pair for items assigned to you (`Get-AzDevOpsAssigned`, `Open-AzDevOpsAssigned`), and an Epic→Feature→User Story tree view (`Show-AzDevOpsTree`). Future commands in this batch will add items you've been mentioned in and an interactive new-user-story creator with parent-feature and iteration pickers.
+PowerShell shortcuts in `powcuts_by_cli/azdevops_workitems.ps1` provide guided setup and work-item navigation against an Azure DevOps organization. Today this includes a guided `Connect-AzDevOps` first-run helper, a cached background sync (`Sync-AzDevOpsCache` + `Register-AzDevOpsSyncSchedule`), a list/open pair for items assigned to you (`Get-AzDevOpsAssigned`, `Open-AzDevOpsAssigned`), the matching pair for items where you've been @-mentioned in discussion (`Get-AzDevOpsMentions`, `Open-AzDevOpsMention`), and an Epic→Feature→User Story tree view (`Show-AzDevOpsTree`). A future command in this batch will add an interactive new-user-story creator with parent-feature and iteration pickers.
 
 ### Prerequisites
 
@@ -202,8 +202,16 @@ Get-AzDevOpsAssigned | Format-Table -AutoSize
 
 Open-AzDevOpsAssigned 12345                # open one of your assigned items in the browser
 
+Get-AzDevOpsMentions                                  # work items where you've been @-mentioned (excludes items you're already assigned to)
+Get-AzDevOpsMentions -State Active                    # filter to a single state
+Get-AzDevOpsMentions -Since (Get-Date).AddDays(-7)    # only mentions whose last activity was in the past week
+Get-AzDevOpsMentions -IncludeAssigned                 # also surface mentioned items already assigned to you
+Get-AzDevOpsMentions | Format-Table -AutoSize
+
+Open-AzDevOpsMention 12345                 # open one of your mentioned items in the browser
+
 Show-AzDevOpsTree                          # print the project's Epic -> Feature -> User Story tree
 ```
 
-If the cache is older than 6 hours, `Get-AzDevOpsAssigned` and `Show-AzDevOpsTree` each print a one-line `WARNING stale (last sync: ...)` notice above their output and still render the cached data.
+If the cache is older than 6 hours, `Get-AzDevOpsAssigned`, `Get-AzDevOpsMentions`, and `Show-AzDevOpsTree` each print a one-line `WARNING stale (last sync: ...)` notice above their output and still render the cached data.
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -439,7 +439,7 @@ function Get-AzDevOpsSyncDatasets {
             Name  = 'mentions'
             Label = "System.History Contains '$mentionsToken'"
             Path  = $Paths.Mentions
-            Wiql  = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State] From WorkItems Where [System.History] Contains '$mentionsToken'"
+            Wiql  = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.ChangedBy], [System.ChangedDate] From WorkItems Where [System.History] Contains '$mentionsToken'"
         },
         @{
             Name  = 'hierarchy'
@@ -725,10 +725,12 @@ function Unregister-AzDevOpsSyncSchedule {
 # Public functions:
 #   Get-AzDevOpsAssigned   - table of work items assigned to me
 #   Open-AzDevOpsAssigned  - open a single assigned item in the browser
+#   Get-AzDevOpsMentions   - table of work items where I've been @-mentioned
+#   Open-AzDevOpsMention   - open a single mentioned item in the browser
 #
-# Both functions read $HOME/.bashcuts-cache/azure-devops/assigned.json (built
-# by Sync-AzDevOpsCache). They never call `az` directly - if the cache is
-# missing, they print a hint and bail.
+# All four read $HOME/.bashcuts-cache/azure-devops/{assigned,mentions}.json
+# (built by Sync-AzDevOpsCache). They never call `az` directly - if the cache
+# is missing, they print a hint and bail.
 # ---------------------------------------------------------------------------
 
 function ConvertFrom-AzDevOpsAssignedItem {
@@ -845,6 +847,166 @@ function Open-AzDevOpsAssigned {
 
     $org        = $env:AZ_DEVOPS_ORG.TrimEnd('/')
     $projectEnc = [uri]::EscapeDataString($env:AZ_PROJECT)
+    $url        = "$org/$projectEnc/_workitems/edit/$Id"
+
+    Write-Host "Opening $url" -ForegroundColor Cyan
+    Start-Process $url
+}
+
+
+function Get-AzDevOpsMentionedByDisplayName {
+    # System.ChangedBy lands as either a complex identity object (displayName /
+    # uniqueName), a "Name <email>" string, or $null depending on the az CLI
+    # version + how it serialized the WIQL row. Normalize all three to a single
+    # string the table column can render.
+    param($ChangedBy)
+
+    if ($null -eq $ChangedBy) {
+        return $null
+    }
+
+    if ($ChangedBy -is [string]) {
+        return $ChangedBy
+    }
+
+    if ($ChangedBy.displayName) {
+        return $ChangedBy.displayName
+    }
+
+    if ($ChangedBy.uniqueName) {
+        return $ChangedBy.uniqueName
+    }
+
+    return "$ChangedBy"
+}
+
+
+function ConvertFrom-AzDevOpsMentionItem {
+    param([Parameter(Mandatory)] $Raw)
+
+    $f = $Raw.fields
+
+    $id = if ($f.'System.Id') {
+        [int]$f.'System.Id'
+    } else {
+        [int]$Raw.id
+    }
+
+    $mentionedAt = if ($f.'System.ChangedDate') {
+        [datetime]$f.'System.ChangedDate'
+    } else {
+        $null
+    }
+
+    $mentionedBy = Get-AzDevOpsMentionedByDisplayName -ChangedBy $f.'System.ChangedBy'
+
+    return [PSCustomObject]@{
+        Id          = $id
+        Type        = $f.'System.WorkItemType'
+        State       = $f.'System.State'
+        Title       = $f.'System.Title'
+        MentionedBy = $mentionedBy
+        MentionedAt = $mentionedAt
+    }
+}
+
+
+function Read-AzDevOpsMentionsCache {
+    $paths = Get-AzDevOpsCachePaths
+    $items = Read-AzDevOpsJsonCache `
+        -Path        $paths.Mentions `
+        -Description 'mentions' `
+        -Converter   { param($r) ConvertFrom-AzDevOpsMentionItem -Raw $r }
+    return $items
+}
+
+
+function Get-AzDevOpsMentions {
+    [CmdletBinding()]
+    param(
+        [string[]] $State,
+        [datetime] $Since,
+        [switch]   $IncludeAssigned
+    )
+
+    $items = Read-AzDevOpsMentionsCache
+    if ($null -eq $items) { return }
+
+    $cacheAge = Get-AzDevOpsCacheAge
+    if ($cacheAge -and $cacheAge.IsStale) {
+        Write-Host "WARNING stale (last sync: $($cacheAge.AgeText))" -ForegroundColor Yellow
+    }
+
+    if (-not $IncludeAssigned) {
+        $assigned   = Read-AzDevOpsAssignedCache
+        $assignedIds = if ($assigned) {
+            @($assigned | ForEach-Object { $_.Id })
+        } else {
+            @()
+        }
+
+        if ($assignedIds.Count -gt 0) {
+            $items = $items | Where-Object { $_.Id -notin $assignedIds }
+        }
+    }
+
+    $filtered = if ($State) {
+        $items | Where-Object { $_.State -in $State }
+    } else {
+        $items | Where-Object { $_.State -notin @('Closed', 'Removed') }
+    }
+
+    if ($Since) {
+        $filtered = $filtered | Where-Object {
+            $_.MentionedAt -and $_.MentionedAt -ge $Since
+        }
+    }
+
+    $titleMaxLen = 80
+
+    $rows = $filtered | Select-Object Id, Type, State,
+        @{ Name = 'Title'; Expression = {
+            if ($_.Title -and $_.Title.Length -gt $titleMaxLen) {
+                $_.Title.Substring(0, $titleMaxLen - 3) + '...'
+            } else {
+                $_.Title
+            }
+        } },
+        MentionedBy, MentionedAt
+
+    return $rows
+}
+
+
+function Open-AzDevOpsMention {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)] [int] $Id
+    )
+
+    $items = Read-AzDevOpsMentionsCache
+    if ($null -eq $items) { return }
+
+    $match = $items | Where-Object { $_.Id -eq $Id } | Select-Object -First 1
+    if (-not $match) {
+        Write-Host "Work item $Id is not in your mentions cache." -ForegroundColor Red
+        Write-Host "  Tip: run Get-AzDevOpsMentions to list valid IDs, or Sync-AzDevOpsCache to refresh." -ForegroundColor Yellow
+        Write-Host "  Or open it directly: $($env:AZ_DEVOPS_ORG)/$($env:AZ_PROJECT)/_workitems/edit/$Id" -ForegroundColor Yellow
+        $global:LASTEXITCODE = 1
+        return
+    }
+
+    if (-not $env:AZ_DEVOPS_ORG -or -not $env:AZ_PROJECT) {
+        Write-Host "AZ_DEVOPS_ORG and AZ_PROJECT must both be set in your `$profile." -ForegroundColor Red
+        $global:LASTEXITCODE = 1
+        return
+    }
+
+    $org        = $env:AZ_DEVOPS_ORG.TrimEnd('/')
+    $projectEnc = [uri]::EscapeDataString($env:AZ_PROJECT)
+    # Anchor #discussion would be ideal, but Azure DevOps' web UI uses an
+    # ephemeral comment id (e.g. #comment-12345) that's not stable across
+    # syncs. Open the plain edit URL; the discussion tab is one click away.
     $url        = "$org/$projectEnc/_workitems/edit/$Id"
 
     Write-Host "Opening $url" -ForegroundColor Cyan

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -778,6 +778,131 @@ function Read-AzDevOpsJsonCache {
 }
 
 
+# ---------------------------------------------------------------------------
+# Shared scaffolding for the Get-/Open-AzDevOps{Assigned,Mentions} pairs
+#
+# These private helpers exist because the same blocks were duplicated across
+# the parallel pairs (CLAUDE.md "extract repeated branches" rule):
+#   - stale-cache banner          - Write-AzDevOpsStaleBanner
+#   - default open-ish state filter + explicit -State filter
+#                                  - Select-AzDevOpsActiveItems
+#   - Title truncation projection - Format-AzDevOpsTruncatedTitle
+#   - id lookup w/ standard miss-hint + LASTEXITCODE=1
+#                                  - Find-AzDevOpsCachedWorkItem
+#   - env-var guard + URL build + Start-Process
+#                                  - Open-AzDevOpsWorkItemUrl
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsClosedStates {
+    return @('Closed', 'Removed')
+}
+
+
+function Write-AzDevOpsStaleBanner {
+    $cacheAge = Get-AzDevOpsCacheAge
+    if ($cacheAge -and $cacheAge.IsStale) {
+        Write-Host "WARNING stale (last sync: $($cacheAge.AgeText))" -ForegroundColor Yellow
+    }
+}
+
+
+function Select-AzDevOpsActiveItems {
+    param(
+        [Parameter(Mandatory)] $Items,
+        [string[]] $State
+    )
+
+    $closedStates = Get-AzDevOpsClosedStates
+
+    $filtered = if ($State) {
+        $Items | Where-Object { $_.State -in $State }
+    } else {
+        $Items | Where-Object { $_.State -notin $closedStates }
+    }
+
+    return $filtered
+}
+
+
+function Format-AzDevOpsTruncatedTitle {
+    param([string] $Title)
+
+    $titleMaxLen = 80
+    $ellipsis    = '...'
+
+    if ($Title -and $Title.Length -gt $titleMaxLen) {
+        $truncated = $Title.Substring(0, $titleMaxLen - $ellipsis.Length) + $ellipsis
+        return $truncated
+    }
+
+    return $Title
+}
+
+
+function Get-AzDevOpsTitleColumn {
+    # Returns a Select-Object calculated-property hashtable that renders the
+    # Title column with the standard 80-char ellipsis truncation. Used by
+    # Get-AzDevOpsAssigned and Get-AzDevOpsMentions so the projection lives
+    # in one place.
+    return @{
+        Name       = 'Title'
+        Expression = { Format-AzDevOpsTruncatedTitle -Title $_.Title }
+    }
+}
+
+
+function Find-AzDevOpsCachedWorkItem {
+    # Looks up $Id in $Items. On hit, returns the matched row. On miss,
+    # prints the standard "not in your <description> cache" hint, optionally
+    # echoes a directly-pasteable URL fallback, sets $LASTEXITCODE = 1, and
+    # returns $null. Callers check for $null and return.
+    param(
+        [Parameter(Mandatory)] $Items,
+        [Parameter(Mandatory)] [int]    $Id,
+        [Parameter(Mandatory)] [string] $Description,
+        [Parameter(Mandatory)] [string] $ListCommand,
+        [switch] $IncludeUrlFallback
+    )
+
+    $match = $Items | Where-Object { $_.Id -eq $Id } | Select-Object -First 1
+    if ($match) {
+        return $match
+    }
+
+    Write-Host "Work item $Id is not in your $Description cache." -ForegroundColor Red
+    Write-Host "  Tip: run $ListCommand to list valid IDs, or Sync-AzDevOpsCache to refresh." -ForegroundColor Yellow
+
+    if ($IncludeUrlFallback -and $env:AZ_DEVOPS_ORG -and $env:AZ_PROJECT) {
+        $org        = $env:AZ_DEVOPS_ORG.TrimEnd('/')
+        $projectEnc = [uri]::EscapeDataString($env:AZ_PROJECT)
+        Write-Host "  Or open it directly: $org/$projectEnc/_workitems/edit/$Id" -ForegroundColor Yellow
+    }
+
+    $global:LASTEXITCODE = 1
+    return $null
+}
+
+
+function Open-AzDevOpsWorkItemUrl {
+    # env-var guard + URL build + Start-Process. Sets $LASTEXITCODE = 1 and
+    # returns when env-vars are missing; otherwise launches the OS browser.
+    param([Parameter(Mandatory)] [int] $Id)
+
+    if (-not $env:AZ_DEVOPS_ORG -or -not $env:AZ_PROJECT) {
+        Write-Host "AZ_DEVOPS_ORG and AZ_PROJECT must both be set in your `$profile." -ForegroundColor Red
+        $global:LASTEXITCODE = 1
+        return
+    }
+
+    $org        = $env:AZ_DEVOPS_ORG.TrimEnd('/')
+    $projectEnc = [uri]::EscapeDataString($env:AZ_PROJECT)
+    $url        = "$org/$projectEnc/_workitems/edit/$Id"
+
+    Write-Host "Opening $url" -ForegroundColor Cyan
+    Start-Process $url
+}
+
+
 function Read-AzDevOpsAssignedCache {
     $paths = Get-AzDevOpsCachePaths
     $items = Read-AzDevOpsJsonCache `
@@ -797,28 +922,12 @@ function Get-AzDevOpsAssigned {
     $items = Read-AzDevOpsAssignedCache
     if ($null -eq $items) { return }
 
-    $cacheAge = Get-AzDevOpsCacheAge
-    if ($cacheAge -and $cacheAge.IsStale) {
-        Write-Host "WARNING stale (last sync: $($cacheAge.AgeText))" -ForegroundColor Yellow
-    }
+    Write-AzDevOpsStaleBanner
 
-    $filtered = if ($State) {
-        $items | Where-Object { $_.State -in $State }
-    } else {
-        $items | Where-Object { $_.State -notin @('Closed', 'Removed') }
-    }
+    $filtered = Select-AzDevOpsActiveItems -Items $items -State $State
 
-    $titleMaxLen = 80
-
-    return $filtered | Select-Object Id, Type, State,
-        @{ Name = 'Title'; Expression = {
-            if ($_.Title -and $_.Title.Length -gt $titleMaxLen) {
-                $_.Title.Substring(0, $titleMaxLen - 3) + '...'
-            } else {
-                $_.Title
-            }
-        } },
-        Iteration, AssignedAt
+    $rows = $filtered | Select-Object Id, Type, State, (Get-AzDevOpsTitleColumn), Iteration, AssignedAt
+    return $rows
 }
 
 
@@ -831,26 +940,15 @@ function Open-AzDevOpsAssigned {
     $items = Read-AzDevOpsAssignedCache
     if ($null -eq $items) { return }
 
-    $match = $items | Where-Object { $_.Id -eq $Id } | Select-Object -First 1
-    if (-not $match) {
-        Write-Host "Work item $Id is not in your assigned-items cache." -ForegroundColor Red
-        Write-Host "  Tip: run Get-AzDevOpsAssigned to list valid IDs, or Sync-AzDevOpsCache to refresh." -ForegroundColor Yellow
-        $global:LASTEXITCODE = 1
-        return
-    }
+    $match = Find-AzDevOpsCachedWorkItem `
+        -Items       $items `
+        -Id          $Id `
+        -Description 'assigned-items' `
+        -ListCommand 'Get-AzDevOpsAssigned' `
+        -IncludeUrlFallback
+    if (-not $match) { return }
 
-    if (-not $env:AZ_DEVOPS_ORG -or -not $env:AZ_PROJECT) {
-        Write-Host "AZ_DEVOPS_ORG and AZ_PROJECT must both be set in your `$profile." -ForegroundColor Red
-        $global:LASTEXITCODE = 1
-        return
-    }
-
-    $org        = $env:AZ_DEVOPS_ORG.TrimEnd('/')
-    $projectEnc = [uri]::EscapeDataString($env:AZ_PROJECT)
-    $url        = "$org/$projectEnc/_workitems/edit/$Id"
-
-    Write-Host "Opening $url" -ForegroundColor Cyan
-    Start-Process $url
+    Open-AzDevOpsWorkItemUrl -Id $Id
 }
 
 
@@ -932,13 +1030,11 @@ function Get-AzDevOpsMentions {
     $items = Read-AzDevOpsMentionsCache
     if ($null -eq $items) { return }
 
-    $cacheAge = Get-AzDevOpsCacheAge
-    if ($cacheAge -and $cacheAge.IsStale) {
-        Write-Host "WARNING stale (last sync: $($cacheAge.AgeText))" -ForegroundColor Yellow
-    }
+    Write-AzDevOpsStaleBanner
 
     if (-not $IncludeAssigned) {
-        $assigned   = Read-AzDevOpsAssignedCache
+        $assigned = Read-AzDevOpsAssignedCache
+
         $assignedIds = if ($assigned) {
             @($assigned | ForEach-Object { $_.Id })
         } else {
@@ -950,11 +1046,7 @@ function Get-AzDevOpsMentions {
         }
     }
 
-    $filtered = if ($State) {
-        $items | Where-Object { $_.State -in $State }
-    } else {
-        $items | Where-Object { $_.State -notin @('Closed', 'Removed') }
-    }
+    $filtered = Select-AzDevOpsActiveItems -Items $items -State $State
 
     if ($Since) {
         $filtered = $filtered | Where-Object {
@@ -962,23 +1054,16 @@ function Get-AzDevOpsMentions {
         }
     }
 
-    $titleMaxLen = 80
-
-    $rows = $filtered | Select-Object Id, Type, State,
-        @{ Name = 'Title'; Expression = {
-            if ($_.Title -and $_.Title.Length -gt $titleMaxLen) {
-                $_.Title.Substring(0, $titleMaxLen - 3) + '...'
-            } else {
-                $_.Title
-            }
-        } },
-        MentionedBy, MentionedAt
-
+    $rows = $filtered | Select-Object Id, Type, State, (Get-AzDevOpsTitleColumn), MentionedBy, MentionedAt
     return $rows
 }
 
 
 function Open-AzDevOpsMention {
+    # Plain /_workitems/edit/<id> URL only - Azure DevOps' #comment-NNNN
+    # anchor is an ephemeral comment id that isn't stable across syncs, so
+    # there's no reliable way to deep-link into the discussion thread; the
+    # discussion tab is one click away once the work item is open.
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, Position = 0)] [int] $Id
@@ -987,30 +1072,15 @@ function Open-AzDevOpsMention {
     $items = Read-AzDevOpsMentionsCache
     if ($null -eq $items) { return }
 
-    $match = $items | Where-Object { $_.Id -eq $Id } | Select-Object -First 1
-    if (-not $match) {
-        Write-Host "Work item $Id is not in your mentions cache." -ForegroundColor Red
-        Write-Host "  Tip: run Get-AzDevOpsMentions to list valid IDs, or Sync-AzDevOpsCache to refresh." -ForegroundColor Yellow
-        Write-Host "  Or open it directly: $($env:AZ_DEVOPS_ORG)/$($env:AZ_PROJECT)/_workitems/edit/$Id" -ForegroundColor Yellow
-        $global:LASTEXITCODE = 1
-        return
-    }
+    $match = Find-AzDevOpsCachedWorkItem `
+        -Items       $items `
+        -Id          $Id `
+        -Description 'mentions' `
+        -ListCommand 'Get-AzDevOpsMentions' `
+        -IncludeUrlFallback
+    if (-not $match) { return }
 
-    if (-not $env:AZ_DEVOPS_ORG -or -not $env:AZ_PROJECT) {
-        Write-Host "AZ_DEVOPS_ORG and AZ_PROJECT must both be set in your `$profile." -ForegroundColor Red
-        $global:LASTEXITCODE = 1
-        return
-    }
-
-    $org        = $env:AZ_DEVOPS_ORG.TrimEnd('/')
-    $projectEnc = [uri]::EscapeDataString($env:AZ_PROJECT)
-    # Anchor #discussion would be ideal, but Azure DevOps' web UI uses an
-    # ephemeral comment id (e.g. #comment-12345) that's not stable across
-    # syncs. Open the plain edit URL; the discussion tab is one click away.
-    $url        = "$org/$projectEnc/_workitems/edit/$Id"
-
-    Write-Host "Opening $url" -ForegroundColor Cyan
-    Start-Process $url
+    Open-AzDevOpsWorkItemUrl -Id $Id
 }
 
 
@@ -1128,10 +1198,7 @@ function Show-AzDevOpsTree {
     $items = Read-AzDevOpsHierarchyCache
     if ($null -eq $items) { return }
 
-    $cacheAge = Get-AzDevOpsCacheAge
-    if ($cacheAge -and $cacheAge.IsStale) {
-        Write-Host "WARNING stale (last sync: $($cacheAge.AgeText))" -ForegroundColor Yellow
-    }
+    Write-AzDevOpsStaleBanner
 
     $byParent = @{}
     foreach ($item in $items) {


### PR DESCRIPTION
<!-- toc:start -->
## Navigation

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #11 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | 🔍 11 manual items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/20#issuecomment-4393500062) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/20#issuecomment-4393508422) |
| 🛡️ Security Audit | ✅ PASS (1 LOW info) — [View](https://github.com/jdschleicher/bashcuts/pull/20#issuecomment-4393521228) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE on re-review — [View](https://github.com/jdschleicher/bashcuts/pull/20#issuecomment-4393591946) (initial REQUEST CHANGES at [4393522913](https://github.com/jdschleicher/bashcuts/pull/20#issuecomment-4393522913) resolved by commit `3e24240`) |
| ✅ Criteria Check | ✅ PASS (15/15 verified, 4 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/20#issuecomment-4393613879) |
| 📚 Docs Check | ✅ CURRENT — inline report (not posted) |
<!-- toc:end -->

## Summary
Adds the list/open command pair for Azure DevOps work items where I've been @-mentioned in discussion, mirroring the shipped `Get-AzDevOpsAssigned` / `Open-AzDevOpsAssigned` pair against `mentions.json`.

## Issue
Closes #11

## Changes
- `powcuts_by_cli/azdevops_workitems.ps1`
  - Extended the mentions WIQL in `Get-AzDevOpsSyncDatasets` to also pull `[System.ChangedBy]` and `[System.ChangedDate]`, so the new `MentionedBy` / `MentionedAt` columns can populate from cache.
  - New `Get-AzDevOpsMentionedByDisplayName` (private helper) — normalizes `System.ChangedBy` whether `az` returns a complex identity object, a `"Name <email>"` string, or `$null`.
  - New `ConvertFrom-AzDevOpsMentionItem` and `Read-AzDevOpsMentionsCache` (private) — both reuse the existing `Read-AzDevOpsJsonCache` shared cache helper.
  - New `Get-AzDevOpsMentions` — `-State`, `-Since`, `-IncludeAssigned`; defaults to open-ish states and excludes items already assigned (those surface in `Get-AzDevOpsAssigned`); reuses the 6h staleness banner.
  - New `Open-AzDevOpsMention <id>` — looks the id up in mentions cache, opens `$AZ_DEVOPS_ORG/$AZ_PROJECT/_workitems/edit/<id>` via `Start-Process`. Sets `$LASTEXITCODE = 1` with a hint when the id isn't cached. Plain edit URL only — Azure DevOps' `#comment-N` anchor isn't stable across syncs (commented inline).
  - **Refactor (commit `3e24240`, resolves clean-code review):** extracted six private helpers (`Write-AzDevOpsStaleBanner`, `Select-AzDevOpsActiveItems`, `Format-AzDevOpsTruncatedTitle`, `Get-AzDevOpsTitleColumn`, `Find-AzDevOpsCachedWorkItem`, `Open-AzDevOpsWorkItemUrl`, plus `Get-AzDevOpsClosedStates`) so the four `Get-/Open-AzDevOps{Assigned,Mention}` public functions become thin orchestrators. Behavior parity tweak: `Open-AzDevOpsAssigned` now also prints the "Or open it directly: <url>" hint on cache miss, matching `Open-AzDevOpsMention`.
- `README.md` — refreshed the AzDevOps section intro and added a `Get-/Open-AzDevOpsMention` block to the day-to-day shortcut list, plus the staleness-banner reference.

## Test Plan
- [ ] `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/azdevops_workitems.ps1', [ref]$null, [ref]$null) | Out-Null; 'OK'"` returns `OK`
- [ ] In a fresh PowerShell terminal after `Sync-AzDevOpsCache`:
  - [ ] `Get-AzDevOps<TAB><TAB>` lists `Get-AzDevOpsAssigned` and `Get-AzDevOpsMentions`
  - [ ] `Open-AzDevOps<TAB><TAB>` lists `Open-AzDevOpsAssigned` and `Open-AzDevOpsMention`
  - [ ] `Get-AzDevOpsMentions | Format-Table -AutoSize` returns rows with the expected columns
  - [ ] `Get-AzDevOpsMentions -State Active` filters to that state
  - [ ] `Get-AzDevOpsMentions -Since (Get-Date).AddDays(-7)` filters by last activity
  - [ ] `Get-AzDevOpsMentions -IncludeAssigned` re-includes items already assigned to me
  - [ ] `Open-AzDevOpsMention <real-id>` launches the browser to the edit URL
  - [ ] `Open-AzDevOpsMention 9999999` prints the red "not in cache" hint and sets `$LASTEXITCODE = 1`
- [ ] Verified on Windows
- [ ] Verified on macOS (PowerShell Core)


---
_Generated by [Claude Code](https://claude.ai/code/session_019hUD1q7Dpo9T18XjPxYBXN)_