### PR TITLE
Add o-pow-azdevops opener to pow_open.ps1

### DIFF
--- a/powcuts_by_cli/pow_open.ps1
+++ b/powcuts_by_cli/pow_open.ps1
@@ -37,6 +37,10 @@ function o-pow-git {
 	Start-Process "$path_to_bashcuts\powcuts_by_cli\git_common.ps1"
 }
 
+function o-pow-azdevops {
+	Start-Process "$path_to_bashcuts\powcuts_by_cli\azdevops_workitems.ps1"
+}
+
 
 function o-pow-jir {
 	Start-Process "$path_to_bashcuts\powcuts_by_cli\jira_automations.ps1"


### PR DESCRIPTION
Closes #29. Brings azdevops_workitems.ps1 inline with every other
PowerShell shortcut file by giving it a tab-discoverable o-pow-* opener.

https://claude.ai/code/session_01RswMCmmsjpXooeaX3nhGZi