### PR TITLE
docs(#28 follow-up): reflect grid presentation helpers in azure-devops-diagrams

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -223,6 +223,7 @@ sequenceDiagram
     participant Banner as Write-AzDevOpsStaleBanner
     participant Filter as Select-AzDevOpsActiveItems
     participant Title as Format-AzDevOpsTruncatedTitle
+    participant Show as Show-AzDevOpsRows
     participant Cache as assigned.json
 
     User->>GetA: az-Get-AzDevOpsAssigned -State Active
@@ -240,7 +241,8 @@ sequenceDiagram
     Filter-->>GetA: filtered[]
     GetA->>Title: title-column projection
     Title-->>GetA: rows
-    GetA-->>User: table rows
+    GetA->>Show: -PassThru (Out-GridView on Windows<br/>or Format-Table fallback)
+    Show-->>User: selected rows / rendered table
 ```
 
 Open-by-id flow re-uses the same cache + a different last-mile helper:
@@ -268,7 +270,10 @@ flowchart TD
     Read --> Banner[Write-AzDevOpsStaleBanner]
     Banner --> Index["build $byParent hashtable<br/>key = ParentId or 0"]
     Index --> Epics["filter Type='Epic', sort by Id"]
-    Epics --> ForEpic{foreach epic}
+    Epics --> Grid{Test-AzDevOpsGridAvailable?}
+    Grid -- yes --> RowsFn["Get-AzDevOpsTreeRows<br/>(Type/Id/Title/State/Depth/Path)"]
+    RowsFn --> Show["Show-AzDevOpsRows<br/>→ Out-GridView"]
+    Grid -- no --> ForEpic{foreach epic}
     ForEpic --> NodeE["Format-AzDevOpsTreeNode -Depth 0<br/>uses Get-AzDevOpsTreeIcon (Epic icon)<br/>+ Get-AzDevOpsTreeIndent"]
     NodeE --> Features["children where Type='Feature'"]
     Features --> NoFeat{any?}
@@ -319,13 +324,13 @@ flowchart TD
     AC -- no --> ReadAC[Read-AzDevOpsAcceptanceCriteria]
     AC -- yes --> Feat{FeatureId >=0?}
     ReadAC --> Feat
-    Feat -- no --> PickFeat["Read-AzDevOpsFeaturePick<br/>(active Features from hierarchy.json)"]
+    Feat -- no --> PickFeat["Read-AzDevOpsFeaturePick<br/>(active Features from hierarchy.json)<br/>Windows: → Read-AzDevOpsGridPick (Out-GridView)<br/>else: numbered menu"]
     Feat -- yes --> Iter{Iteration param?}
     PickFeat --> Iter
-    Iter -- no --> PickIter["Read-AzDevOpsKindPick -Kind 'Iteration'<br/>cache or Invoke-AzDevOpsClassificationLive"]
+    Iter -- no --> PickIter["Read-AzDevOpsKindPick -Kind 'Iteration'<br/>cache or Invoke-AzDevOpsClassificationLive<br/>Windows: → Read-AzDevOpsGridPick"]
     Iter -- yes --> Area{Area param?}
     PickIter --> Area
-    Area -- no --> PickArea["Read-AzDevOpsKindPick -Kind 'Area'"]
+    Area -- no --> PickArea["Read-AzDevOpsKindPick -Kind 'Area'<br/>Windows: → Read-AzDevOpsGridPick"]
     Area -- yes --> Create
     PickArea --> Create
 
@@ -471,6 +476,13 @@ graph LR
     Indent[Get-AzDevOpsTreeIndent]:::priv
     Icon[Get-AzDevOpsTreeIcon]:::priv
     NodeFmt[Format-AzDevOpsTreeNode]:::priv
+    TreeRows[Get-AzDevOpsTreeRows]:::priv
+
+    %% Grid presentation helpers
+    GridAvail[Test-AzDevOpsGridAvailable]:::priv
+    ShowRows[Show-AzDevOpsRows]:::priv
+    GridPick[Read-AzDevOpsGridPick]:::priv
+    StatusRows[Get-AzDevOpsCacheStatusRows]:::priv
 
     %% NewStory helpers
     ReadCls[Read-AzDevOpsClassificationCache]:::priv
@@ -522,6 +534,7 @@ graph LR
     DSets --> Measure
 
     Status --> Age --> Paths
+    Status --> StatusRows --> ShowRows
     Reg --> Plat
     Reg --> TaskName
     Reg --> Interval
@@ -542,6 +555,7 @@ graph LR
     GetA --> Stale --> Age
     GetA --> SelAct --> Closed
     GetA --> TitleCol --> Trunc
+    GetA --> ShowRows
     OpenA --> ReadA
     OpenA --> Find
     OpenA --> OpenUrl --> Az
@@ -551,6 +565,7 @@ graph LR
     GetM --> Stale
     GetM --> SelAct
     GetM --> TitleCol
+    GetM --> ShowRows
     OpenM --> ReadM
     OpenM --> Find
     OpenM --> OpenUrl
@@ -559,6 +574,9 @@ graph LR
     Tree --> Stale
     Tree --> NodeFmt --> Indent
     NodeFmt --> Icon
+    Tree --> TreeRows --> ShowRows
+    ShowRows --> GridAvail
+    GridPick --> GridAvail
 
     NewS --> TestAuth
     NewS --> ReadH
@@ -571,6 +589,8 @@ graph LR
     ReadCls --> Paths
     PKind --> GetCPaths --> ToCPaths --> ToWIPath
     PFeat --> PCls
+    PFeat --> GridPick
+    PCls --> GridPick
     NewS --> InvCreate --> NewWI --> AzJson
     NewS --> InvLink --> AddRel --> AzJson
 ```


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Follow-up to #28 (PR #30) |
| [Changes](#changes) | ✅ 1 file (+25/-5) |
| [Out of scope](#out-of-scope) | ✅ |
| [Test Plan](#test-plan) | 0/2 manual items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/33#issuecomment-4409030501) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/33#issuecomment-4409030432) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/33#issuecomment-4409031893) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/33#issuecomment-4409033591) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/33#issuecomment-4409038543) |
| 📚 Docs Check | ✅ CURRENT (run inline; 9 bash + 9 PS files all wired) |
| 🗺️ AzDO Diagrams Check | ⏭️ N/A — this PR *is* the diagram update; no AzDO source files in diff |
<!-- toc:end -->

## Summary
Follow-up to PR #30 — adds the 5 new grid presentation helpers introduced by issue #28 to `docs/azure-devops-diagrams.md`. PR #30 was merged before `/azdevops-diagrams-check` ran in the `/pr-flow` pipeline, so the diagram update landed on the branch but missed the merge window.

## Issue
Follow-up to #28 (PR #30 already shipped the feature commit).

## Changes
`docs/azure-devops-diagrams.md` — 4 targeted edits, +25/-5 lines:

1. **Diagram 9 (function dependency map)** — added 5 new helpers (`Test-AzDevOpsGridAvailable`, `Show-AzDevOpsRows`, `Read-AzDevOpsGridPick`, `Get-AzDevOpsCacheStatusRows`, `Get-AzDevOpsTreeRows`) under a new "Grid presentation helpers" cluster + edges from `Status` / `GetA` / `GetM` / `Tree` / `PFeat` / `PCls`.
2. **Diagram 5 (cache consumers sequence)** — added `Show-AzDevOpsRows` participant + render step (Out-GridView on Windows, Format-Table fallback).
3. **Diagram 6 (tree)** — added `Test-AzDevOpsGridAvailable` decision fork; grid path → `Get-AzDevOpsTreeRows` → `Show-AzDevOpsRows`; fallback → existing indented loop.
4. **Diagram 7 (new user story)** — annotated picker labels (`Read-AzDevOpsFeaturePick` / `Read-AzDevOpsKindPick`) to mention `Read-AzDevOpsGridPick` on Windows + numbered-menu fallback.

## Out of scope
21 pre-existing schema-management helpers (`Get-AzDevOpsSchema*` family, `Read-AzDevOpsSchemaFile`, `Resolve-AzDevOpsEditor`, `Assert-AzDevOpsAuthOrAbort`, etc.) are also missing from the diagrams from earlier PRs. Those are intentionally left for a separate cleanup pass — this PR's scope is strictly the 5 helpers added by #28.

## Test Plan
- [ ] Render `docs/azure-devops-diagrams.md` (GitHub mermaid renderer or a local mermaid CLI) and confirm:
  - Diagram 9 shows all 5 new helper nodes wired into the right public functions
  - Diagram 5 sequence shows the new `Show-AzDevOpsRows` participant + step
  - Diagram 6 shows the grid-vs-fallback fork after `Banner`
  - Diagram 7 picker labels mention `Read-AzDevOpsGridPick` (Windows) / numbered-menu fallback
- [ ] No mermaid syntax errors in any of the 9 diagrams
