### PR TITLE
fix(#31): scope az calls via env vars + use IN GROUP for hierarchy WIQL

### DIFF
--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -21,11 +21,27 @@ function Invoke-AzDevOpsAzJson {
     # Generic wrapper around `az ... --output json` that captures stdout JSON
     # and stderr text separately. The canonical JSON+error path used by every
     # other data-plane wrapper in this file.
+    #
+    # When $env:AZ_DEVOPS_ORG / $env:AZ_PROJECT are set and the caller has not
+    # already supplied --organization / --project, we inject them so every
+    # wrapper auto-scopes to the bashcuts env-var contract instead of relying
+    # on `az devops configure --defaults`. Explicit caller flags always win
+    # (e.g. New-AzDevOpsWorkItem passes its own --project).
     param([Parameter(Mandatory)] [string[]] $ArgList)
+
+    $scopedArgs = @($ArgList)
+
+    if ($env:AZ_DEVOPS_ORG -and ($scopedArgs -notcontains '--organization')) {
+        $scopedArgs += @('--organization', $env:AZ_DEVOPS_ORG)
+    }
+
+    if ($env:AZ_PROJECT -and ($scopedArgs -notcontains '--project')) {
+        $scopedArgs += @('--project', $env:AZ_PROJECT)
+    }
 
     $stderrFile = [System.IO.Path]::GetTempFileName()
     try {
-        $json = & az @ArgList --output json 2>$stderrFile
+        $json = & az @scopedArgs --output json 2>$stderrFile
         $exit = $LASTEXITCODE
         $stderr = if (Test-Path -LiteralPath $stderrFile) {
             (Get-Content -LiteralPath $stderrFile -Raw)

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -429,7 +429,13 @@ function Get-AzDevOpsSyncDatasets {
     # Flat work-items query (not link-mode): az boards query resolves
     # System.Parent + the rest of the fields for each item in one shot,
     # giving az-Show-AzDevOpsTree everything it needs without re-calling az.
-    $hierarchyWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.Parent] From WorkItems Where [System.TeamProject] = @Project AND [System.WorkItemType] IN ('Epic', 'Feature', 'User Story')"
+    # IN GROUP queries by work-item-type *category* so this works on every
+    # process template - 'User Story' only exists in Agile; Scrum uses
+    # 'Product Backlog Item', CMMI uses 'Requirement', Basic uses 'Issue'.
+    # Project scope is supplied by --project on the az invocation
+    # (Invoke-AzDevOpsAzJson injects it from $env:AZ_PROJECT), so the WIQL
+    # itself no longer needs a [System.TeamProject] = @Project clause.
+    $hierarchyWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.Parent] From WorkItems Where [System.WorkItemType] IN GROUP 'Microsoft.EpicCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.FeatureCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory'"
 
     $rowCounter  = { param($parsed) @($parsed).Count }
     $treeCounter = { param($parsed) Measure-AzDevOpsClassificationNodes -Node $parsed }
@@ -453,7 +459,7 @@ function Get-AzDevOpsSyncDatasets {
         },
         @{
             Name     = 'hierarchy'
-            Label    = 'Epic/Feature/Story hierarchy in @Project'
+            Label    = 'Epic/Feature/Requirement-tier hierarchy'
             Path     = $Paths.Hierarchy
             Fetch    = { Invoke-AzDevOpsBoardsQuery -Wiql $hierarchyWiql }.GetNewClosure()
             Counter  = $rowCounter


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #31 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | ✅ 4 manual items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/34#issuecomment-4409086448) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/34#issuecomment-4409093747) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/34#issuecomment-4409091432) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/34#issuecomment-4409094913) |
| ✅ Criteria Check | ✅ PASS (7/11 verified, 4 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/34#issuecomment-4409113470) |
| 📚 Docs Check | ✅ CURRENT — reported in `/pr-flow` chat only (no PR comment) |
<!-- toc:end -->

## Summary

`Sync-AzDevOpsCache` produced an empty `hierarchy.json` on non-Agile process templates because the WIQL hardcoded `'User Story'` (Agile-only) and the `az` calls never passed `--organization` / `--project`, leaving scope up to whatever `az devops configure --defaults` happened to be set to. This PR plumbs `$env:AZ_DEVOPS_ORG` / `$env:AZ_PROJECT` into every `az` call routed through `Invoke-AzDevOpsAzJson` and rewrites the hierarchy WIQL to use **work-item-type categories** (`Microsoft.{Epic,Feature,Requirement}Category`) so it works on every process template (Agile, Scrum, CMMI, Basic, and inherited variants).

## Issue

Closes #31

## Changes

- **`powcuts_by_cli/azdevops_db.ps1`** — `Invoke-AzDevOpsAzJson` injects `--organization $env:AZ_DEVOPS_ORG` and `--project $env:AZ_PROJECT` into the arg list when each env var is set **and** the flag isn't already present. Explicit caller flags (e.g. `New-AzDevOpsWorkItem`'s own `--project`) still win, so backward compatibility is preserved. When env vars are unset, behavior is unchanged (still falls back to `az devops configure` defaults).
- **`powcuts_by_cli/azdevops_workitems.ps1`** — `$hierarchyWiql` switched to `IN GROUP 'Microsoft.EpicCategory' OR IN GROUP 'Microsoft.FeatureCategory' OR IN GROUP 'Microsoft.RequirementCategory'`. The redundant `[System.TeamProject] = @Project` clause was removed (`--project` plumbing scopes it now). Surrounding comment refreshed; dataset `Label` updated to `'Epic/Feature/Requirement-tier hierarchy'`.

## Test Plan

- [ ] Local `[System.Management.Automation.Language.Parser]::ParseFile(...)` passes for both `.ps1` files (pwsh wasn't on PATH in CI sandbox)
- [ ] Agile-template project: `Sync-AzDevOpsCache` populates `hierarchy.json` with Epic / Feature / User Story rows
- [ ] Non-Agile-template project (Scrum/CMMI/Basic): `Sync-AzDevOpsCache` populates `hierarchy.json` with that template's Epic / Feature / Requirement-tier types
- [ ] `az devops configure --defaults organization='' project=''`, then re-run `Sync-AzDevOpsCache` — should still scope correctly via env-var plumbing
- [ ] `Submit-AzDevOpsNewStory` (which calls `New-AzDevOpsWorkItem` with explicit `--project`) still creates a story without duplicate-flag error

## Shell Parity

PowerShell-only — `bashcuts_by_cli/.az_bashcuts` has its own simpler `az boards query` aliases that don't share this code path. No bash counterpart needed.

## Follow-ups

- **#43** — Consumer-side filter in `az-Show-AzDevOpsTree` still uses literal `'User Story'`; this PR fixed the producer (WIQL) but the tree view will render zero leaves on non-Agile projects until the consumer is widened. Filed during retroactive `/pr-flow` review.

https://claude.ai/code/session_013NXnUngs9sRm2q4ZajysLs