### PR TITLE
feat(#35): echo every Azure DevOps query (WIQL + az command) to terminal

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -440,6 +440,11 @@ graph LR
     NewWI[New-AzDevOpsWorkItem]:::priv
     AddRel[Add-AzDevOpsWorkItemRelation]:::priv
 
+    %% Query echo helpers (azdevops_db.ps1)
+    CmdDisp[Format-AzDevOpsCommandDisplay]:::priv
+    CmdHead[Get-AzDevOpsCommandHeadline]:::priv
+    EchoLn[Write-AzDevOpsQueryEcho]:::priv
+
     %% Schedule helpers
     Plat[Get-AzDevOpsPlatform]:::priv
     TaskName[Get-AzDevOpsScheduledTaskName]:::priv
@@ -514,6 +519,10 @@ graph LR
     InvokeDS --> ClassList
     Boards --> AzJson
     ClassList --> AzJson
+    Boards --> EchoLn
+    AzJson --> CmdDisp
+    AzJson --> CmdHead
+    AzJson --> EchoLn
     AzJson --> Az
     InvokeDS --> Stderr1
     InvokeDS --> DStatus

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -14,19 +14,99 @@
 #   - Session/admin calls (az login, az account show, az extension *,
 #     az devops configure) are NOT wrapped here - they live in
 #     azdevops_workitems.ps1 alongside az-Connect-AzDevOps.
+#
+# Diagnostic echoes:
+#   - Every call through Invoke-AzDevOpsAzJson echoes the assembled `az`
+#     command line before invoking and the elapsed-time / exit-code summary
+#     after the call returns. WIQL queries additionally echo the WIQL string
+#     as its own labeled line via Invoke-AzDevOpsBoardsQuery so the SQL-ish
+#     text isn't buried inside the `--wiql` arg of the command echo.
+#   - All echoes go through Write-Host (host stream only) so the canonical
+#     { Json, Error, ExitCode } envelope is unaffected for callers that
+#     consume the function's return value.
 # ---------------------------------------------------------------------------
+
+
+function Write-AzDevOpsQueryEcho {
+    # Private helper - emits a single status line for query echoes (the WIQL
+    # string, the assembled `az` command, and the post-call elapsed/exit
+    # summary). Lifts the indent and arrow glyph into one place so the
+    # visual style stays consistent across callers and a future tweak
+    # (different glyph, different indent, different default color) is a
+    # one-line edit. Uses an unapproved-verb-free name (Write-* is approved)
+    # but is treated as private to azdevops_db.ps1 / azdevops_workitems.ps1.
+    param(
+        [Parameter(Mandatory)] [string] $Message,
+        [string] $Color = 'DarkCyan'
+    )
+
+    $indent    = '  '
+    $arrowChar = "$([char]0x21B3)"   # downwards arrow with tip rightwards
+    $line      = "$indent$arrowChar $Message"
+
+    Write-Host $line -ForegroundColor $Color
+}
+
+
+function Format-AzDevOpsCommandDisplay {
+    # Private helper - renders an `az` ArgList into a human-readable single
+    # line for echo output. Args containing whitespace or quotes get wrapped
+    # in double quotes (with embedded quotes escaped); plain args stay
+    # unquoted. Appends `--output json` to match what Invoke-AzDevOpsAzJson
+    # actually runs so a copy-pasted line reproduces the call faithfully.
+    param([Parameter(Mandatory)] [string[]] $ArgList)
+
+    $displayParts = @()
+    foreach ($a in $ArgList) {
+        $needsQuote = $a -match '\s|"'
+        if ($needsQuote) {
+            $escaped = $a -replace '"', '\"'
+            $displayParts += "`"$escaped`""
+        } else {
+            $displayParts += $a
+        }
+    }
+
+    $command = "az $($displayParts -join ' ') --output json"
+    return $command
+}
+
+
+function Get-AzDevOpsCommandHeadline {
+    # Private helper - extracts a short subcommand-only headline from an `az`
+    # ArgList by joining tokens up to (but not including) the first `--flag`
+    # arg. Used for the post-call elapsed/exit summary line so the trailing
+    # echo stays compact (e.g. `az boards query (0.8s, exit=0)`) instead of
+    # repeating the full command which is already on the line above.
+    param([Parameter(Mandatory)] [string[]] $ArgList)
+
+    $parts = @('az')
+    foreach ($a in $ArgList) {
+        if ($a -like '--*') {
+            break
+        }
+        $parts += $a
+    }
+
+    $headline = $parts -join ' '
+    return $headline
+}
 
 
 function Invoke-AzDevOpsAzJson {
     # Generic wrapper around `az ... --output json` that captures stdout JSON
     # and stderr text separately. The canonical JSON+error path used by every
-    # other data-plane wrapper in this file.
+    # other data-plane wrapper in this file. Emits diagnostic before/after
+    # echoes so every query is visible in the terminal alongside its elapsed
+    # time and exit code.
     #
     # When $env:AZ_DEVOPS_ORG / $env:AZ_PROJECT are set and the caller has not
     # already supplied --organization / --project, we inject them so every
     # wrapper auto-scopes to the bashcuts env-var contract instead of relying
     # on `az devops configure --defaults`. Explicit caller flags always win
-    # (e.g. New-AzDevOpsWorkItem passes its own --project).
+    # (e.g. New-AzDevOpsWorkItem passes its own --project). The echo prints
+    # the post-injection command so the user sees the actual flags being
+    # sent to az, not the pre-scoped ArgList from the caller.
     param([Parameter(Mandatory)] [string[]] $ArgList)
 
     $scopedArgs = @($ArgList)
@@ -39,7 +119,11 @@ function Invoke-AzDevOpsAzJson {
         $scopedArgs += @('--project', $env:AZ_PROJECT)
     }
 
+    $commandDisplay = Format-AzDevOpsCommandDisplay -ArgList $scopedArgs
+    Write-AzDevOpsQueryEcho -Message $commandDisplay -Color 'DarkCyan'
+
     $stderrFile = [System.IO.Path]::GetTempFileName()
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
     try {
         $json = & az @scopedArgs --output json 2>$stderrFile
         $exit = $LASTEXITCODE
@@ -50,6 +134,18 @@ function Invoke-AzDevOpsAzJson {
         }
     } finally {
         Remove-Item -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+    }
+    $sw.Stop()
+
+    $elapsed  = '{0:N1}s' -f $sw.Elapsed.TotalSeconds
+    $headline = Get-AzDevOpsCommandHeadline -ArgList $scopedArgs
+
+    if ($exit -eq 0) {
+        $summary = "$headline ($elapsed, exit=0)"
+        Write-AzDevOpsQueryEcho -Message $summary -Color 'DarkGreen'
+    } else {
+        $summary = "$headline ($elapsed, exit=$exit)"
+        Write-AzDevOpsQueryEcho -Message $summary -Color 'Red'
     }
 
     if ($null -eq $stderr) {
@@ -66,8 +162,13 @@ function Invoke-AzDevOpsAzJson {
 
 function Invoke-AzDevOpsBoardsQuery {
     # Runs a WIQL query via `az boards query --wiql <Wiql>`. Returns the
-    # canonical { Json, Error, ExitCode } envelope.
+    # canonical { Json, Error, ExitCode } envelope. Echoes the WIQL string
+    # to the terminal before delegating so the query is visible as its own
+    # labeled line, separate from the `--wiql` arg embedded in the command
+    # echo emitted by Invoke-AzDevOpsAzJson.
     param([Parameter(Mandatory)] [string] $Wiql)
+
+    Write-AzDevOpsQueryEcho -Message "WIQL: $Wiql" -Color 'DarkCyan'
 
     $result = Invoke-AzDevOpsAzJson -ArgList @('boards', 'query', '--wiql', $Wiql)
     return $result

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -140,13 +140,14 @@ function Invoke-AzDevOpsAzJson {
     $elapsed  = '{0:N1}s' -f $sw.Elapsed.TotalSeconds
     $headline = Get-AzDevOpsCommandHeadline -ArgList $scopedArgs
 
-    if ($exit -eq 0) {
-        $summary = "$headline ($elapsed, exit=0)"
-        Write-AzDevOpsQueryEcho -Message $summary -Color 'DarkGreen'
+    $summary      = "$headline ($elapsed, exit=$exit)"
+    $summaryColor = if ($exit -eq 0) {
+        'DarkGreen'
     } else {
-        $summary = "$headline ($elapsed, exit=$exit)"
-        Write-AzDevOpsQueryEcho -Message $summary -Color 'Red'
+        'Red'
     }
+
+    Write-AzDevOpsQueryEcho -Message $summary -Color $summaryColor
 
     if ($null -eq $stderr) {
         $stderr = ''


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #35 |
| [Changes](#changes) | ✅ 1 source file + 1 diagram |
| [Visual Sample](#visual-sample) | ✅ |
| [Test Plan](#test-plan) | 0/5 (manual, run locally) |
| [Shell Parity](#shell-parity) | ✅ PowerShell-only by design |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/37#issuecomment-4409140919) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/37#issuecomment-4409147389) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/37#issuecomment-4409150712) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE *(MEDIUM fixed in `adf5536`)* — [View](https://github.com/jdschleicher/bashcuts/pull/37#issuecomment-4409147609) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/37#issuecomment-4409170996) |
| 📐 AzDO Diagrams Check | ✅ CURRENT *(updated in `81a7fd8`)* — [View](https://github.com/jdschleicher/bashcuts/pull/37#issuecomment-4409198263) |
<!-- toc:end -->

## Summary

Instrument the central data-plane wrapper `Invoke-AzDevOpsAzJson` so every `az boards ...` invocation echoes its assembled command line before running and an elapsed-time / exit-code summary after returning. `Invoke-AzDevOpsBoardsQuery` additionally echoes the WIQL string as its own labeled line so the SQL-ish text isn't buried inside the `--wiql` arg of the command echo.

## Issue

Closes #35

## Changes

- `powcuts_by_cli/azdevops_db.ps1`
  - **New private helpers**
    - `Write-AzDevOpsQueryEcho` — emits a single nested `↳` status line (indent + arrow lifted into one place per CLAUDE.md's name-magic-strings rule)
    - `Format-AzDevOpsCommandDisplay` — renders an ArgList into a quoted human-readable command string, appends `--output json`
    - `Get-AzDevOpsCommandHeadline` — short subcommand-only summary tag for the post-call line
  - **Modified** `Invoke-AzDevOpsAzJson` — emits before-command echo (using post-injection `$scopedArgs` so the user sees the actual flags), captures stopwatch, emits elapsed/exit summary with single Write call (color picked via multi-line if/else — `DarkGreen` on success, `Red` on non-zero)
  - **Modified** `Invoke-AzDevOpsBoardsQuery` — emits `WIQL: ...` echo before delegating
- `docs/azure-devops-diagrams.md`
  - **Diagram 9 (function dependency map)** — adds the three new helpers under a new "Query echo helpers" cluster with edges from `Invoke-AzDevOpsAzJson` → CmdDisp / CmdHead / EchoLn and `Invoke-AzDevOpsBoardsQuery` → EchoLn

Every query path in the work-item layer surfaces these echoes — the smoke test, the three sync WIQL queries (assigned / mentions / hierarchy), classification-list reads (iterations / areas), `New-AzDevOpsWorkItem`, `Add-AzDevOpsWorkItemRelation`, and `Get-AzDevOpsWorkItemTypeDefinition` — because all of them route through `Invoke-AzDevOpsAzJson`.

All echoes go through `Write-Host`; the canonical `{ Json, Error, ExitCode }` envelope is unchanged so callers consuming the return value see no behavior change.

## Visual Sample

```
-> Querying assigned (System.AssignedTo = @Me)...
  ↳ WIQL: Select [System.Id], [System.Title], ... From WorkItems Where [System.AssignedTo] = @Me
  ↳ az boards query --wiql "Select [System.Id], ..." --organization https://dev.azure.com/org --project MyProject --output json
  ↳ az boards query (0.8s, exit=0)
  OK  assigned - 12 rows in 0.9s
```

## Test Plan

- [ ] `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/azdevops_db.ps1', [ref]\$null, [ref]\$null) | Out-Null"` returns no parse errors
- [ ] Open a fresh PowerShell terminal, run `Invoke-AzDevOpsSmokeQuery` — expect the WIQL echo, the `az boards query --wiql ... --output json` echo, and the `az boards query (Xs, exit=0)` summary line
- [ ] Run `az-Sync-AzDevOpsCache` — confirms each of the three datasets (assigned / mentions / hierarchy) prints the new echo trio under the existing `-> Querying ...` banner, plus the iterations/areas classification reads
- [ ] (Optional) Trigger a work-item create flow — confirms non-WIQL paths echo the `az boards work-item create --type ... --output json` line too
- [ ] Confirm no regression: callers consuming `$result.Json` / `$result.ExitCode` still receive the same PSCustomObject envelope — echoes are `Write-Host` only, not pipeline output

## Shell Parity

PowerShell only — there is no `.azdevops_bashcuts` file in `bashcuts_by_cli/` (per issue #35's Shell Parity Note).


---
_Generated by [Claude Code](https://claude.ai/code/session_011LkBWG1EzkDkfvLUUXh37D)_