### PR TITLE
feat(#47): default-sort assigned + mentions by date desc

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -224,6 +224,7 @@ sequenceDiagram
     participant Conv as ConvertFrom-AzDevOpsAssignedItem
     participant Banner as Write-AzDevOpsStaleBanner
     participant Filter as Select-AzDevOpsActiveItems
+    participant Sort as Sort-AzDevOpsByDateDesc
     participant Title as Format-AzDevOpsTruncatedTitle
     participant Show as Show-AzDevOpsRows
     participant Cache as assigned.json
@@ -241,6 +242,8 @@ sequenceDiagram
     GetA->>Banner: WARNING stale (if last-sync > 6h)
     GetA->>Filter: filter by -State or active default
     Filter-->>GetA: filtered[]
+    GetA->>Sort: newest-first by AssignedAt (or MentionedAt)
+    Sort-->>GetA: sorted[]
     GetA->>Title: title-column projection
     Title-->>GetA: rows
     GetA->>Show: -PassThru (Out-ConsoleGridView<br/>or Format-Table fallback)
@@ -475,6 +478,7 @@ graph LR
     Closed[Get-AzDevOpsClosedStates]:::priv
     Stale[Write-AzDevOpsStaleBanner]:::priv
     SelAct[Select-AzDevOpsActiveItems]:::priv
+    Sort[Sort-AzDevOpsByDateDesc]:::priv
     Trunc[Format-AzDevOpsTruncatedTitle]:::priv
     TitleCol[Get-AzDevOpsTitleColumn]:::priv
     Find[Find-AzDevOpsCachedWorkItem]:::priv
@@ -570,6 +574,7 @@ graph LR
     GetA --> ReadA
     GetA --> Stale --> Age
     GetA --> SelAct --> Closed
+    GetA --> Sort
     GetA --> TitleCol --> Trunc
     GetA --> ShowRows
     OpenA --> ReadA
@@ -582,6 +587,7 @@ graph LR
     GetM --> ReadA
     GetM --> Stale
     GetM --> SelAct
+    GetM --> Sort
     GetM --> TitleCol
     GetM --> ShowRows
     OpenM --> ReadM

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -927,6 +927,10 @@ function Read-AzDevOpsGridPick {
 # All four read $HOME/.bashcuts-cache/azure-devops/{assigned,mentions}.json
 # (built by az-Sync-AzDevOpsCache). They never call `az` directly - if the cache
 # is missing, they print a hint and bail.
+#
+# Default order for the two Get- listings: most recently changed first
+# (AssignedAt / MentionedAt descending). Click the column header in
+# Out-ConsoleGridView to re-sort by Id, State, etc.
 # ---------------------------------------------------------------------------
 
 function ConvertFrom-AzDevOpsAssignedItem {
@@ -1155,7 +1159,14 @@ function az-Get-AzDevOpsAssigned {
 
     $filtered = Select-AzDevOpsActiveItems -Items $items -State $State
 
-    $rows  = @($filtered | Select-Object Id, Type, State, (Get-AzDevOpsTitleColumn), Iteration, AssignedAt)
+    # Newest first; Sort-Object -Descending puts $null at the top because
+    # $null sorts below every value, so use a two-key sort whose first key
+    # pushes null dates to the bottom before applying the date order.
+    $sorted = @($filtered | Sort-Object `
+        @{ Expression = { $null -ne $_.AssignedAt }; Descending = $true }, `
+        @{ Expression = 'AssignedAt';                Descending = $true })
+
+    $rows  = @($sorted | Select-Object Id, Type, State, (Get-AzDevOpsTitleColumn), Iteration, AssignedAt)
     $title = "Assigned to me - $($rows.Count) items"
 
     $selected = Show-AzDevOpsRows -Rows $rows -Title $title -PassThru
@@ -1286,7 +1297,12 @@ function az-Get-AzDevOpsMentions {
         }
     }
 
-    $rows  = @($filtered | Select-Object Id, Type, State, (Get-AzDevOpsTitleColumn), MentionedBy, MentionedAt)
+    # Newest first; same null-at-bottom trick as az-Get-AzDevOpsAssigned.
+    $sorted = @($filtered | Sort-Object `
+        @{ Expression = { $null -ne $_.MentionedAt }; Descending = $true }, `
+        @{ Expression = 'MentionedAt';                Descending = $true })
+
+    $rows  = @($sorted | Select-Object Id, Type, State, (Get-AzDevOpsTitleColumn), MentionedBy, MentionedAt)
     $title = "Mentions - $($rows.Count) items"
 
     $selected = Show-AzDevOpsRows -Rows $rows -Title $title -PassThru

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -991,6 +991,8 @@ function Read-AzDevOpsJsonCache {
 #                                  - Find-AzDevOpsCachedWorkItem
 #   - env-var guard + URL build + Start-Process
 #                                  - Open-AzDevOpsWorkItemUrl
+#   - newest-first sort with $null dates pushed to the bottom
+#                                  - Sort-AzDevOpsByDateDesc
 # ---------------------------------------------------------------------------
 
 function Get-AzDevOpsClosedStates {
@@ -1021,6 +1023,26 @@ function Select-AzDevOpsActiveItems {
     }
 
     return $filtered
+}
+
+
+function Sort-AzDevOpsByDateDesc {
+    # Newest first. Sort-Object -Descending on a date alone would surface
+    # rows whose date is $null at the *top* of the list, because PowerShell
+    # sorts $null below every value. Two-key sort: the first key pushes
+    # null-date rows to the bottom; the second orders the non-nulls
+    # newest-first. Used by the Get-AzDevOpsAssigned / Get-AzDevOpsMentions
+    # listings so each one is a one-line call.
+    param(
+        [Parameter(Mandatory)] $Items,
+        [Parameter(Mandatory)] [string] $Field
+    )
+
+    $sorted = $Items | Sort-Object `
+        @{ Expression = { $null -ne $_.$Field }; Descending = $true }, `
+        @{ Expression = $Field;                  Descending = $true }
+
+    return @($sorted)
 }
 
 
@@ -1158,13 +1180,7 @@ function az-Get-AzDevOpsAssigned {
     Write-AzDevOpsStaleBanner
 
     $filtered = Select-AzDevOpsActiveItems -Items $items -State $State
-
-    # Newest first; Sort-Object -Descending puts $null at the top because
-    # $null sorts below every value, so use a two-key sort whose first key
-    # pushes null dates to the bottom before applying the date order.
-    $sorted = @($filtered | Sort-Object `
-        @{ Expression = { $null -ne $_.AssignedAt }; Descending = $true }, `
-        @{ Expression = 'AssignedAt';                Descending = $true })
+    $sorted   = Sort-AzDevOpsByDateDesc -Items $filtered -Field 'AssignedAt'
 
     $rows  = @($sorted | Select-Object Id, Type, State, (Get-AzDevOpsTitleColumn), Iteration, AssignedAt)
     $title = "Assigned to me - $($rows.Count) items"
@@ -1297,10 +1313,7 @@ function az-Get-AzDevOpsMentions {
         }
     }
 
-    # Newest first; same null-at-bottom trick as az-Get-AzDevOpsAssigned.
-    $sorted = @($filtered | Sort-Object `
-        @{ Expression = { $null -ne $_.MentionedAt }; Descending = $true }, `
-        @{ Expression = 'MentionedAt';                Descending = $true })
+    $sorted = Sort-AzDevOpsByDateDesc -Items $filtered -Field 'MentionedAt'
 
     $rows  = @($sorted | Select-Object Id, Type, State, (Get-AzDevOpsTitleColumn), MentionedBy, MentionedAt)
     $title = "Mentions - $($rows.Count) items"


### PR DESCRIPTION
<!-- toc:start -->
## Table of Contents

| Section | Status |
|---|---|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #47 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | ✅ 4 items (manual) |
| [Shell Parity](#shell-parity) | ⚠️ pwsh-only (intentional) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/51#issuecomment-4411341686) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/51#issuecomment-4411344577) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/51#issuecomment-4411343173) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE (HIGH resolved in `b37c4b4`) — [View](https://github.com/jdschleicher/bashcuts/pull/51#issuecomment-4411346935) |
| ✅ Criteria Check | ✅ PASS (5/7 automated, 2/7 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/51#issuecomment-4412352380) |
| 📚 Docs Check | ✅ CURRENT (no README impact) |
| 🗺️ AzDO Diagrams Check | ✅ CURRENT (5 edits applied in `7b2561d`) |
<!-- toc:end -->

## Summary
`Out-ConsoleGridView` opened the assigned/mentions listings in cache-insertion order, so finding today's @-mention or fresh assignment required a manual column-header click. This PR sorts `$filtered` before projecting `$rows` in both `az-Get-AzDevOpsAssigned` and `az-Get-AzDevOpsMentions` so the most recently changed item is on top by default.

The two-key sort is now extracted into a private `Sort-AzDevOpsByDateDesc` helper in the existing `# Shared scaffolding for the Get-/Open-AzDevOps{Assigned,Mentions} pairs` section, so each call site is one line and the non-obvious null-handling lives in a single named home.

## Issue
Closes #47

## Changes
- `powcuts_by_cli/azdevops_workitems.ps1`
  - New private helper `Sort-AzDevOpsByDateDesc -Items <coll> -Field <name>` in the `# Shared scaffolding` section (two-key sort: null-pushed-to-bottom + date desc)
  - `az-Get-AzDevOpsAssigned`: one-line call `$sorted = Sort-AzDevOpsByDateDesc -Items $filtered -Field 'AssignedAt'`
  - `az-Get-AzDevOpsMentions`: same call with `-Field 'MentionedAt'`
  - Header docblock: three-line note documenting the new default order
- `docs/azure-devops-diagrams.md`
  - Diagram 5 (cache consumers): `Sort` participant + sequence step
  - Diagram 9 (function dependency map): `Sort` node in shared-scaffolding cluster + `GetA --> Sort` and `GetM --> Sort` edges

### Why a two-key sort
PowerShell's `Sort-Object -Descending` puts `$null` at the **top** because `$null` sorts below every value. The first sort key (`$null -ne $_.X`) pushes null dates to the bottom; the second key (the date itself, descending) orders the non-nulls newest-first. The helper centralizes this so a maintainer can't accidentally regress the order by "simplifying" to a single-key sort.

## Test Plan
- [ ] `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/azdevops_workitems.ps1', [ref]$null, [ref]$null) | Out-Null"` — zero parse errors
- [ ] In a fresh PowerShell terminal: `az-Get-AzDevOpsMentions` — top row is the most recently changed mention
- [ ] In a fresh PowerShell terminal: `az-Get-AzDevOpsAssigned` — top row is the most recently changed assignment
- [ ] Click the `MentionedAt` / `AssignedAt` column header in `Out-ConsoleGridView` — interactive re-sort still works

## Shell Parity
PowerShell-only, per issue #47's Shell Parity Note (the bash side has no equivalent listing surface yet).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReBb1NpwZhrvzfEDATfPgV)_
