### PR TITLE
fix(#55): replace bogus `az boards work-item-type show` with `az devops invoke`

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,8 @@ Every Azure DevOps org configures its own required + custom fields via process t
 The schema lives at `$HOME/.bashcuts/azure-devops/schema-<org>.json` (per-org keyed off `$env:AZ_DEVOPS_ORG`; falls back to `schema.json` when unset). The directory is created with `0700` permissions on macOS / Linux; Windows inherits the user-only ACL from `%USERPROFILE%`.
 
 ```powershell
-az-Initialize-AzDevOpsSchema     # introspect your org via `az boards work-item-type show`
+az-Initialize-AzDevOpsSchema     # introspect your org via
+                              #   `az devops invoke --area wit --resource workitemtypes`
                               #   and write a starter schema. Refine afterward.
 az-Get-AzDevOpsSchema            # print summary table of every required/optional field
 az-Get-AzDevOpsSchema -PassThru  # return objects (pipeable / scriptable)

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -107,7 +107,16 @@ function Invoke-AzDevOpsAzJson {
     # (e.g. New-AzDevOpsWorkItem passes its own --project). The echo prints
     # the post-injection command so the user sees the actual flags being
     # sent to az, not the pre-scoped ArgList from the caller.
-    param([Parameter(Mandatory)] [string[]] $ArgList)
+    #
+    # -SkipProjectFlag opts out of the --project auto-injection for callers
+    # whose subcommand rejects --project as a top-level flag (e.g.
+    # `az devops invoke`, which carries the project in --route-parameters
+    # instead). --organization auto-injection still applies since
+    # `az devops invoke` accepts it.
+    param(
+        [Parameter(Mandatory)] [string[]] $ArgList,
+        [switch] $SkipProjectFlag
+    )
 
     $scopedArgs = @($ArgList)
 
@@ -115,7 +124,7 @@ function Invoke-AzDevOpsAzJson {
         $scopedArgs += @('--organization', $env:AZ_DEVOPS_ORG)
     }
 
-    if ($env:AZ_PROJECT -and ($scopedArgs -notcontains '--project')) {
+    if (-not $SkipProjectFlag -and $env:AZ_PROJECT -and ($scopedArgs -notcontains '--project')) {
         $scopedArgs += @('--project', $env:AZ_PROJECT)
     }
 
@@ -274,11 +283,25 @@ function Add-AzDevOpsWorkItemRelation {
 
 
 function Get-AzDevOpsWorkItemTypeDefinition {
-    # `az boards work-item-type show --type <T>` wrapper. Returns the type's
-    # field-instance definitions inside the canonical envelope so callers can
-    # walk fieldInstances[] without re-doing the az + parse dance.
+    # `az devops invoke --area wit --resource workitemtypes` wrapper. Returns
+    # the type's field-instance definitions inside the canonical envelope so
+    # callers can walk fieldInstances[] without re-doing the az + parse dance.
+    #
+    # The azure-devops extension does NOT expose a `boards work-item-type`
+    # subgroup, so we go through `az devops invoke` (REST passthrough) against
+    # the WIT workitemtypes endpoint. Project scope rides in --route-parameters
+    # rather than --project, so we pass -SkipProjectFlag to bypass the
+    # Invoke-AzDevOpsAzJson auto-injection that `az devops invoke` would reject.
     param([Parameter(Mandatory)] [string] $Type)
 
-    $result = Invoke-AzDevOpsAzJson -ArgList @('boards', 'work-item-type', 'show', '--type', $Type)
+    $apiVersion = '7.1'
+
+    $result = Invoke-AzDevOpsAzJson -SkipProjectFlag -ArgList @(
+        'devops', 'invoke',
+        '--area',             'wit',
+        '--resource',         'workitemtypes',
+        '--route-parameters', "project=$env:AZ_PROJECT", "type=$Type",
+        '--api-version',      $apiVersion
+    )
     return $result
 }

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -3077,9 +3077,9 @@ function az-New-AzDevOpsFeatureStories {
 #                                  code / notepad / nano. Creates a stub
 #                                  if the file does not exist.
 #   az-Initialize-AzDevOpsSchema   - introspect the org via
-#                                  `az boards work-item-type show` and
-#                                  write a starter schema. User refines
-#                                  afterward via az-Edit-AzDevOpsSchema.
+#                                  `az devops invoke --area wit --resource
+#                                  workitemtypes` and write a starter schema.
+#                                  User refines afterward via az-Edit-AzDevOpsSchema.
 #   az-Test-AzDevOpsSchema         - validate JSON parses, every ref still
 #                                  exists in the org, and picklist options
 #                                  are a subset of allowedValues. Verdict:
@@ -3401,9 +3401,10 @@ function az-Edit-AzDevOpsSchema {
 
 
 function Invoke-AzDevOpsWorkItemTypeShow {
-    # Wraps `az boards work-item-type show --type <T>`. Returns Ok / Error /
-    # Type so callers can react to a missing type (org's process doesn't have
-    # one of the standards) without taking down the whole flow.
+    # Wraps `az devops invoke --area wit --resource workitemtypes` for one
+    # type. Returns Ok / Error / Type so callers can react to a missing type
+    # (org's process doesn't have one of the standards) without taking down
+    # the whole flow.
     param([Parameter(Mandatory)] [string] $Type)
 
     $result = Get-AzDevOpsWorkItemTypeDefinition -Type $Type
@@ -3423,7 +3424,7 @@ function Invoke-AzDevOpsWorkItemTypeShow {
 
 function ConvertTo-AzDevOpsSchemaFieldEntry {
     # Maps one fieldInstances[] element to our { name, ref, type, options? }
-    # shape. Type defaults to 'string' since `az boards work-item-type show`
+    # shape. Type defaults to 'string' since the workitemtypes REST response
     # doesn't surface the underlying field type; presence of allowedValues
     # promotes it to 'picklist'. Users refine via az-Edit-AzDevOpsSchema.
     param([Parameter(Mandatory)] $FieldInstance)


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #55 |
| [Changes](#changes) | ✅ 3 files |
| [Test Plan](#test-plan) | ✅ 5 items |
| [Shell Parity](#shell-parity) | ✅ PowerShell-only |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE (N/A — no bash files) — [View](https://github.com/jdschleicher/bashcuts/pull/58#issuecomment-4416587398) |
| 💠 PowerShell Engineer Review | ✅ APPROVE (0 critical, 0 high, 2 med, 3 low) — [View](https://github.com/jdschleicher/bashcuts/pull/58#issuecomment-4416589585) |
| 🛡️ Security Audit | ✅ PASS (0 critical, 0 high, 2 low) — [View](https://github.com/jdschleicher/bashcuts/pull/58#issuecomment-4416589004) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE (0 high, 0 med, 1 low) — [View](https://github.com/jdschleicher/bashcuts/pull/58#issuecomment-4416588825) |
| ✅ Criteria Check | ✅ PASS (6 verified, 0 missing, 3 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/58#issuecomment-4416593559) |
| 📚 Docs Check | ✅ CURRENT (inline in pr-flow output) |
| 🗺️ AzDO Diagrams Check | ✅ CURRENT for this PR (inline in pr-flow output) |
<!-- toc:end -->

## Summary
Replaces a bogus `az boards work-item-type show` invocation (which doesn't exist in the azure-devops extension) with a real `az devops invoke --area wit --resource workitemtypes` REST passthrough. Unblocks `az-Initialize-AzDevOpsSchema` and `az-Test-AzDevOpsSchema`.

## Issue
Closes #55

## Changes
- `powcuts_by_cli/azdevops_db.ps1`
  - Added `[switch] $SkipProjectFlag` to `Invoke-AzDevOpsAzJson` — opts out of the auto `--project` injection for callers whose subcommand rejects it (e.g. `az devops invoke`, which carries project in `--route-parameters`). `--organization` auto-injection still applies.
  - Rewrote `Get-AzDevOpsWorkItemTypeDefinition` to call `az devops invoke --area wit --resource workitemtypes --route-parameters project=$env:AZ_PROJECT type=$Type --api-version 7.1` with `-SkipProjectFlag`.
- `powcuts_by_cli/azdevops_workitems.ps1` — three doc comments (3079-3082, 3403-3406, 3424-3427) updated to reference the real REST command. Function bodies unchanged.
- `README.md:306` — updated the `az-Initialize-AzDevOpsSchema` blurb to reference the real command.

The REST endpoint `/_apis/wit/workitemtypes/{type}` returns the same `fieldInstances[]` shape that `ConvertTo-AzDevOpsSchemaFieldEntry` already walks, so both callers (`az-Initialize-AzDevOpsSchema`, `az-Test-AzDevOpsSchema`) work without further changes.

## Test Plan
- [ ] `pwsh -NoProfile` parses both `.ps1` files (sandbox didn't have pwsh; verify locally)
- [ ] `Invoke-AzDevOpsWorkItemTypeShow -Type 'User Story'` returns `Ok=$true` and `Type.fieldInstances` is populated
- [ ] `Invoke-AzDevOpsWorkItemTypeShow -Type 'BogusType'` returns `Ok=$false` with a non-empty `Error` (no throw)
- [ ] `az-Initialize-AzDevOpsSchema` runs end-to-end against a real org and writes `$HOME/.bashcuts/azure-devops/schema-<org>.json` with `required`/`optional` entries for Epic, Feature, User Story — no `(unknown az error)` skip lines
- [ ] Other `az` invocations in `azdevops_db.ps1` / `azdevops_workitems.ps1` audited and confirmed legitimate (pre-checked during issue triage)

## Shell Parity
PowerShell-only. There is no bash counterpart of `az-Initialize-AzDevOpsSchema` and `.az_bashcuts` doesn't reference work-item-type.

https://claude.ai/code/session_01D9E7cZcgXY6dBjzpTi5dMv