### PR TITLE
feat: Phase B — type-aware defaults in az-New-AzDevOps* creators (#56)

### DIFF
--- a/powcuts_by_cli/azdevops_projects.ps1
+++ b/powcuts_by_cli/azdevops_projects.ps1
@@ -1,0 +1,536 @@
+# ============================================================================
+# Azure DevOps Multi-Project Map
+# ============================================================================
+#
+# Lets the user define a hashtable in their `$profile` describing every Azure
+# DevOps project board they touch, then switch the active board with a single
+# command. Existing az-* functions don't change shape - the switcher hydrates
+# the same flat $env:AZ_DEVOPS_ORG / AZ_PROJECT / AZ_AREA / AZ_ITERATION env
+# vars they already read.
+#
+# Profile shape (set in $profile, AFTER bashcuts is sourced):
+#
+#   $global:AzDevOpsProjectMap = @{
+#       ProjectABC = @{
+#           Org       = 'https://dev.azure.com/myorg'
+#           Project   = 'Project ABC'
+#           Area      = 'Project ABC\Team Phoenix'
+#           Iteration = 'Project ABC\Sprint 42'
+#           Tags      = @('team-phoenix')
+#           Types = @{
+#               EPIC = @{
+#                   Area      = 'Project ABC\Portfolio'
+#                   Iteration = 'Project ABC'
+#                   Tags      = @('portfolio')
+#                   DefaultPriority = 2
+#                   RequiredFields  = @{ 'Custom.BusinessValue' = 'prompt' }
+#                   ParentScope     = $null
+#               }
+#               FEATURE = @{
+#                   Area      = 'Project ABC\Team Phoenix'
+#                   Iteration = 'Project ABC\Sprint 42'
+#                   ParentScope = @{
+#                       Type      = 'EPIC'
+#                       AreaPaths = @('Project ABC\Portfolio')
+#                   }
+#               }
+#               USER_STORY = @{
+#                   Area      = 'Project ABC\Team Phoenix\Backend'
+#                   Iteration = 'Project ABC\Sprint 42'
+#                   ParentScope = @{
+#                       Type      = 'FEATURE'
+#                       AreaPaths = @('Project ABC\Team Phoenix')
+#                   }
+#               }
+#           }
+#       }
+#       Project123 = @{ ... }
+#   }
+#
+#   $global:AzDevOpsDefaultProject = 'ProjectABC'
+#
+# User-facing functions:
+#   az-Use-AzDevOpsProject   - switch the active project board (hydrates env
+#                              vars + runs `az devops configure --defaults`)
+#   az-Show-AzDevOpsProject  - print the active project + resolved env vars
+#   az-Get-AzDevOpsProjects  - list every project name in the map, marking
+#                              the active one
+#
+# Type-key normalization: lookups uppercase the type and replace spaces with
+# underscores, so `'User Story'`, `'user story'`, and `'USER_STORY'` all hit
+# the same map entry. Author your map keys in any of those forms.
+# ============================================================================
+
+
+# ---------------------------------------------------------------------------
+# Private helpers (no `az-` prefix; callable from azdevops_workitems.ps1)
+# ---------------------------------------------------------------------------
+
+function Test-AzDevOpsProjectMapDefined {
+    if ($null -eq $global:AzDevOpsProjectMap) {
+        return $false
+    }
+
+    if ($global:AzDevOpsProjectMap -isnot [hashtable]) {
+        return $false
+    }
+
+    if ($global:AzDevOpsProjectMap.Count -eq 0) {
+        return $false
+    }
+
+    return $true
+}
+
+
+function ConvertTo-AzDevOpsTypeKey {
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $upper = $Type.ToUpper()
+    $key   = $upper -replace '\s+', '_'
+    return $key
+}
+
+
+function Get-AzDevOpsActiveProjectName {
+    if ($script:ActiveAzDevOpsProject) {
+        return $script:ActiveAzDevOpsProject
+    }
+
+    if ($global:AzDevOpsDefaultProject) {
+        return $global:AzDevOpsDefaultProject
+    }
+
+    return $null
+}
+
+
+function Get-AzDevOpsActiveProjectConfig {
+    if (-not (Test-AzDevOpsProjectMapDefined)) {
+        return $null
+    }
+
+    $name = Get-AzDevOpsActiveProjectName
+    if (-not $name) {
+        return $null
+    }
+
+    if (-not $global:AzDevOpsProjectMap.ContainsKey($name)) {
+        return $null
+    }
+
+    $config = $global:AzDevOpsProjectMap[$name]
+    return $config
+}
+
+
+function Get-AzDevOpsTypeConfig {
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $project = Get-AzDevOpsActiveProjectConfig
+    if ($null -eq $project) {
+        return $null
+    }
+
+    if (-not $project.ContainsKey('Types')) {
+        return $null
+    }
+
+    $types = $project['Types']
+    if ($null -eq $types -or $types -isnot [hashtable]) {
+        return $null
+    }
+
+    $key = ConvertTo-AzDevOpsTypeKey -Type $Type
+    if (-not $types.ContainsKey($key)) {
+        return $null
+    }
+
+    $entry = $types[$key]
+    return $entry
+}
+
+
+function Get-AzDevOpsActiveProjectSlug {
+    # Per-project cache key - lowercased, alnum-and-dash only. Mirrors
+    # Get-AzDevOpsSchemaOrgSlug's shape so cache and schema slugs read alike.
+    # Returns $null when no active project is set, which keeps
+    # Get-AzDevOpsCachePaths backward-compatible with single-project use.
+    $name = Get-AzDevOpsActiveProjectName
+    if (-not $name) {
+        return $null
+    }
+
+    $slug = ($name.ToLower() -replace '[^a-z0-9-]', '-').Trim('-')
+    if (-not $slug) {
+        return $null
+    }
+
+    return $slug
+}
+
+
+function Resolve-AzDevOpsTypeArea {
+    # Type override -> board default -> $env:AZ_AREA -> $null.
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $typeConfig = Get-AzDevOpsTypeConfig -Type $Type
+    if ($null -ne $typeConfig -and $typeConfig.ContainsKey('Area') -and $typeConfig['Area']) {
+        $area = [string]$typeConfig['Area']
+        return $area
+    }
+
+    $project = Get-AzDevOpsActiveProjectConfig
+    if ($null -ne $project -and $project.ContainsKey('Area') -and $project['Area']) {
+        $area = [string]$project['Area']
+        return $area
+    }
+
+    if ($env:AZ_AREA) {
+        return $env:AZ_AREA
+    }
+
+    return $null
+}
+
+
+function Resolve-AzDevOpsTypeIteration {
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $typeConfig = Get-AzDevOpsTypeConfig -Type $Type
+    if ($null -ne $typeConfig -and $typeConfig.ContainsKey('Iteration') -and $typeConfig['Iteration']) {
+        $iteration = [string]$typeConfig['Iteration']
+        return $iteration
+    }
+
+    $project = Get-AzDevOpsActiveProjectConfig
+    if ($null -ne $project -and $project.ContainsKey('Iteration') -and $project['Iteration']) {
+        $iteration = [string]$project['Iteration']
+        return $iteration
+    }
+
+    if ($env:AZ_ITERATION) {
+        return $env:AZ_ITERATION
+    }
+
+    return $null
+}
+
+
+function Resolve-AzDevOpsTypeTags {
+    # Concatenates board-level Tags with type-level Tags, dedupes, returns a
+    # string[] (possibly empty). Always returns an array so callers can feed
+    # it to `--fields System.Tags=...` after a `-join ';'` without nullguarding.
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $combined = New-Object System.Collections.Generic.List[string]
+
+    $project = Get-AzDevOpsActiveProjectConfig
+    if ($null -ne $project -and $project.ContainsKey('Tags')) {
+        foreach ($tag in @($project['Tags'])) {
+            if ($tag) {
+                [void]$combined.Add([string]$tag)
+            }
+        }
+    }
+
+    $typeConfig = Get-AzDevOpsTypeConfig -Type $Type
+    if ($null -ne $typeConfig -and $typeConfig.ContainsKey('Tags')) {
+        foreach ($tag in @($typeConfig['Tags'])) {
+            if ($tag) {
+                [void]$combined.Add([string]$tag)
+            }
+        }
+    }
+
+    $deduped = $combined | Select-Object -Unique
+    $tags    = @($deduped)
+    return $tags
+}
+
+
+function Resolve-AzDevOpsTypeRequiredFields {
+    # Returns a hashtable of <RefName> = <value or 'prompt'> for the given
+    # type, or an empty hashtable. Callers walk the entries and, for each
+    # 'prompt' value, Read-Host for input; literal values pass through to
+    # `az boards work-item create --fields ...`.
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $typeConfig = Get-AzDevOpsTypeConfig -Type $Type
+    if ($null -eq $typeConfig) {
+        return @{}
+    }
+
+    if (-not $typeConfig.ContainsKey('RequiredFields')) {
+        return @{}
+    }
+
+    $fields = $typeConfig['RequiredFields']
+    if ($null -eq $fields -or $fields -isnot [hashtable]) {
+        return @{}
+    }
+
+    return $fields
+}
+
+
+function Resolve-AzDevOpsTypeDefaultPriority {
+    # Returns a 1-4 int when configured, $null otherwise. Callers use $null
+    # to mean "fall through to the existing Read-AzDevOpsPriority prompt".
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $typeConfig = Get-AzDevOpsTypeConfig -Type $Type
+    if ($null -eq $typeConfig) {
+        return $null
+    }
+
+    if (-not $typeConfig.ContainsKey('DefaultPriority')) {
+        return $null
+    }
+
+    $value = $typeConfig['DefaultPriority']
+    if ($null -eq $value) {
+        return $null
+    }
+
+    $parsed = 0
+    if (-not [int]::TryParse([string]$value, [ref]$parsed)) {
+        return $null
+    }
+
+    if ($parsed -lt 1 -or $parsed -gt 4) {
+        return $null
+    }
+
+    return $parsed
+}
+
+
+function Resolve-AzDevOpsTypeDefaultStoryPoints {
+    # Returns a non-negative int when configured, $null otherwise. Only
+    # meaningful for USER_STORY in default Agile / Scrum templates.
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $typeConfig = Get-AzDevOpsTypeConfig -Type $Type
+    if ($null -eq $typeConfig) {
+        return $null
+    }
+
+    if (-not $typeConfig.ContainsKey('DefaultStoryPoints')) {
+        return $null
+    }
+
+    $value = $typeConfig['DefaultStoryPoints']
+    if ($null -eq $value) {
+        return $null
+    }
+
+    $parsed = 0
+    if (-not [int]::TryParse([string]$value, [ref]$parsed)) {
+        return $null
+    }
+
+    if ($parsed -lt 0) {
+        return $null
+    }
+
+    return $parsed
+}
+
+
+function Resolve-AzDevOpsTypeParentScope {
+    # Normalizes ParentScope to [PSCustomObject]@{ Type = '...'; AreaPaths = @('...', ...) }.
+    # Accepts AreaPath as either a single string or a list; always emits
+    # AreaPaths as a string[]. Returns $null when no scope is configured.
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $typeConfig = Get-AzDevOpsTypeConfig -Type $Type
+    if ($null -eq $typeConfig) {
+        return $null
+    }
+
+    if (-not $typeConfig.ContainsKey('ParentScope')) {
+        return $null
+    }
+
+    $scope = $typeConfig['ParentScope']
+    if ($null -eq $scope -or $scope -isnot [hashtable]) {
+        return $null
+    }
+
+    $parentType = if ($scope.ContainsKey('Type')) {
+        [string]$scope['Type']
+    } else {
+        ''
+    }
+
+    $rawPaths = $null
+    if ($scope.ContainsKey('AreaPaths')) {
+        $rawPaths = $scope['AreaPaths']
+    } elseif ($scope.ContainsKey('AreaPath')) {
+        $rawPaths = $scope['AreaPath']
+    }
+
+    $paths = @()
+    if ($null -ne $rawPaths) {
+        $paths = @($rawPaths) | Where-Object { $_ } | ForEach-Object { [string]$_ }
+    }
+
+    $normalized = [PSCustomObject]@{
+        Type      = $parentType
+        AreaPaths = @($paths)
+    }
+    return $normalized
+}
+
+
+function Set-AzDevOpsActiveProjectEnv {
+    # Hydrates the flat env vars from a project config hashtable. Only sets
+    # vars whose keys are present in the config - missing keys leave the
+    # current $env:AZ_* value alone so partial configs don't blow away an
+    # existing setup.
+    param([Parameter(Mandatory)] [hashtable] $Config)
+
+    if ($Config.ContainsKey('Org') -and $Config['Org']) {
+        $env:AZ_DEVOPS_ORG = [string]$Config['Org']
+    }
+
+    if ($Config.ContainsKey('Project') -and $Config['Project']) {
+        $env:AZ_PROJECT = [string]$Config['Project']
+    }
+
+    if ($Config.ContainsKey('Area') -and $Config['Area']) {
+        $env:AZ_AREA = [string]$Config['Area']
+    }
+
+    if ($Config.ContainsKey('Iteration') -and $Config['Iteration']) {
+        $env:AZ_ITERATION = [string]$Config['Iteration']
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# User-facing project-switch commands
+# ---------------------------------------------------------------------------
+
+function az-Get-AzDevOpsProjects {
+    # Lists every project name in $global:AzDevOpsProjectMap with an active
+    # marker. Returns [PSCustomObject]s so callers can pipe into Format-Table
+    # / Where-Object / etc.
+    if (-not (Test-AzDevOpsProjectMapDefined)) {
+        Write-Host "(`$global:AzDevOpsProjectMap is not defined - see azdevops_projects.ps1 header for shape)" -ForegroundColor Yellow
+        return
+    }
+
+    $active = Get-AzDevOpsActiveProjectName
+
+    $rows = foreach ($name in ($global:AzDevOpsProjectMap.Keys | Sort-Object)) {
+        $entry      = $global:AzDevOpsProjectMap[$name]
+        $org        = if ($entry.ContainsKey('Org'))     { [string]$entry['Org'] }     else { '' }
+        $project    = if ($entry.ContainsKey('Project')) { [string]$entry['Project'] } else { '' }
+        $isActive   = ($active -and $name -eq $active)
+
+        [PSCustomObject]@{
+            Active  = $isActive
+            Name    = $name
+            Project = $project
+            Org     = $org
+        }
+    }
+
+    return $rows
+}
+
+
+function az-Show-AzDevOpsProject {
+    # Prints the active project name and the four flat env vars it controls.
+    # Cheap alternative to az-Connect-AzDevOps when you just want to confirm
+    # which board your next az-* command will hit.
+    $name = Get-AzDevOpsActiveProjectName
+
+    Write-Host ""
+    Write-Host "Active Azure DevOps project" -ForegroundColor Cyan
+    Write-Host "===========================" -ForegroundColor Cyan
+
+    if (-not $name) {
+        Write-Host "  (none - `$global:AzDevOpsDefaultProject unset and az-Use-AzDevOpsProject not called)" -ForegroundColor Yellow
+    } else {
+        Write-Host "  Name : $name" -ForegroundColor Green
+    }
+
+    Write-Host "  AZ_DEVOPS_ORG = $env:AZ_DEVOPS_ORG"
+    Write-Host "  AZ_PROJECT    = $env:AZ_PROJECT"
+    Write-Host "  AZ_AREA       = $env:AZ_AREA"
+    Write-Host "  AZ_ITERATION  = $env:AZ_ITERATION"
+}
+
+
+function az-Use-AzDevOpsProject {
+    # Switches the active project board. Hydrates the four flat env vars from
+    # the map entry, records the new active name in $script:ActiveAzDevOpsProject,
+    # then runs `az devops configure --defaults` (skip with -SkipConfigure when
+    # you only want the env vars and no `az` round-trip - useful for shell
+    # startup auto-hydrate).
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)] [string] $Name,
+        [switch] $Quiet,
+        [switch] $SkipConfigure
+    )
+
+    if (-not (Test-AzDevOpsProjectMapDefined)) {
+        Write-Host "`$global:AzDevOpsProjectMap is not defined - set it in `$profile (see azdevops_projects.ps1 header)." -ForegroundColor Red
+        return
+    }
+
+    if (-not $global:AzDevOpsProjectMap.ContainsKey($Name)) {
+        $available = ($global:AzDevOpsProjectMap.Keys | Sort-Object) -join ', '
+        Write-Host "Project '$Name' not in `$global:AzDevOpsProjectMap. Available: $available" -ForegroundColor Red
+        return
+    }
+
+    $config = $global:AzDevOpsProjectMap[$Name]
+    if ($null -eq $config -or $config -isnot [hashtable]) {
+        Write-Host "`$global:AzDevOpsProjectMap['$Name'] is not a hashtable." -ForegroundColor Red
+        return
+    }
+
+    Set-AzDevOpsActiveProjectEnv -Config $config
+    $script:ActiveAzDevOpsProject = $Name
+
+    if (-not $SkipConfigure) {
+        if (Get-Command az -ErrorAction SilentlyContinue) {
+            $configureOutput = az devops configure --defaults "organization=$env:AZ_DEVOPS_ORG" "project=$env:AZ_PROJECT" 2>&1
+            if ($LASTEXITCODE -ne 0 -and -not $Quiet) {
+                Write-Host "  !  az devops configure failed (env vars still set):" -ForegroundColor Yellow
+                Write-Host "     $configureOutput" -ForegroundColor Yellow
+            }
+        } elseif (-not $Quiet) {
+            Write-Host "  !  az CLI not on PATH - env vars set but `az devops configure` skipped." -ForegroundColor Yellow
+        }
+    }
+
+    if (-not $Quiet) {
+        Write-Host ""
+        Write-Host "Switched to Azure DevOps project '$Name'" -ForegroundColor Green
+        Write-Host "  AZ_DEVOPS_ORG = $env:AZ_DEVOPS_ORG"
+        Write-Host "  AZ_PROJECT    = $env:AZ_PROJECT"
+        Write-Host "  AZ_AREA       = $env:AZ_AREA"
+        Write-Host "  AZ_ITERATION  = $env:AZ_ITERATION"
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Auto-hydrate on shell startup. Runs once when this file is dot-sourced from
+# powcuts_home.ps1. Silent + no `az devops configure` round-trip (-Quiet
+# -SkipConfigure) so a fresh terminal stays fast and quiet; users who want
+# `az boards` defaults pinned for the current shell run az-Use-AzDevOpsProject
+# (or az-Connect-AzDevOps) explicitly.
+# ---------------------------------------------------------------------------
+
+if ((Test-AzDevOpsProjectMapDefined) -and $global:AzDevOpsDefaultProject) {
+    if ($global:AzDevOpsProjectMap.ContainsKey($global:AzDevOpsDefaultProject)) {
+        az-Use-AzDevOpsProject -Name $global:AzDevOpsDefaultProject -Quiet -SkipConfigure
+    }
+}

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -304,7 +304,21 @@ function az-Connect-AzDevOps {
 # ---------------------------------------------------------------------------
 
 function Get-AzDevOpsCachePaths {
-    $cacheDir = Join-Path (Join-Path $HOME '.bashcuts-cache') 'azure-devops'
+    # Cache directory is segmented by active project slug when one is set, so
+    # az-Use-AzDevOpsProject can flip boards without contaminating cached
+    # hierarchy / assigned / mentions data across projects. Falls back to the
+    # legacy unsegmented layout when no project map is active, which keeps
+    # single-project users unaffected (no migration needed for them).
+    $rootDir  = Join-Path (Join-Path $HOME '.bashcuts-cache') 'azure-devops'
+    $cacheDir = $rootDir
+
+    if (Get-Command Get-AzDevOpsActiveProjectSlug -ErrorAction SilentlyContinue) {
+        $slug = Get-AzDevOpsActiveProjectSlug
+        if ($slug) {
+            $cacheDir = Join-Path $rootDir $slug
+        }
+    }
+
     return [PSCustomObject]@{
         Dir        = $cacheDir
         Assigned   = Join-Path $cacheDir 'assigned.json'

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -201,6 +201,63 @@ function az-Confirm-AzDevOpsEnvVars {
 }
 
 
+function az-Confirm-AzDevOpsProjectMap {
+    # Validates `$global:AzDevOpsProjectMap` when it's defined; silently passes
+    # when it isn't (multi-project mode is opt-in). When the map is defined but
+    # `$global:AzDevOpsDefaultProject` is unset, prompts the user with a numbered
+    # menu of project names and calls az-Use-AzDevOpsProject -Quiet on the
+    # choice. When the active project is missing required keys (Org / Project),
+    # returns Ok=$false with a clear FailMessage so the orchestrator bails.
+    if (-not (Get-Command Test-AzDevOpsProjectMapDefined -ErrorAction SilentlyContinue)) {
+        Write-Host "  -- Skipped (multi-project resolver layer not loaded)" -ForegroundColor DarkGray
+        return New-AzDevOpsStepResult -Ok $true
+    }
+
+    if (-not (Test-AzDevOpsProjectMapDefined)) {
+        Write-Host "  -- Skipped (`$global:AzDevOpsProjectMap not defined - single-project mode)" -ForegroundColor DarkGray
+        return New-AzDevOpsStepResult -Ok $true
+    }
+
+    $activeName = Get-AzDevOpsActiveProjectName
+    if (-not $activeName) {
+        Write-Host "  !  `$global:AzDevOpsProjectMap defined but no active project chosen" -ForegroundColor Yellow
+
+        $names = @($global:AzDevOpsProjectMap.Keys | Sort-Object)
+        Write-Host ""
+        Write-Host "    Available projects:" -ForegroundColor Cyan
+        for ($i = 0; $i -lt $names.Count; $i++) {
+            Write-Host ("      {0}. {1}" -f ($i + 1), $names[$i])
+        }
+
+        $idx = 0
+        while ($true) {
+            $resp = Read-Host "    Pick a project (1..$($names.Count))"
+            if ([int]::TryParse($resp, [ref]$idx) -and $idx -ge 1 -and $idx -le $names.Count) {
+                break
+            }
+            Write-Host "      Please enter 1..$($names.Count)." -ForegroundColor Yellow
+        }
+
+        $activeName = $names[$idx - 1]
+        az-Use-AzDevOpsProject -Name $activeName -Quiet
+    }
+
+    $config = Get-AzDevOpsActiveProjectConfig
+    if ($null -eq $config) {
+        return New-AzDevOpsStepResult -Ok $false -FailMessage "active project '$activeName' missing from `$global:AzDevOpsProjectMap"
+    }
+
+    foreach ($requiredKey in @('Org', 'Project')) {
+        if (-not $config.ContainsKey($requiredKey) -or -not $config[$requiredKey]) {
+            return New-AzDevOpsStepResult -Ok $false -FailMessage "project '$activeName' missing required key '$requiredKey' in `$global:AzDevOpsProjectMap"
+        }
+    }
+
+    Write-Host "  OK  Active project: $activeName" -ForegroundColor Green
+    return New-AzDevOpsStepResult -Ok $true
+}
+
+
 function az-Confirm-AzDevOpsLogin {
     if (-not (Test-AzDevOpsLoggedIn)) {
         Write-Host "  !  No active az login session" -ForegroundColor Yellow
@@ -261,9 +318,10 @@ function az-Connect-AzDevOps {
         @{ Num = 1; Name = 'Azure CLI';                     Action = { az-Confirm-AzDevOpsCli } },
         @{ Num = 2; Name = 'azure-devops extension';        Action = { az-Confirm-AzDevOpsExtension } },
         @{ Num = 3; Name = 'Profile environment variables'; Action = { az-Confirm-AzDevOpsEnvVars } },
-        @{ Num = 4; Name = 'Azure login session';           Action = { az-Confirm-AzDevOpsLogin } },
-        @{ Num = 5; Name = 'Configure az devops defaults';  Action = { az-Set-AzDevOpsDefaults } },
-        @{ Num = 6; Name = 'Smoke test (az boards query)';  Action = { az-Confirm-AzDevOpsSmokeQuery } }
+        @{ Num = 4; Name = 'Project map (multi-project)';   Action = { az-Confirm-AzDevOpsProjectMap } },
+        @{ Num = 5; Name = 'Azure login session';           Action = { az-Confirm-AzDevOpsLogin } },
+        @{ Num = 6; Name = 'Configure az devops defaults';  Action = { az-Set-AzDevOpsDefaults } },
+        @{ Num = 7; Name = 'Smoke test (az boards query)';  Action = { az-Confirm-AzDevOpsSmokeQuery } }
     )
 
     foreach ($step in $steps) {
@@ -449,7 +507,7 @@ function Get-AzDevOpsSyncDatasets {
     # Project scope is supplied by --project on the az invocation
     # (Invoke-AzDevOpsAzJson injects it from $env:AZ_PROJECT), so the WIQL
     # itself no longer needs a [System.TeamProject] = @Project clause.
-    $hierarchyWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.Parent] From WorkItems Where [System.WorkItemType] IN GROUP 'Microsoft.EpicCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.FeatureCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory'"
+    $hierarchyWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.WorkItemType] IN GROUP 'Microsoft.EpicCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.FeatureCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory'"
 
     $rowCounter  = { param($parsed) @($parsed).Count }
     $treeCounter = { param($parsed) Measure-AzDevOpsClassificationNodes -Node $parsed }
@@ -1417,6 +1475,7 @@ function ConvertFrom-AzDevOpsHierarchyItem {
         State     = $f.'System.State'
         Title     = $f.'System.Title'
         Iteration = $f.'System.IterationPath'
+        AreaPath  = $f.'System.AreaPath'
         Parent    = $parent
     }
     return $item
@@ -2262,12 +2321,50 @@ function Read-AzDevOpsAcceptanceCriteria {
 }
 
 
+function Test-AzDevOpsAreaPathMatch {
+    # Returns $true when $CandidatePath equals any element of $AllowedPaths
+    # exactly OR is a sub-path of one (matches at backslash boundary). Path
+    # comparison is case-insensitive to match Azure DevOps' own semantics:
+    # 'Project ABC\Portfolio' matches both 'Project ABC\Portfolio' and
+    # 'Project ABC\Portfolio\R&D'.
+    param(
+        [string]   $CandidatePath,
+        [string[]] $AllowedPaths
+    )
+
+    if (-not $CandidatePath) {
+        return $false
+    }
+
+    foreach ($allowed in $AllowedPaths) {
+        if (-not $allowed) {
+            continue
+        }
+        if ($CandidatePath -ieq $allowed) {
+            return $true
+        }
+        $prefix = "$allowed\"
+        if ($CandidatePath.Length -gt $prefix.Length -and
+            $CandidatePath.Substring(0, $prefix.Length) -ieq $prefix) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+
 function Read-AzDevOpsParentPick {
     # Generic parent picker shared by Read-AzDevOpsFeaturePick (story -> Feature)
     # and Read-AzDevOpsEpicPick (Feature -> Epic). Lists active rows of the
     # requested ParentType from the hierarchy cache and returns the chosen Id,
     # or 0 when the user picks 'orphan' / cancels. Out-ConsoleGridView TUI when
     # available, Read-Host numbered menu otherwise.
+    #
+    # -AreaPaths narrows the candidate list to rows whose AreaPath equals or is
+    # a sub-path of any provided value (sourced from
+    # ParentScope.AreaPaths in the active project map). When the hierarchy rows
+    # carry no AreaPath the filter is a silent no-op (logged once at -Verbose).
     #
     # Limitation: Basic-template projects skip the Feature tier entirely
     # (Epic -> Issue, no Feature). For -ParentType Feature this filter
@@ -2277,7 +2374,8 @@ function Read-AzDevOpsParentPick {
     param(
         [Parameter(Mandatory)] [ValidateSet('Feature','Epic')] [string] $ParentType,
         [Parameter(Mandatory)] $Hierarchy,
-        [string] $ChildLabel = 'item'
+        [string]   $ChildLabel = 'item',
+        [string[]] $AreaPaths
     )
 
     $closedStates = Get-AzDevOpsClosedStates
@@ -2290,6 +2388,30 @@ function Read-AzDevOpsParentPick {
     if ($candidates.Count -eq 0) {
         Write-Host "(no active ${ParentType}s in hierarchy.json - $ChildLabel will be orphaned)" -ForegroundColor Yellow
         return 0
+    }
+
+    if ($AreaPaths -and $AreaPaths.Count -gt 0) {
+        $hasAreaField = $false
+        foreach ($row in $candidates) {
+            if ($row.PSObject.Properties.Match('AreaPath').Count -gt 0 -and $row.AreaPath) {
+                $hasAreaField = $true
+                break
+            }
+        }
+
+        if (-not $hasAreaField) {
+            Write-Verbose "Read-AzDevOpsParentPick: hierarchy rows lack AreaPath; ParentScope.AreaPaths filter skipped. Run az-Sync-AzDevOpsCache to refresh."
+        } else {
+            $filtered = @($candidates |
+                Where-Object { Test-AzDevOpsAreaPathMatch -CandidatePath $_.AreaPath -AllowedPaths $AreaPaths })
+
+            if ($filtered.Count -eq 0) {
+                Write-Host "(no ${ParentType}s match ParentScope.AreaPaths - $ChildLabel will be orphaned)" -ForegroundColor Yellow
+                return 0
+            }
+
+            $candidates = $filtered
+        }
     }
 
     if (Test-AzDevOpsGridAvailable) {
@@ -2350,22 +2472,53 @@ function Read-AzDevOpsParentPick {
 }
 
 
+function Get-AzDevOpsParentScopeAreaPaths {
+    # Looks up ParentScope.AreaPaths for the given child work-item type via the
+    # Phase A resolver layer. Returns a (possibly empty) string[] - callers
+    # forward straight to Read-AzDevOpsParentPick -AreaPaths and the filter is
+    # a no-op on empty.
+    param([Parameter(Mandatory)] [string] $ChildType)
+
+    if (-not (Get-Command Resolve-AzDevOpsTypeParentScope -ErrorAction SilentlyContinue)) {
+        return @()
+    }
+
+    $scope = Resolve-AzDevOpsTypeParentScope -Type $ChildType
+    if ($null -eq $scope) {
+        return @()
+    }
+
+    $paths = @($scope.AreaPaths)
+    return $paths
+}
+
+
 function Read-AzDevOpsFeaturePick {
     # Story -> Feature parent picker. Thin wrapper over Read-AzDevOpsParentPick
     # so az-New-AzDevOpsUserStory keeps its current call site unchanged.
-    param([Parameter(Mandatory)] $Hierarchy)
+    # -ChildType drives the ParentScope.AreaPaths lookup; defaults to USER_STORY.
+    param(
+        [Parameter(Mandatory)] $Hierarchy,
+        [string] $ChildType = 'USER_STORY'
+    )
 
-    $featureId = Read-AzDevOpsParentPick -ParentType 'Feature' -Hierarchy $Hierarchy -ChildLabel 'story'
+    $areaPaths = Get-AzDevOpsParentScopeAreaPaths -ChildType $ChildType
+    $featureId = Read-AzDevOpsParentPick -ParentType 'Feature' -Hierarchy $Hierarchy -ChildLabel 'story' -AreaPaths $areaPaths
     return $featureId
 }
 
 
 function Read-AzDevOpsEpicPick {
     # Feature -> Epic parent picker. Thin wrapper over Read-AzDevOpsParentPick
-    # used by az-New-AzDevOpsFeature.
-    param([Parameter(Mandatory)] $Hierarchy)
+    # used by az-New-AzDevOpsFeature. -ChildType drives the ParentScope.AreaPaths
+    # lookup; defaults to FEATURE.
+    param(
+        [Parameter(Mandatory)] $Hierarchy,
+        [string] $ChildType = 'FEATURE'
+    )
 
-    $epicId = Read-AzDevOpsParentPick -ParentType 'Epic' -Hierarchy $Hierarchy -ChildLabel 'Feature'
+    $areaPaths = Get-AzDevOpsParentScopeAreaPaths -ChildType $ChildType
+    $epicId = Read-AzDevOpsParentPick -ParentType 'Epic' -Hierarchy $Hierarchy -ChildLabel 'Feature' -AreaPaths $areaPaths
     return $epicId
 }
 
@@ -2498,7 +2651,9 @@ function Invoke-AzDevOpsWorkItemCreate {
         [string] $AcceptanceCriteria,
         [Parameter(Mandatory)] [string] $Iteration,
         [Parameter(Mandatory)] [string] $Area,
-        [string] $Type = 'User Story'
+        [string] $Type = 'User Story',
+        [string[]]  $Tags,
+        [hashtable] $ExtraFields
     )
 
     $fields = @(
@@ -2508,6 +2663,23 @@ function Invoke-AzDevOpsWorkItemCreate {
 
     if ($StoryPoints -ge 0) {
         $fields += "Microsoft.VSTS.Scheduling.StoryPoints=$StoryPoints"
+    }
+
+    if ($Tags -and $Tags.Count -gt 0) {
+        $tagList = ($Tags | Where-Object { $_ } | ForEach-Object { [string]$_ }) -join '; '
+        if ($tagList) {
+            $fields += "System.Tags=$tagList"
+        }
+    }
+
+    if ($ExtraFields -and $ExtraFields.Count -gt 0) {
+        foreach ($key in $ExtraFields.Keys) {
+            $value = $ExtraFields[$key]
+            if ($null -eq $value) {
+                continue
+            }
+            $fields += "$key=$value"
+        }
     }
 
     $result = New-AzDevOpsWorkItem `
@@ -2598,18 +2770,116 @@ function Test-AzDevOpsCreateGate {
 }
 
 
-function Resolve-AzDevOpsIterationArea {
-    # Picker + env-var fallback shared by every az-New-AzDevOps* creator. For
-    # each kind: if the caller already passed a value, keep it; otherwise prompt
-    # via Read-AzDevOpsKindPick. Missing-after-pick prints the standard "Set
-    # `$env:AZ_* or run az-Sync-AzDevOpsCache" abort. Returns a result object
-    # with .Ok / .Iteration / .Area so callers can short-circuit with a single
-    # `if (-not $resolved.Ok) { return }`.
+function Read-AzDevOpsRequiredFields {
+    # Walks Resolve-AzDevOpsTypeRequiredFields output for the given type and
+    # returns a hashtable of <RefName> = <value> ready to feed
+    # Invoke-AzDevOpsWorkItemCreate -ExtraFields. Entries whose value is the
+    # literal 'prompt' (case-insensitive) trigger a Read-Host; any other value
+    # passes through unchanged. Empty input on a 'prompt' entry skips that field
+    # rather than sending an empty string to `az boards work-item create`.
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $result = @{}
+    if (-not (Get-Command Resolve-AzDevOpsTypeRequiredFields -ErrorAction SilentlyContinue)) {
+        return $result
+    }
+
+    $required = Resolve-AzDevOpsTypeRequiredFields -Type $Type
+    if ($null -eq $required -or $required.Count -eq 0) {
+        return $result
+    }
+
+    foreach ($refName in $required.Keys) {
+        $value = $required[$refName]
+        if ("$value".Trim().ToLower() -eq 'prompt') {
+            $answer = Read-Host "Enter $refName"
+            if ($answer) {
+                $result[$refName] = $answer
+            }
+        } else {
+            $result[$refName] = $value
+        }
+    }
+
+    return $result
+}
+
+
+function Resolve-AzDevOpsTypePriorityOrPrompt {
+    # Type override -> Read-AzDevOpsPriority fallback. Used by az-New-AzDevOps*
+    # creators to skip the prompt when the active project pins a DefaultPriority.
+    # -Previous flows the batch-loop "Enter to reuse" hint through when applicable.
     param(
-        [string] $Iteration,
-        [string] $Area
+        [Parameter(Mandatory)] [string] $Type,
+        [int] $Previous = -1
     )
 
+    if (Get-Command Resolve-AzDevOpsTypeDefaultPriority -ErrorAction SilentlyContinue) {
+        $default = Resolve-AzDevOpsTypeDefaultPriority -Type $Type
+        if ($null -ne $default) {
+            return [int]$default
+        }
+    }
+
+    $priority = Read-AzDevOpsPriority -Previous $Previous
+    return $priority
+}
+
+
+function Resolve-AzDevOpsTypeStoryPointsOrPrompt {
+    # Type override -> Read-AzDevOpsStoryPoints fallback. Same shape as
+    # Resolve-AzDevOpsTypePriorityOrPrompt; only meaningful for USER_STORY in
+    # default Agile / Scrum templates.
+    param(
+        [Parameter(Mandatory)] [string] $Type,
+        [int] $Previous = -1
+    )
+
+    if (Get-Command Resolve-AzDevOpsTypeDefaultStoryPoints -ErrorAction SilentlyContinue) {
+        $default = Resolve-AzDevOpsTypeDefaultStoryPoints -Type $Type
+        if ($null -ne $default) {
+            return [int]$default
+        }
+    }
+
+    $storyPoints = Read-AzDevOpsStoryPoints -Previous $Previous
+    return $storyPoints
+}
+
+
+function Resolve-AzDevOpsTypeTagsOrEmpty {
+    # Thin wrapper that hides the Get-Command guard so creators stay readable.
+    # Always returns a string[] (possibly empty).
+    param([Parameter(Mandatory)] [string] $Type)
+
+    if (-not (Get-Command Resolve-AzDevOpsTypeTags -ErrorAction SilentlyContinue)) {
+        return @()
+    }
+
+    $tags = @(Resolve-AzDevOpsTypeTags -Type $Type)
+    return $tags
+}
+
+
+function Resolve-AzDevOpsIterationArea {
+    # Picker + env-var fallback shared by every az-New-AzDevOps* creator. For
+    # each kind: if the caller already passed a value, keep it; otherwise consult
+    # the per-type project-map override (Resolve-AzDevOpsType{Area,Iteration})
+    # when -Type is set; finally fall back to Read-AzDevOpsKindPick. Missing-
+    # after-pick prints the standard "Set `$env:AZ_* or run az-Sync-AzDevOpsCache"
+    # abort. Returns a result object with .Ok / .Iteration / .Area so callers
+    # can short-circuit with a single `if (-not $resolved.Ok) { return }`.
+    param(
+        [string] $Iteration,
+        [string] $Area,
+        [string] $Type
+    )
+
+    if (-not $Iteration -and $Type) {
+        if (Get-Command Resolve-AzDevOpsTypeIteration -ErrorAction SilentlyContinue) {
+            $Iteration = Resolve-AzDevOpsTypeIteration -Type $Type
+        }
+    }
     if (-not $Iteration) {
         $Iteration = Read-AzDevOpsKindPick -Kind 'Iteration'
     }
@@ -2618,6 +2888,11 @@ function Resolve-AzDevOpsIterationArea {
         return [PSCustomObject]@{ Ok = $false; Iteration = $null; Area = $null }
     }
 
+    if (-not $Area -and $Type) {
+        if (Get-Command Resolve-AzDevOpsTypeArea -ErrorAction SilentlyContinue) {
+            $Area = Resolve-AzDevOpsTypeArea -Type $Type
+        }
+    }
     if (-not $Area) {
         $Area = Read-AzDevOpsKindPick -Kind 'Area'
     }
@@ -2731,11 +3006,11 @@ function az-New-AzDevOpsUserStory {
     }
 
     if ($Priority -lt 1 -or $Priority -gt 4) {
-        $Priority = Read-AzDevOpsPriority
+        $Priority = Resolve-AzDevOpsTypePriorityOrPrompt -Type 'USER_STORY'
     }
 
     if ($StoryPoints -lt 0) {
-        $StoryPoints = Read-AzDevOpsStoryPoints
+        $StoryPoints = Resolve-AzDevOpsTypeStoryPointsOrPrompt -Type 'USER_STORY'
     }
 
     if (-not $PSBoundParameters.ContainsKey('AcceptanceCriteria')) {
@@ -2743,15 +3018,18 @@ function az-New-AzDevOpsUserStory {
     }
 
     if ($FeatureId -lt 0) {
-        $FeatureId = Read-AzDevOpsFeaturePick -Hierarchy $hierarchy
+        $FeatureId = Read-AzDevOpsFeaturePick -Hierarchy $hierarchy -ChildType 'USER_STORY'
     }
 
-    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'USER_STORY'
     if (-not $resolved.Ok) {
         return
     }
     $Iteration = $resolved.Iteration
     $Area      = $resolved.Area
+
+    $tags        = Resolve-AzDevOpsTypeTagsOrEmpty   -Type 'USER_STORY'
+    $extraFields = Read-AzDevOpsRequiredFields       -Type 'USER_STORY'
 
     $createArgs = @{
         Title              = $Title
@@ -2761,6 +3039,8 @@ function az-New-AzDevOpsUserStory {
         AcceptanceCriteria = $AcceptanceCriteria
         Iteration          = $Iteration
         Area               = $Area
+        Tags               = $tags
+        ExtraFields        = $extraFields
     }
 
     $outcome = Invoke-AzDevOpsCreateAndLink `
@@ -2828,7 +3108,7 @@ function az-New-AzDevOpsFeature {
     }
 
     if ($Priority -lt 1 -or $Priority -gt 4) {
-        $Priority = Read-AzDevOpsPriority
+        $Priority = Resolve-AzDevOpsTypePriorityOrPrompt -Type 'FEATURE'
     }
 
     if (-not $PSBoundParameters.ContainsKey('AcceptanceCriteria')) {
@@ -2836,15 +3116,18 @@ function az-New-AzDevOpsFeature {
     }
 
     if ($ParentEpicId -lt 0) {
-        $ParentEpicId = Read-AzDevOpsEpicPick -Hierarchy $hierarchy
+        $ParentEpicId = Read-AzDevOpsEpicPick -Hierarchy $hierarchy -ChildType 'FEATURE'
     }
 
-    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'FEATURE'
     if (-not $resolved.Ok) {
         return
     }
     $Iteration = $resolved.Iteration
     $Area      = $resolved.Area
+
+    $tags        = Resolve-AzDevOpsTypeTagsOrEmpty -Type 'FEATURE'
+    $extraFields = Read-AzDevOpsRequiredFields     -Type 'FEATURE'
 
     $createArgs = @{
         Type               = 'Feature'
@@ -2854,6 +3137,8 @@ function az-New-AzDevOpsFeature {
         AcceptanceCriteria = $AcceptanceCriteria
         Iteration          = $Iteration
         Area               = $Area
+        Tags               = $tags
+        ExtraFields        = $extraFields
     }
 
     $outcome = Invoke-AzDevOpsCreateAndLink `
@@ -2968,12 +3253,14 @@ function az-New-AzDevOpsFeatureStories {
         return $createdIds
     }
 
-    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'USER_STORY'
     if (-not $resolved.Ok) {
         return $createdIds
     }
     $Iteration = $resolved.Iteration
     $Area      = $resolved.Area
+
+    $tags = Resolve-AzDevOpsTypeTagsOrEmpty -Type 'USER_STORY'
 
     Write-Host ""
     Write-Host "Batch-creating child User Stories under Feature $ParentId" -ForegroundColor Cyan
@@ -2997,8 +3284,9 @@ function az-New-AzDevOpsFeatureStories {
         }
 
         $acceptanceCriteria = Read-AzDevOpsAcceptanceCriteria
-        $priority           = Read-AzDevOpsPriority    -Previous $previousPriority
-        $storyPoints        = Read-AzDevOpsStoryPoints -Previous $previousStoryPoints
+        $priority           = Resolve-AzDevOpsTypePriorityOrPrompt    -Type 'USER_STORY' -Previous $previousPriority
+        $storyPoints        = Resolve-AzDevOpsTypeStoryPointsOrPrompt -Type 'USER_STORY' -Previous $previousStoryPoints
+        $extraFields        = Read-AzDevOpsRequiredFields             -Type 'USER_STORY'
 
         $createArgs = @{
             Title              = $title
@@ -3008,6 +3296,8 @@ function az-New-AzDevOpsFeatureStories {
             AcceptanceCriteria = $acceptanceCriteria
             Iteration          = $Iteration
             Area               = $Area
+            Tags               = $tags
+            ExtraFields        = $extraFields
         }
 
         $outcome = Invoke-AzDevOpsCreateAndLink `

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -62,3 +62,10 @@ if ($azdevops_workitems -ne $NULL) {
 } else {
     Write-Host "no azdevops_workitems.ps1"
 }
+
+$azdevops_projects = Get-Content "$path_to_bashcuts\powcuts_by_cli\azdevops_projects.ps1"
+if ($azdevops_projects -ne $NULL) {
+ . "$path_to_bashcuts\powcuts_by_cli\azdevops_projects.ps1"
+} else {
+    Write-Host "no azdevops_projects.ps1"
+}


### PR DESCRIPTION
## Summary

Closes #56. Wires per-type configuration in `$global:AzDevOpsProjectMap..Types.<TYPE>` through to the work-item creators so users stop re-picking Area / Iteration / Priority / Story Points / Tags / RequiredFields when switching projects, and so the parent picker filters to `ParentScope.AreaPaths`.

> ⚠️ **Depends on Phase A (#55, branch `claude/azure-workitems-operations-ItyQo`, commit `4d137dd`)** — Phase A is **not yet merged to main**. This branch was reset onto Phase A's tip and contains both Phase A's commit *and* this Phase B commit. Merge Phase A first; this PR will then show only the Phase B delta.

## What changes

| # | Change |
|---|---|
| 1 | `hierarchy.json` rows now carry `System.AreaPath` (WIQL + `ConvertFrom-AzDevOpsHierarchyItem`) so `ParentScope.AreaPaths` filtering works on first ship |
| 2 | `Resolve-AzDevOpsIterationArea -Type` consults `Resolve-AzDevOpsType{Area,Iteration}` before prompting; explicit `-Area`/`-Iteration` still win |
| 3 | `Invoke-AzDevOpsWorkItemCreate` gains `-Tags [string[]]` and `-ExtraFields [hashtable]` (System.Tags + RequiredFields pass-through) |
| 4 | `Read-AzDevOpsParentPick -AreaPaths` filters candidates by equal-or-sub-path match. Rows lacking `AreaPath` → silent no-op (+ `Write-Verbose`); narrowed-to-zero → yellow `(no Xs match ParentScope.AreaPaths…)` + return 0 |
| 5-6 | `Read-AzDevOpsFeaturePick` / `Read-AzDevOpsEpicPick` gain `-ChildType` (defaults `USER_STORY` / `FEATURE`) and look up `Resolve-AzDevOpsTypeParentScope` |
| 7-9 | `az-New-AzDevOpsUserStory` / `Feature` / `FeatureStories` honor `DefaultPriority`, `DefaultStoryPoints`, `Tags`, and `RequiredFields` (`'prompt'` values trigger `Read-Host`; literal values pass through) |
| 10-11 | `az-Confirm-AzDevOpsProjectMap` added as step 4 in `az-Connect-AzDevOps`; silent when map undefined, picker menu when map defined but no active project, hard fail when active project is missing `Org`/`Project` |

**Backward compatibility**: users without `$global:AzDevOpsProjectMap` defined see zero behavior change in any `az-New-AzDevOps*` command.

## Test plan

- [ ] `pwsh -NoProfile -Command "[Parser]::ParseFile('powcuts_by_cli/azdevops_workitems.ps1', [ref]\$null, [ref]\$null)"` reports zero errors (pwsh wasn't available in the dev sandbox — verify locally)
- [ ] `pwsh -NoProfile -Command "[Parser]::ParseFile('powcuts_by_cli/azdevops_projects.ps1', [ref]\$null, [ref]\$null)"` reports zero errors
- [ ] Brace + paren balance unchanged on both files (workitems 714/714 + 1037/1037, projects 104/104 + 149/149 — both diff 0)
- [ ] Fresh `pwsh -NoProfile` without `$global:AzDevOpsProjectMap` set → `az-New-AzDevOpsUserStory` prompts work exactly as today (Priority, StoryPoints, AC, Feature picker, area/iteration via `Read-AzDevOpsKindPick`)
- [ ] Define a 2-project map with per-type `Area`/`Iteration`/`Tags`/`DefaultPriority`/`DefaultStoryPoints`/`RequiredFields = @{ 'Custom.BusinessValue' = 'prompt' }`/`ParentScope.AreaPaths`; `az-Use-AzDevOpsProject ProjectA`; run `az-New-AzDevOpsUserStory` → prompts skip Priority + StoryPoints (defaulted), prompts `Custom.BusinessValue`, applies Tags, Feature picker shows only Features whose `AreaPath` matches `ParentScope.AreaPaths`
- [ ] `az-Connect-AzDevOps` with map+default → step 4 reports `OK Active project: ...`; without default → numbered prompt; with active project missing `Org` → `NOT READY - blocked at step 4`

https://claude.ai/code/session_01PgnQRCNH8gMeEEcoR9n6qu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgnQRCNH8gMeEEcoR9n6qu)_