### PR TITLE
feat(#56): multi-project Azure DevOps map + type-aware az-New-* defaults

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -3,7 +3,7 @@
 Visual reference for the Azure DevOps work-item shortcuts in `powcuts_by_cli/azdevops_workitems.ps1`. Each diagram covers one subsystem; the last diagram is a cross-cutting function-dependency map.
 
 - [1. High-level architecture](#1-high-level-architecture)
-- [2. `az-Connect-AzDevOps` — 6-step orchestrator](#2-az-connect-azdevops--6-step-orchestrator)
+- [2. `az-Connect-AzDevOps` — 7-step orchestrator](#2-az-connect-azdevops--7-step-orchestrator)
 - [3. `az-Test-AzDevOpsAuth` — silent diagnostic chain](#3-az-test-azdevopsauth--silent-diagnostic-chain)
 - [4. `az-Sync-AzDevOpsCache` — dataset fan-out](#4-az-sync-azdevopscache--dataset-fan-out)
 - [5. Cache consumers (`az-Get-/az-Open-AzDevOps{Assigned,Mentions}`)](#5-cache-consumers-az-get-az-open-azdevopsassignedmentions)
@@ -107,9 +107,9 @@ flowchart LR
 
 ---
 
-## 2. `az-Connect-AzDevOps` — 6-step orchestrator
+## 2. `az-Connect-AzDevOps` — 7-step orchestrator
 
-Thin orchestrator: a hard-coded array of step descriptors. Each step is a `Confirm-*` function that prints its own status and returns `{Ok, FailMessage}`. First failure short-circuits with `NOT READY`.
+Thin orchestrator: a hard-coded array of step descriptors. Each step is a `Confirm-*` function that prints its own status and returns `{Ok, FailMessage}`. First failure short-circuits with `NOT READY`. Step 4 (`az-Confirm-AzDevOpsProjectMap`) is opt-in: it returns `Ok=$true` immediately when `$global:AzDevOpsProjectMap` is not defined, so single-project users skip it transparently.
 
 ```mermaid
 flowchart TD
@@ -118,9 +118,10 @@ flowchart TD
     S1["Step 1 — az-Confirm-AzDevOpsCli<br/>uses Test-AzDevOpsCliPresent"]
     S2["Step 2 — az-Confirm-AzDevOpsExtension<br/>uses Test-AzDevOpsExtensionInstalled<br/>+ optional 'az extension add'"]
     S3["Step 3 — az-Confirm-AzDevOpsEnvVars<br/>uses Get-AzDevOpsMissingEnvVars"]
-    S4["Step 4 — az-Confirm-AzDevOpsLogin<br/>uses Test-AzDevOpsLoggedIn<br/>+ optional 'az login'"]
-    S5["Step 5 — az-Set-AzDevOpsDefaults<br/>'az devops configure --defaults'"]
-    S6["Step 6 — az-Confirm-AzDevOpsSmokeQuery<br/>uses Invoke-AzDevOpsSmokeQuery"]
+    S4["Step 4 — az-Confirm-AzDevOpsProjectMap<br/>opt-in $global:AzDevOpsProjectMap<br/>+ optional az-Use-AzDevOpsProject prompt"]
+    S5["Step 5 — az-Confirm-AzDevOpsLogin<br/>uses Test-AzDevOpsLoggedIn<br/>+ optional 'az login'"]
+    S6["Step 6 — az-Set-AzDevOpsDefaults<br/>'az devops configure --defaults'"]
+    S7["Step 7 — az-Confirm-AzDevOpsSmokeQuery<br/>uses Invoke-AzDevOpsSmokeQuery"]
 
     Ready([READY])
     NotReady([NOT READY — blocked at step N])
@@ -130,7 +131,8 @@ flowchart TD
     S3 -- Ok --> S4
     S4 -- Ok --> S5
     S5 -- Ok --> S6
-    S6 -- Ok --> Ready
+    S6 -- Ok --> S7
+    S7 -- Ok --> Ready
 
     S1 -- fail --> NotReady
     S2 -- fail --> NotReady
@@ -138,9 +140,10 @@ flowchart TD
     S4 -- fail --> NotReady
     S5 -- fail --> NotReady
     S6 -- fail --> NotReady
+    S7 -- fail --> NotReady
 
     classDef step fill:#1f3a5f,stroke:#4ea3ff,color:#fff
-    class S1,S2,S3,S4,S5,S6 step
+    class S1,S2,S3,S4,S5,S6,S7 step
 ```
 
 Helpers used by every step:
@@ -514,7 +517,7 @@ Shared private helpers (named in CLAUDE.md):
 
 ## 11. Function dependency map
 
-Public functions on the left, private helpers on the right. Helpers under "Shared scaffolding" exist specifically because their bodies were duplicated across the parallel `Get-/Open-` pairs and the parallel `Register-/Unregister-` pairs.
+Public functions on the left, private helpers on the right. Helpers under "Shared scaffolding" exist specifically because their bodies were duplicated across the parallel `Get-/Open-` pairs and the parallel `Register-/Unregister-` pairs. The "Multi-project resolver layer" cluster collects the opt-in `$global:AzDevOpsProjectMap` switcher (`az-Use-/Show-/Get-AzDevOpsProject(s)`) plus every `Resolve-AzDevOpsType*` helper consumed by the `az-New-*` creators; when no map is defined, all resolvers return `$null`/`-1`/`@{}` and the create paths fall through to today's prompt-driven flow.
 
 ```mermaid
 graph LR
@@ -541,10 +544,16 @@ graph LR
     NewSB(["az-New-AzDevOpsFeatureStories"]):::pub
     Find(["az-Find-AzDevOpsWorkItem"]):::pub
 
+    %% Multi-project switcher (azdevops_projects.ps1)
+    UseProj(["az-Use-AzDevOpsProject"]):::pub
+    ShowProj(["az-Show-AzDevOpsProject"]):::pub
+    GetProjs(["az-Get-AzDevOpsProjects"]):::pub
+
     %% Step helpers
     C1[az-Confirm-AzDevOpsCli]:::priv
     C2[az-Confirm-AzDevOpsExtension]:::priv
     C3[az-Confirm-AzDevOpsEnvVars]:::priv
+    CMap[az-Confirm-AzDevOpsProjectMap]:::priv
     C4[az-Confirm-AzDevOpsLogin]:::priv
     C5[az-Set-AzDevOpsDefaults]:::priv
     C6[az-Confirm-AzDevOpsSmokeQuery]:::priv
@@ -655,6 +664,26 @@ graph LR
     ResIA[Resolve-AzDevOpsIterationArea]:::priv
     CrLink[Invoke-AzDevOpsCreateAndLink]:::priv
 
+    %% Multi-project resolver layer (azdevops_projects.ps1 + Phase B wiring)
+    TypeKey[Get-AzDevOpsProjectTypeKey]:::priv
+    ActProj[Get-AzDevOpsActiveProject]:::priv
+    ActType[Get-AzDevOpsActiveTypeEntry]:::priv
+    Slug[Get-AzDevOpsProjectCacheSlug]:::priv
+    TypeStr[Get-AzDevOpsTypeStringProperty]:::priv
+    TypeInt[Get-AzDevOpsTypeIntegerDefault]:::priv
+    RArea[Resolve-AzDevOpsTypeArea]:::priv
+    RIter[Resolve-AzDevOpsTypeIteration]:::priv
+    RTags[Resolve-AzDevOpsTypeTags]:::priv
+    RPri[Resolve-AzDevOpsTypeDefaultPriority]:::priv
+    RPts[Resolve-AzDevOpsTypeDefaultStoryPoints]:::priv
+    RReq[Resolve-AzDevOpsTypeRequiredFields]:::priv
+    RScope[Resolve-AzDevOpsTypeParentScope]:::priv
+    RPriDef[Resolve-AzDevOpsPriorityWithDefault]:::priv
+    RPtsDef[Resolve-AzDevOpsStoryPointsWithDefault]:::priv
+    RReqVal[Resolve-AzDevOpsRequiredFieldValues]:::priv
+    ScopePaths[Get-AzDevOpsTypeParentScopeAreaPaths]:::priv
+    AreaMatch[Test-AzDevOpsAreaPathMatch]:::priv
+
     %% I/O sinks
     Az[(az CLI)]:::io
     FS[(cache files)]:::io
@@ -662,11 +691,14 @@ graph LR
     Connect --> C1 --> TCli
     Connect --> C2 --> TExt
     Connect --> C3 --> TEnv
+    Connect --> CMap
     Connect --> C4 --> TLog
     Connect --> C5
     Connect --> C6 --> TSmoke
-    C1 & C2 & C3 & C4 & C5 & C6 --> StepRes
+    C1 & C2 & C3 & CMap & C4 & C5 & C6 --> StepRes
     C2 & C4 --> YN
+    CMap --> ActProj
+    CMap --> UseProj
 
     TestAuth --> TCli
     TestAuth --> TEnv
@@ -824,6 +856,56 @@ graph LR
     %% Reusable-prompt hint
     Pri --> ReuseHint
     Pts --> ReuseHint
+
+    %% Multi-project switcher fan-out
+    UseProj --> GetProjs
+    UseProj --> Az
+    ShowProj --> ActProj
+    GetProjs --> ActProj
+    Paths --> Slug
+    ActType --> ActProj
+    ActType --> TypeKey
+
+    %% Resolver layer (shared lookup chain)
+    TypeStr --> ActType
+    TypeStr --> ActProj
+    TypeInt --> ActType
+    RArea --> TypeStr
+    RIter --> TypeStr
+    RTags --> ActType
+    RTags --> ActProj
+    RPri --> TypeInt
+    RPts --> TypeInt
+    RReq --> ActType
+    RScope --> ActType
+
+    %% Type-aware creator wiring (Phase B)
+    ResIA --> RArea
+    ResIA --> RIter
+    RPriDef --> RPri
+    RPriDef --> Pri
+    RPtsDef --> RPts
+    RPtsDef --> Pts
+    RReqVal --> RReq
+
+    NewS --> RPriDef
+    NewS --> RPtsDef
+    NewS --> RTags
+    NewS --> RReqVal
+    NewF --> RPriDef
+    NewF --> RTags
+    NewF --> RReqVal
+    NewSB --> RPri
+    NewSB --> RPts
+    NewSB --> RTags
+    NewSB --> RReq
+
+    InvCreate -.System.Tags + ExtraFields.-> NewWI
+
+    %% ParentScope.AreaPaths filter (Phase B)
+    PFeat --> ScopePaths --> RScope
+    PEpic --> ScopePaths
+    PParent --> AreaMatch
 ```
 
 ---

--- a/powcuts_by_cli/azdevops_projects.ps1
+++ b/powcuts_by_cli/azdevops_projects.ps1
@@ -158,12 +158,17 @@ function Get-AzDevOpsProjectCacheSlug {
     # layer can namespace assigned.json / mentions.json / hierarchy.json
     # under ~/.bashcuts-cache/azure-devops/<slug>/. Returns '' when no
     # project is active so the legacy single-project cache path stays put.
+    #
+    # The regex strips dots so a hostile project name like '..' cannot
+    # escape the cache root via Join-Path; an entirely-stripped name
+    # collapses to '' which also falls back to the legacy path rather
+    # than the silently-attacker-controlled one.
     if (-not $global:AzDevOpsActiveProject) {
         return ''
     }
 
     $raw  = "$global:AzDevOpsActiveProject"
-    $safe = ($raw -replace '[^A-Za-z0-9._-]+', '-').Trim('-')
+    $safe = ($raw -replace '[^A-Za-z0-9_-]+', '-').Trim('-')
     return $safe
 }
 
@@ -172,23 +177,73 @@ function Get-AzDevOpsProjectCacheSlug {
 # Per-type defaults resolvers (consumed by Phase B creators)
 # ---------------------------------------------------------------------------
 
+function Get-AzDevOpsTypeStringProperty {
+    # Shared "type override -> project default -> null" walk used by every
+    # per-type Resolve-AzDevOpsType<X> helper that returns a string (Area,
+    # Iteration). Extracted so the public Resolve-* layer stays one-liners
+    # and the lookup chain lives in one place (CLAUDE.md extract-repeated
+    # -branches rule).
+    param(
+        [Parameter(Mandatory)] [string] $Type,
+        [Parameter(Mandatory)] [string] $Property
+    )
+
+    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
+    if ($entry -and $entry.$Property) {
+        $typeValue = [string]$entry.$Property
+        return $typeValue
+    }
+
+    $project = Get-AzDevOpsActiveProject
+    if ($project -and $project.$Property) {
+        $projectValue = [string]$project.$Property
+        return $projectValue
+    }
+
+    return $null
+}
+
+
+function Get-AzDevOpsTypeIntegerDefault {
+    # Shared "TryParse + range-clamp -> sentinel -1" walk used by every
+    # integer-default resolver (DefaultPriority, DefaultStoryPoints). The
+    # caller picks the valid range; out-of-range values collapse to -1
+    # so the consumer treats them as "no override; fall through to prompt".
+    param(
+        [Parameter(Mandatory)] [string] $Type,
+        [Parameter(Mandatory)] [string] $Property,
+        [int] $Min = 0,
+        [int] $Max = [int]::MaxValue
+    )
+
+    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
+    if ($null -eq $entry) {
+        return -1
+    }
+    if ($null -eq $entry.$Property) {
+        return -1
+    }
+
+    $value = 0
+    if (-not [int]::TryParse("$($entry.$Property)", [ref]$value)) {
+        return -1
+    }
+    if ($value -lt $Min -or $value -gt $Max) {
+        return -1
+    }
+
+    return $value
+}
+
+
 function Resolve-AzDevOpsTypeArea {
     # Returns Types.<TYPE>.Area when configured, falling back to the
     # project-level Area, then $null. Phase B's Resolve-AzDevOpsIterationArea
     # treats $null as "no map override; keep current env-var + prompt flow".
     param([string] $Type)
 
-    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
-    if ($entry -and $entry.Area) {
-        return [string]$entry.Area
-    }
-
-    $project = Get-AzDevOpsActiveProject
-    if ($project -and $project.Area) {
-        return [string]$project.Area
-    }
-
-    return $null
+    $value = Get-AzDevOpsTypeStringProperty -Type $Type -Property 'Area'
+    return $value
 }
 
 
@@ -196,17 +251,8 @@ function Resolve-AzDevOpsTypeIteration {
     # Mirror of Resolve-AzDevOpsTypeArea for the iteration path.
     param([string] $Type)
 
-    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
-    if ($entry -and $entry.Iteration) {
-        return [string]$entry.Iteration
-    }
-
-    $project = Get-AzDevOpsActiveProject
-    if ($project -and $project.Iteration) {
-        return [string]$project.Iteration
-    }
-
-    return $null
+    $value = Get-AzDevOpsTypeStringProperty -Type $Type -Property 'Iteration'
+    return $value
 }
 
 
@@ -248,22 +294,7 @@ function Resolve-AzDevOpsTypeDefaultPriority {
     # "fall through to Read-AzDevOpsPriority".
     param([string] $Type)
 
-    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
-    if ($null -eq $entry) {
-        return -1
-    }
-    if ($null -eq $entry.DefaultPriority) {
-        return -1
-    }
-
-    $value = 0
-    if (-not [int]::TryParse("$($entry.DefaultPriority)", [ref]$value)) {
-        return -1
-    }
-    if ($value -lt 1 -or $value -gt 4) {
-        return -1
-    }
-
+    $value = Get-AzDevOpsTypeIntegerDefault -Type $Type -Property 'DefaultPriority' -Min 1 -Max 4
     return $value
 }
 
@@ -274,22 +305,7 @@ function Resolve-AzDevOpsTypeDefaultStoryPoints {
     # to Read-AzDevOpsStoryPoints".
     param([string] $Type)
 
-    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
-    if ($null -eq $entry) {
-        return -1
-    }
-    if ($null -eq $entry.DefaultStoryPoints) {
-        return -1
-    }
-
-    $value = 0
-    if (-not [int]::TryParse("$($entry.DefaultStoryPoints)", [ref]$value)) {
-        return -1
-    }
-    if ($value -lt 0) {
-        return -1
-    }
-
+    $value = Get-AzDevOpsTypeIntegerDefault -Type $Type -Property 'DefaultStoryPoints' -Min 0
     return $value
 }
 
@@ -419,10 +435,19 @@ function az-Use-AzDevOpsProject {
     $global:AzDevOpsActiveProject = $Name
 
     if (-not $Quiet) {
+        $configureFailed = $false
         if ($env:AZ_DEVOPS_ORG -and $env:AZ_PROJECT) {
-            $null = az devops configure --defaults "organization=$env:AZ_DEVOPS_ORG" "project=$env:AZ_PROJECT" 2>&1
+            $configureOutput = az devops configure --defaults "organization=$env:AZ_DEVOPS_ORG" "project=$env:AZ_PROJECT" 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                $configureFailed = $true
+                Write-Host "az devops configure --defaults failed for project '$Name'" -ForegroundColor Red
+                Write-Host "  $configureOutput" -ForegroundColor Red
+            }
         }
-        Write-Host "Active Azure DevOps project: $Name (org=$env:AZ_DEVOPS_ORG project=$env:AZ_PROJECT)" -ForegroundColor Green
+
+        if (-not $configureFailed) {
+            Write-Host "Active Azure DevOps project: $Name (org=$env:AZ_DEVOPS_ORG project=$env:AZ_PROJECT)" -ForegroundColor Green
+        }
     }
 }
 

--- a/powcuts_by_cli/azdevops_projects.ps1
+++ b/powcuts_by_cli/azdevops_projects.ps1
@@ -1,0 +1,439 @@
+# ============================================================================
+# Azure DevOps Multi-Project Support (Phase A)
+# ============================================================================
+#
+# Opt-in switcher + per-type defaults resolver layer that sits in front of
+# every az-New-AzDevOps* creator and the cache layer in azdevops_workitems.ps1.
+#
+# When $global:AzDevOpsProjectMap is undefined, every function in this file is
+# a no-op (Resolve-* helpers return $null / empty, the cache slug is empty,
+# the switcher's auto-hydrate block does nothing). All existing single-project
+# users see zero behavior change.
+#
+# Map shape (set in $profile):
+#
+#   $global:AzDevOpsProjectMap = @{
+#       ProjectABC = @{
+#           Org       = 'https://dev.azure.com/contoso'
+#           Project   = 'Project ABC'
+#           Email     = 'me@contoso.com'
+#           Area      = 'Project ABC\Portfolio'
+#           Iteration = 'Project ABC\Sprint 42'
+#           Tags      = @('abc-team')
+#           Types     = @{
+#               EPIC = @{
+#                   Area        = 'Project ABC\Portfolio'
+#                   ParentScope = @{ AreaPaths = @('Project ABC\Portfolio') }
+#               }
+#               FEATURE = @{
+#                   Area            = 'Project ABC\Portfolio\R&D'
+#                   DefaultPriority = 2
+#                   ParentScope     = @{ AreaPaths = @('Project ABC\Portfolio') }
+#               }
+#               USER_STORY = @{
+#                   Area               = 'Project ABC\Teams\Platform'
+#                   DefaultPriority    = 3
+#                   DefaultStoryPoints = 3
+#                   Tags               = @('platform')
+#                   RequiredFields     = @{ 'Custom.ChangeReason' = 'prompt' }
+#                   ParentScope        = @{ AreaPaths = @('Project ABC\Portfolio\R&D') }
+#               }
+#           }
+#       }
+#
+#       ProjectXYZ = @{ Org = '...'; Project = 'Project XYZ'; ... }
+#   }
+#
+#   $global:AzDevOpsDefaultProject = 'ProjectABC'   # optional auto-hydrate
+#
+# Type keys are normalized; 'EPIC' / 'Epic' / 'epic' / 'USER_STORY' /
+# 'UserStory' / 'User Story' / 'FEATURE' / 'Feature' all refer to the same
+# entry. Use whichever you prefer when building the map.
+#
+# Public functions:
+#   az-Use-AzDevOpsProject   - activate a project; hydrates $env:AZ_* and (by
+#                              default) runs `az devops configure --defaults`
+#   az-Show-AzDevOpsProject  - print the currently active project + hydrated
+#                              env vars (no I/O when no map is defined)
+#   az-Get-AzDevOpsProjects  - return the project keys from the map
+#
+# Internal resolver layer consumed by Phase B creators:
+#   Resolve-AzDevOpsTypeArea
+#   Resolve-AzDevOpsTypeIteration
+#   Resolve-AzDevOpsTypeTags
+#   Resolve-AzDevOpsTypeDefaultPriority
+#   Resolve-AzDevOpsTypeDefaultStoryPoints
+#   Resolve-AzDevOpsTypeRequiredFields
+#   Resolve-AzDevOpsTypeParentScope
+#
+# Cache namespacing:
+#   Get-AzDevOpsProjectCacheSlug - returns '' when no project is active so
+#                                  the legacy cache path stays put; otherwise
+#                                  returns a filesystem-safe slug used as a
+#                                  subdirectory under ~/.bashcuts-cache/
+#                                  azure-devops/<slug>/.
+# ============================================================================
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsProjectTypeKey {
+    # Normalizes the many spellings of a work-item type into one of the
+    # three canonical map keys: 'EPIC', 'FEATURE', 'USER_STORY'. Returns
+    # the input unchanged when it doesn't match a known synonym so the
+    # caller can still look up exotic types verbatim (BUG, TASK, etc.).
+    param([string] $Type)
+
+    if (-not $Type) {
+        return ''
+    }
+
+    $normalized = ($Type -replace '\s+', '').ToUpperInvariant()
+
+    switch ($normalized) {
+        'EPIC' {
+            return 'EPIC'
+        }
+
+        'FEATURE' {
+            return 'FEATURE'
+        }
+
+        'USERSTORY' {
+            return 'USER_STORY'
+        }
+
+        'USER_STORY' {
+            return 'USER_STORY'
+        }
+
+        default {
+            return $Type
+        }
+    }
+}
+
+
+function Get-AzDevOpsActiveProject {
+    # Returns the active project entry (hashtable) from $global:AzDevOpsProjectMap,
+    # keyed by $global:AzDevOpsActiveProject. Returns $null when no map is
+    # defined or no project is currently active - callers treat $null as
+    # "fall through to env-var / prompt behavior".
+    if (-not $global:AzDevOpsProjectMap) {
+        return $null
+    }
+    if (-not $global:AzDevOpsActiveProject) {
+        return $null
+    }
+
+    $entry = $global:AzDevOpsProjectMap[$global:AzDevOpsActiveProject]
+    return $entry
+}
+
+
+function Get-AzDevOpsActiveTypeEntry {
+    # Returns the Types.<TYPE> hashtable for the active project, or $null
+    # when no map is defined, no project is active, the active project has
+    # no Types block, or the requested type isn't in it.
+    param([string] $Type)
+
+    $project = Get-AzDevOpsActiveProject
+    if ($null -eq $project) {
+        return $null
+    }
+    if (-not $project.Types) {
+        return $null
+    }
+
+    $key   = Get-AzDevOpsProjectTypeKey -Type $Type
+    $entry = $project.Types[$key]
+    return $entry
+}
+
+
+function Get-AzDevOpsProjectCacheSlug {
+    # Returns a filesystem-safe slug for the active project so the cache
+    # layer can namespace assigned.json / mentions.json / hierarchy.json
+    # under ~/.bashcuts-cache/azure-devops/<slug>/. Returns '' when no
+    # project is active so the legacy single-project cache path stays put.
+    if (-not $global:AzDevOpsActiveProject) {
+        return ''
+    }
+
+    $raw  = "$global:AzDevOpsActiveProject"
+    $safe = ($raw -replace '[^A-Za-z0-9._-]+', '-').Trim('-')
+    return $safe
+}
+
+
+# ---------------------------------------------------------------------------
+# Per-type defaults resolvers (consumed by Phase B creators)
+# ---------------------------------------------------------------------------
+
+function Resolve-AzDevOpsTypeArea {
+    # Returns Types.<TYPE>.Area when configured, falling back to the
+    # project-level Area, then $null. Phase B's Resolve-AzDevOpsIterationArea
+    # treats $null as "no map override; keep current env-var + prompt flow".
+    param([string] $Type)
+
+    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
+    if ($entry -and $entry.Area) {
+        return [string]$entry.Area
+    }
+
+    $project = Get-AzDevOpsActiveProject
+    if ($project -and $project.Area) {
+        return [string]$project.Area
+    }
+
+    return $null
+}
+
+
+function Resolve-AzDevOpsTypeIteration {
+    # Mirror of Resolve-AzDevOpsTypeArea for the iteration path.
+    param([string] $Type)
+
+    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
+    if ($entry -and $entry.Iteration) {
+        return [string]$entry.Iteration
+    }
+
+    $project = Get-AzDevOpsActiveProject
+    if ($project -and $project.Iteration) {
+        return [string]$project.Iteration
+    }
+
+    return $null
+}
+
+
+function Resolve-AzDevOpsTypeTags {
+    # Merges project-level Tags with Types.<TYPE>.Tags, deduplicating
+    # case-insensitively. Returns a [string[]] (possibly empty) so callers
+    # can `if ($tags.Count -gt 0)` without null guards.
+    param([string] $Type)
+
+    $merged = New-Object System.Collections.Generic.List[string]
+    $seen   = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+
+    $project = Get-AzDevOpsActiveProject
+    if ($project -and $project.Tags) {
+        foreach ($tag in @($project.Tags)) {
+            if ($tag -and $seen.Add($tag)) {
+                $merged.Add($tag)
+            }
+        }
+    }
+
+    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
+    if ($entry -and $entry.Tags) {
+        foreach ($tag in @($entry.Tags)) {
+            if ($tag -and $seen.Add($tag)) {
+                $merged.Add($tag)
+            }
+        }
+    }
+
+    $tags = [string[]]$merged.ToArray()
+    return ,$tags
+}
+
+
+function Resolve-AzDevOpsTypeDefaultPriority {
+    # Returns the configured default 1-4 priority for the given type, or -1
+    # when no map / no override / out-of-range. Callers interpret -1 as
+    # "fall through to Read-AzDevOpsPriority".
+    param([string] $Type)
+
+    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
+    if ($null -eq $entry) {
+        return -1
+    }
+    if ($null -eq $entry.DefaultPriority) {
+        return -1
+    }
+
+    $value = 0
+    if (-not [int]::TryParse("$($entry.DefaultPriority)", [ref]$value)) {
+        return -1
+    }
+    if ($value -lt 1 -or $value -gt 4) {
+        return -1
+    }
+
+    return $value
+}
+
+
+function Resolve-AzDevOpsTypeDefaultStoryPoints {
+    # Returns the configured default non-negative story-points for the type,
+    # or -1 when no map / no override. Callers interpret -1 as "fall through
+    # to Read-AzDevOpsStoryPoints".
+    param([string] $Type)
+
+    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
+    if ($null -eq $entry) {
+        return -1
+    }
+    if ($null -eq $entry.DefaultStoryPoints) {
+        return -1
+    }
+
+    $value = 0
+    if (-not [int]::TryParse("$($entry.DefaultStoryPoints)", [ref]$value)) {
+        return -1
+    }
+    if ($value -lt 0) {
+        return -1
+    }
+
+    return $value
+}
+
+
+function Resolve-AzDevOpsTypeRequiredFields {
+    # Returns the Types.<TYPE>.RequiredFields hashtable (RefName -> value or
+    # the literal string 'prompt'). Always returns a hashtable so callers can
+    # iterate without null guards; empty when no override / no map.
+    param([string] $Type)
+
+    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
+    if ($null -eq $entry) {
+        return @{}
+    }
+    if ($null -eq $entry.RequiredFields) {
+        return @{}
+    }
+
+    $fields = @{}
+    foreach ($key in $entry.RequiredFields.Keys) {
+        $fields[$key] = $entry.RequiredFields[$key]
+    }
+    return $fields
+}
+
+
+function Resolve-AzDevOpsTypeParentScope {
+    # Returns Types.<TYPE>.ParentScope or $null. Phase B's Feature/Epic
+    # pickers read .AreaPaths off the returned hashtable to filter the
+    # candidate list to the correct area.
+    param([string] $Type)
+
+    $entry = Get-AzDevOpsActiveTypeEntry -Type $Type
+    if ($null -eq $entry) {
+        return $null
+    }
+    if ($null -eq $entry.ParentScope) {
+        return $null
+    }
+
+    return $entry.ParentScope
+}
+
+
+# ---------------------------------------------------------------------------
+# Public switcher commands
+# ---------------------------------------------------------------------------
+
+function az-Get-AzDevOpsProjects {
+    # Returns the project keys from $global:AzDevOpsProjectMap as [string[]],
+    # alphabetized. Returns an empty array when no map is defined so callers
+    # can `foreach` without guards.
+    if (-not $global:AzDevOpsProjectMap) {
+        $empty = [string[]]@()
+        return ,$empty
+    }
+
+    $names = @($global:AzDevOpsProjectMap.Keys | Sort-Object)
+    $arr   = [string[]]$names
+    return ,$arr
+}
+
+
+function az-Show-AzDevOpsProject {
+    # Prints the currently active project plus the hydrated $env:AZ_* vars.
+    # When no map is defined, prints '(none)' and the existing env vars so
+    # the command stays useful in single-project setups.
+    Write-Host ''
+    Write-Host 'Azure DevOps - active project' -ForegroundColor Cyan
+    Write-Host '-----------------------------' -ForegroundColor Cyan
+
+    if (-not $global:AzDevOpsProjectMap) {
+        Write-Host '  $global:AzDevOpsProjectMap : (none - single-project mode)' -ForegroundColor Yellow
+    } else {
+        $name = if ($global:AzDevOpsActiveProject) {
+            $global:AzDevOpsActiveProject
+        } else {
+            '(none)'
+        }
+        Write-Host "  Active project : $name"
+    }
+
+    Write-Host "  AZ_DEVOPS_ORG  : $env:AZ_DEVOPS_ORG"
+    Write-Host "  AZ_PROJECT     : $env:AZ_PROJECT"
+    Write-Host "  AZ_USER_EMAIL  : $env:AZ_USER_EMAIL"
+    Write-Host "  AZ_AREA        : $env:AZ_AREA"
+    Write-Host "  AZ_ITERATION   : $env:AZ_ITERATION"
+}
+
+
+function az-Use-AzDevOpsProject {
+    # Switches the active project. Reads $global:AzDevOpsProjectMap[$Name],
+    # hydrates $env:AZ_DEVOPS_ORG / AZ_PROJECT / AZ_USER_EMAIL / AZ_AREA /
+    # AZ_ITERATION from the entry's flat keys (each is optional - missing
+    # ones leave the existing env var alone), sets $global:AzDevOpsActiveProject,
+    # and (unless -Quiet) runs `az devops configure --defaults` so the CLI
+    # tracks the new project.
+    #
+    # -Quiet suppresses both the Write-Host status line and the
+    # `az devops configure` side effect; used by the auto-hydrate block
+    # below so opening a new terminal stays silent.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [switch] $Quiet
+    )
+
+    if (-not $global:AzDevOpsProjectMap) {
+        Write-Host "az-Use-AzDevOpsProject aborted - `$global:AzDevOpsProjectMap is not defined." -ForegroundColor Red
+        return
+    }
+
+    if (-not $global:AzDevOpsProjectMap.ContainsKey($Name)) {
+        $known = (az-Get-AzDevOpsProjects) -join ', '
+        Write-Host "az-Use-AzDevOpsProject aborted - '$Name' not in map. Known projects: $known" -ForegroundColor Red
+        return
+    }
+
+    $entry = $global:AzDevOpsProjectMap[$Name]
+
+    if ($entry.Org)       { $env:AZ_DEVOPS_ORG = [string]$entry.Org }
+    if ($entry.Project)   { $env:AZ_PROJECT    = [string]$entry.Project }
+    if ($entry.Email)     { $env:AZ_USER_EMAIL = [string]$entry.Email }
+    if ($entry.Area)      { $env:AZ_AREA       = [string]$entry.Area }
+    if ($entry.Iteration) { $env:AZ_ITERATION  = [string]$entry.Iteration }
+
+    $global:AzDevOpsActiveProject = $Name
+
+    if (-not $Quiet) {
+        if ($env:AZ_DEVOPS_ORG -and $env:AZ_PROJECT) {
+            $null = az devops configure --defaults "organization=$env:AZ_DEVOPS_ORG" "project=$env:AZ_PROJECT" 2>&1
+        }
+        Write-Host "Active Azure DevOps project: $Name (org=$env:AZ_DEVOPS_ORG project=$env:AZ_PROJECT)" -ForegroundColor Green
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Auto-hydrate at shell startup
+# ---------------------------------------------------------------------------
+# Silent by design - profile sourcing should not print noise. Users who want
+# explicit feedback can run `az-Show-AzDevOpsProject` after.
+if ($global:AzDevOpsProjectMap -and $global:AzDevOpsDefaultProject -and -not $global:AzDevOpsActiveProject) {
+    if ($global:AzDevOpsProjectMap.ContainsKey($global:AzDevOpsDefaultProject)) {
+        az-Use-AzDevOpsProject -Name $global:AzDevOpsDefaultProject -Quiet
+    }
+}

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -17,9 +17,11 @@
 #   az-Confirm-AzDevOpsCli              - step 1 (CLI on PATH + version echo)
 #   az-Confirm-AzDevOpsExtension        - step 2 (azure-devops extension; offers install)
 #   az-Confirm-AzDevOpsEnvVars          - step 3 (required $profile env vars set)
-#   az-Confirm-AzDevOpsLogin            - step 4 (az login session; offers login)
-#   az-Set-AzDevOpsDefaults             - step 5 (az devops configure --defaults)
-#   az-Confirm-AzDevOpsSmokeQuery       - step 6 (az boards query smoke test)
+#   az-Confirm-AzDevOpsProjectMap       - step 4 ($global:AzDevOpsProjectMap;
+#                                              opt-in, no-op when unset)
+#   az-Confirm-AzDevOpsLogin            - step 5 (az login session; offers login)
+#   az-Set-AzDevOpsDefaults             - step 6 (az devops configure --defaults)
+#   az-Confirm-AzDevOpsSmokeQuery       - step 7 (az boards query smoke test)
 #
 # Silent diagnostic helpers (pure checks, no I/O — used by az-Test-AzDevOpsAuth):
 #   Test-AzDevOpsCliPresent          - is the `az` CLI on PATH?
@@ -201,6 +203,71 @@ function az-Confirm-AzDevOpsEnvVars {
 }
 
 
+function az-Confirm-AzDevOpsProjectMap {
+    # Project-map step in the az-Connect-AzDevOps orchestrator. The map is
+    # opt-in, so the default verdict when no map is defined is Ok=$true with
+    # an informational status line.
+    #
+    # When the map is defined:
+    #   - $global:AzDevOpsActiveProject set + active entry has Org + Project
+    #     non-empty: Ok=$true
+    #   - $global:AzDevOpsDefaultProject set but ActiveProject unset: hydrate
+    #     via az-Use-AzDevOpsProject -Quiet, then verify Org + Project keys
+    #   - Map defined but neither default nor active set: prompt the user to
+    #     pick one (numbered menu) and call az-Use-AzDevOpsProject -Quiet on
+    #     the choice
+    #   - Map defined but the active project entry is missing Org or Project:
+    #     Ok=$false with a clear FailMessage
+    if (-not $global:AzDevOpsProjectMap) {
+        Write-Host "  -  No `$global:AzDevOpsProjectMap defined (single-project mode)" -ForegroundColor DarkGray
+        return New-AzDevOpsStepResult -Ok $true
+    }
+
+    if (-not $global:AzDevOpsActiveProject -and $global:AzDevOpsDefaultProject) {
+        if ($global:AzDevOpsProjectMap.ContainsKey($global:AzDevOpsDefaultProject)) {
+            az-Use-AzDevOpsProject -Name $global:AzDevOpsDefaultProject -Quiet
+        }
+    }
+
+    if (-not $global:AzDevOpsActiveProject) {
+        $names = az-Get-AzDevOpsProjects
+        if (-not $names -or $names.Count -eq 0) {
+            return New-AzDevOpsStepResult -Ok $false -FailMessage '$global:AzDevOpsProjectMap is empty'
+        }
+
+        Write-Host '  ?  No active Azure DevOps project. Pick one:' -ForegroundColor Yellow
+        for ($i = 0; $i -lt $names.Count; $i++) {
+            Write-Host ("    {0}. {1}" -f ($i + 1), $names[$i])
+        }
+
+        $idx = 0
+        while ($true) {
+            $resp = Read-Host "    Pick 1..$($names.Count)"
+            if ([int]::TryParse($resp, [ref]$idx) -and $idx -ge 1 -and $idx -le $names.Count) {
+                break
+            }
+            Write-Host "    Please enter a number between 1 and $($names.Count)." -ForegroundColor Yellow
+        }
+
+        az-Use-AzDevOpsProject -Name $names[$idx - 1] -Quiet
+    }
+
+    $active = Get-AzDevOpsActiveProject
+    if ($null -eq $active) {
+        return New-AzDevOpsStepResult -Ok $false -FailMessage "active project '$global:AzDevOpsActiveProject' not found in map"
+    }
+    if (-not $active.Org) {
+        return New-AzDevOpsStepResult -Ok $false -FailMessage "active project '$global:AzDevOpsActiveProject' is missing required key 'Org'"
+    }
+    if (-not $active.Project) {
+        return New-AzDevOpsStepResult -Ok $false -FailMessage "active project '$global:AzDevOpsActiveProject' is missing required key 'Project'"
+    }
+
+    Write-Host "  OK  Active project: $global:AzDevOpsActiveProject (org=$($active.Org) project=$($active.Project))" -ForegroundColor Green
+    return New-AzDevOpsStepResult -Ok $true
+}
+
+
 function az-Confirm-AzDevOpsLogin {
     if (-not (Test-AzDevOpsLoggedIn)) {
         Write-Host "  !  No active az login session" -ForegroundColor Yellow
@@ -261,9 +328,10 @@ function az-Connect-AzDevOps {
         @{ Num = 1; Name = 'Azure CLI';                     Action = { az-Confirm-AzDevOpsCli } },
         @{ Num = 2; Name = 'azure-devops extension';        Action = { az-Confirm-AzDevOpsExtension } },
         @{ Num = 3; Name = 'Profile environment variables'; Action = { az-Confirm-AzDevOpsEnvVars } },
-        @{ Num = 4; Name = 'Azure login session';           Action = { az-Confirm-AzDevOpsLogin } },
-        @{ Num = 5; Name = 'Configure az devops defaults';  Action = { az-Set-AzDevOpsDefaults } },
-        @{ Num = 6; Name = 'Smoke test (az boards query)';  Action = { az-Confirm-AzDevOpsSmokeQuery } }
+        @{ Num = 4; Name = 'Azure DevOps project map';      Action = { az-Confirm-AzDevOpsProjectMap } },
+        @{ Num = 5; Name = 'Azure login session';           Action = { az-Confirm-AzDevOpsLogin } },
+        @{ Num = 6; Name = 'Configure az devops defaults';  Action = { az-Set-AzDevOpsDefaults } },
+        @{ Num = 7; Name = 'Smoke test (az boards query)';  Action = { az-Confirm-AzDevOpsSmokeQuery } }
     )
 
     foreach ($step in $steps) {
@@ -304,7 +372,25 @@ function az-Connect-AzDevOps {
 # ---------------------------------------------------------------------------
 
 function Get-AzDevOpsCachePaths {
-    $cacheDir = Join-Path (Join-Path $HOME '.bashcuts-cache') 'azure-devops'
+    # When $global:AzDevOpsProjectMap is in play, the cache splits into
+    # per-project subdirs under ~/.bashcuts-cache/azure-devops/<slug>/ so
+    # switching projects loads the right assigned/mentions/hierarchy set.
+    # Get-AzDevOpsProjectCacheSlug returns '' for single-project users so
+    # the legacy path stays put.
+    $base = Join-Path (Join-Path $HOME '.bashcuts-cache') 'azure-devops'
+
+    $slug = if (Get-Command Get-AzDevOpsProjectCacheSlug -ErrorAction SilentlyContinue) {
+        Get-AzDevOpsProjectCacheSlug
+    } else {
+        ''
+    }
+
+    $cacheDir = if ($slug) {
+        Join-Path $base $slug
+    } else {
+        $base
+    }
+
     return [PSCustomObject]@{
         Dir        = $cacheDir
         Assigned   = Join-Path $cacheDir 'assigned.json'
@@ -435,7 +521,11 @@ function Get-AzDevOpsSyncDatasets {
     # Project scope is supplied by --project on the az invocation
     # (Invoke-AzDevOpsAzJson injects it from $env:AZ_PROJECT), so the WIQL
     # itself no longer needs a [System.TeamProject] = @Project clause.
-    $hierarchyWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.Parent] From WorkItems Where [System.WorkItemType] IN GROUP 'Microsoft.EpicCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.FeatureCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory'"
+    # [System.AreaPath] is included so the Phase B parent picker can filter
+    # candidates against $global:AzDevOpsProjectMap..Types..ParentScope.AreaPaths.
+    # Older caches written without AreaPath stay valid - the filter is a
+    # silent no-op when the field is missing on a row.
+    $hierarchyWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.WorkItemType] IN GROUP 'Microsoft.EpicCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.FeatureCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory'"
 
     $rowCounter  = { param($parsed) @($parsed).Count }
     $treeCounter = { param($parsed) Measure-AzDevOpsClassificationNodes -Node $parsed }
@@ -1397,12 +1487,19 @@ function ConvertFrom-AzDevOpsHierarchyItem {
         [int]$Raw.id
     }
 
+    $area = if ($null -ne $f.'System.AreaPath' -and "$($f.'System.AreaPath')" -ne '') {
+        [string]$f.'System.AreaPath'
+    } else {
+        $null
+    }
+
     $item = [PSCustomObject]@{
         Id        = $id
         Type      = $f.'System.WorkItemType'
         State     = $f.'System.State'
         Title     = $f.'System.Title'
         Iteration = $f.'System.IterationPath'
+        AreaPath  = $area
         Parent    = $parent
     }
     return $item
@@ -2248,6 +2345,41 @@ function Read-AzDevOpsAcceptanceCriteria {
 }
 
 
+function Test-AzDevOpsAreaPathMatch {
+    # True when $RowArea is equal to, or a sub-path of, any path in
+    # $ScopePaths. Sub-path comparison uses backslash boundaries so
+    # 'Project ABC\Portfolio' matches 'Project ABC\Portfolio\R&D' but
+    # does NOT match 'Project ABC\PortfolioOther'. Case-insensitive to
+    # match Azure DevOps's own path semantics.
+    param(
+        [string]   $RowArea,
+        [string[]] $ScopePaths
+    )
+
+    if (-not $RowArea) {
+        return $false
+    }
+    if (-not $ScopePaths -or $ScopePaths.Count -eq 0) {
+        return $false
+    }
+
+    foreach ($scope in $ScopePaths) {
+        if (-not $scope) {
+            continue
+        }
+        if ($RowArea -ieq $scope) {
+            return $true
+        }
+        $prefix = "$scope\"
+        if ($RowArea.Length -gt $prefix.Length -and $RowArea.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+
 function Read-AzDevOpsParentPick {
     # Generic parent picker shared by Read-AzDevOpsFeaturePick (story -> Feature)
     # and Read-AzDevOpsEpicPick (Feature -> Epic). Lists active rows of the
@@ -2255,15 +2387,25 @@ function Read-AzDevOpsParentPick {
     # or 0 when the user picks 'orphan' / cancels. Out-ConsoleGridView TUI when
     # available, Read-Host numbered menu otherwise.
     #
+    # -AreaPaths narrows the candidate list to rows whose AreaPath equals or
+    # is a sub-path of any provided path - sourced from
+    # $global:AzDevOpsProjectMap..Types..ParentScope.AreaPaths by
+    # the type-aware wrappers below. Silent no-op when the hierarchy cache
+    # was written before the AreaPath field was added (older rows -> the
+    # filter sees $null and treats them as non-matches; we then surface
+    # the empty list via the existing "no active parents" path).
+    #
     # Limitation: Basic-template projects skip the Feature tier entirely
     # (Epic -> Issue, no Feature). For -ParentType Feature this filter
     # returns zero rows on Basic projects and the caller falls through to
     # the orphan path - acceptable while the create flow stays Agile/Scrum/
     # CMMI-focused.
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)] [ValidateSet('Feature','Epic')] [string] $ParentType,
         [Parameter(Mandatory)] $Hierarchy,
-        [string] $ChildLabel = 'item'
+        [string]   $ChildLabel = 'item',
+        [string[]] $AreaPaths
     )
 
     $closedStates = Get-AzDevOpsClosedStates
@@ -2276,6 +2418,29 @@ function Read-AzDevOpsParentPick {
     if ($candidates.Count -eq 0) {
         Write-Host "(no active ${ParentType}s in hierarchy.json - $ChildLabel will be orphaned)" -ForegroundColor Yellow
         return 0
+    }
+
+    if ($AreaPaths -and $AreaPaths.Count -gt 0) {
+        # ConvertFrom-AzDevOpsHierarchyItem always defines an AreaPath property,
+        # but cache files written before the WIQL schema bump have it set to
+        # $null on every row. Detect that case (no row carries a non-empty
+        # AreaPath) and skip the filter silently to preserve current behavior
+        # until the user re-runs az-Sync-AzDevOpsCache.
+        $hasAreaField = @($candidates | Where-Object { $_.AreaPath }).Count -gt 0
+        if (-not $hasAreaField) {
+            Write-Verbose "ParentScope.AreaPaths filter skipped - hierarchy cache rows do not carry AreaPath. Run az-Sync-AzDevOpsCache to refresh."
+        } else {
+            $filtered = @($candidates | Where-Object {
+                Test-AzDevOpsAreaPathMatch -RowArea $_.AreaPath -ScopePaths $AreaPaths
+            })
+
+            if ($filtered.Count -eq 0) {
+                Write-Host "(no ${ParentType}s match ParentScope.AreaPaths - $ChildLabel will be orphaned)" -ForegroundColor Yellow
+                return 0
+            }
+
+            $candidates = $filtered
+        }
     }
 
     if (Test-AzDevOpsGridAvailable) {
@@ -2336,22 +2501,62 @@ function Read-AzDevOpsParentPick {
 }
 
 
+function Get-AzDevOpsTypeParentScopeAreaPaths {
+    # Looks up the AreaPaths array off Types..ParentScope for the
+    # given child type and returns it (or $null when no map / no scope).
+    # Centralizes the resolver call so the Feature/Epic pickers stay one-liners.
+    param([Parameter(Mandatory)] [string] $ChildType)
+
+    if (-not (Get-Command Resolve-AzDevOpsTypeParentScope -ErrorAction SilentlyContinue)) {
+        return $null
+    }
+
+    $scope = Resolve-AzDevOpsTypeParentScope -Type $ChildType
+    if ($null -eq $scope) {
+        return $null
+    }
+    if ($null -eq $scope.AreaPaths) {
+        return $null
+    }
+
+    $paths = [string[]]@($scope.AreaPaths)
+    return ,$paths
+}
+
+
 function Read-AzDevOpsFeaturePick {
     # Story -> Feature parent picker. Thin wrapper over Read-AzDevOpsParentPick
     # so az-New-AzDevOpsUserStory keeps its current call site unchanged.
+    # Looks up Types.USER_STORY.ParentScope.AreaPaths to narrow the candidate
+    # list when configured (Phase B multi-project support).
     param([Parameter(Mandatory)] $Hierarchy)
 
-    $featureId = Read-AzDevOpsParentPick -ParentType 'Feature' -Hierarchy $Hierarchy -ChildLabel 'story'
+    $areaPaths = Get-AzDevOpsTypeParentScopeAreaPaths -ChildType 'USER_STORY'
+
+    $featureId = if ($areaPaths -and $areaPaths.Count -gt 0) {
+        Read-AzDevOpsParentPick -ParentType 'Feature' -Hierarchy $Hierarchy -ChildLabel 'story' -AreaPaths $areaPaths
+    } else {
+        Read-AzDevOpsParentPick -ParentType 'Feature' -Hierarchy $Hierarchy -ChildLabel 'story'
+    }
+
     return $featureId
 }
 
 
 function Read-AzDevOpsEpicPick {
     # Feature -> Epic parent picker. Thin wrapper over Read-AzDevOpsParentPick
-    # used by az-New-AzDevOpsFeature.
+    # used by az-New-AzDevOpsFeature. Looks up Types.FEATURE.ParentScope.AreaPaths
+    # to narrow the candidate list when configured.
     param([Parameter(Mandatory)] $Hierarchy)
 
-    $epicId = Read-AzDevOpsParentPick -ParentType 'Epic' -Hierarchy $Hierarchy -ChildLabel 'Feature'
+    $areaPaths = Get-AzDevOpsTypeParentScopeAreaPaths -ChildType 'FEATURE'
+
+    $epicId = if ($areaPaths -and $areaPaths.Count -gt 0) {
+        Read-AzDevOpsParentPick -ParentType 'Epic' -Hierarchy $Hierarchy -ChildLabel 'Feature' -AreaPaths $areaPaths
+    } else {
+        Read-AzDevOpsParentPick -ParentType 'Epic' -Hierarchy $Hierarchy -ChildLabel 'Feature'
+    }
+
     return $epicId
 }
 
@@ -2484,7 +2689,9 @@ function Invoke-AzDevOpsWorkItemCreate {
         [string] $AcceptanceCriteria,
         [Parameter(Mandatory)] [string] $Iteration,
         [Parameter(Mandatory)] [string] $Area,
-        [string] $Type = 'User Story'
+        [string]    $Type = 'User Story',
+        [string[]]  $Tags,
+        [hashtable] $ExtraFields
     )
 
     $fields = @(
@@ -2494,6 +2701,25 @@ function Invoke-AzDevOpsWorkItemCreate {
 
     if ($StoryPoints -ge 0) {
         $fields += "Microsoft.VSTS.Scheduling.StoryPoints=$StoryPoints"
+    }
+
+    # Tags: appended only when non-empty so the field is not touched on
+    # creates that don't opt in (preserves today's "don't pass System.Tags"
+    # behavior for users without $global:AzDevOpsProjectMap).
+    if ($Tags -and $Tags.Count -gt 0) {
+        $tagList = ($Tags -join '; ')
+        $fields += "System.Tags=$tagList"
+    }
+
+    # ExtraFields: any RefName -> value pair the caller wants merged into the
+    # `--fields` list (e.g. Types.<TYPE>.RequiredFields resolved upstream).
+    # Values are passed through verbatim; the caller is responsible for
+    # turning 'prompt' into a real user-supplied value before getting here.
+    if ($ExtraFields -and $ExtraFields.Count -gt 0) {
+        foreach ($refName in $ExtraFields.Keys) {
+            $value = $ExtraFields[$refName]
+            $fields += "$refName=$value"
+        }
     }
 
     $result = New-AzDevOpsWorkItem `
@@ -2586,16 +2812,31 @@ function Test-AzDevOpsCreateGate {
 
 function Resolve-AzDevOpsIterationArea {
     # Picker + env-var fallback shared by every az-New-AzDevOps* creator. For
-    # each kind: if the caller already passed a value, keep it; otherwise prompt
-    # via Read-AzDevOpsKindPick. Missing-after-pick prints the standard "Set
+    # each kind: if the caller already passed a value, keep it; otherwise
+    # consult the active project's Types..Area / Iteration overrides
+    # (Phase B multi-project support); if still empty, prompt via
+    # Read-AzDevOpsKindPick. Missing-after-pick prints the standard "Set
     # `$env:AZ_* or run az-Sync-AzDevOpsCache" abort. Returns a result object
     # with .Ok / .Iteration / .Area so callers can short-circuit with a single
     # `if (-not $resolved.Ok) { return }`.
+    #
+    # -Type names the work-item type the resolver should look up in
+    # $global:AzDevOpsProjectMap..Types.. When unset (or no map
+    # defined), the resolver layer returns $null and the function falls
+    # through to today's env-var + prompt flow - preserving single-project
+    # behavior for users who never opt into the map.
     param(
         [string] $Iteration,
-        [string] $Area
+        [string] $Area,
+        [string] $Type
     )
 
+    if (-not $Iteration -and $Type) {
+        $typeIteration = Resolve-AzDevOpsTypeIteration -Type $Type
+        if ($typeIteration) {
+            $Iteration = $typeIteration
+        }
+    }
     if (-not $Iteration) {
         $Iteration = Read-AzDevOpsKindPick -Kind 'Iteration'
     }
@@ -2604,6 +2845,12 @@ function Resolve-AzDevOpsIterationArea {
         return [PSCustomObject]@{ Ok = $false; Iteration = $null; Area = $null }
     }
 
+    if (-not $Area -and $Type) {
+        $typeArea = Resolve-AzDevOpsTypeArea -Type $Type
+        if ($typeArea) {
+            $Area = $typeArea
+        }
+    }
     if (-not $Area) {
         $Area = Read-AzDevOpsKindPick -Kind 'Area'
     }
@@ -2613,6 +2860,42 @@ function Resolve-AzDevOpsIterationArea {
     }
 
     $resolved = [PSCustomObject]@{ Ok = $true; Iteration = $Iteration; Area = $Area }
+    return $resolved
+}
+
+
+function Resolve-AzDevOpsRequiredFieldValues {
+    # Walks the Types..RequiredFields hashtable returned by
+    # Resolve-AzDevOpsTypeRequiredFields and produces a flat hashtable of
+    # RefName -> value ready to splat as Invoke-AzDevOpsWorkItemCreate
+    # -ExtraFields. Values equal to 'prompt' (case-insensitive) are turned
+    # into a Read-Host so the user supplies the value at create time; any
+    # other value is passed through verbatim.
+    #
+    # Returns an empty hashtable when no map / no override, so callers can
+    # skip the parameter entirely when .Count is 0.
+    param([string] $Type)
+
+    if (-not (Get-Command Resolve-AzDevOpsTypeRequiredFields -ErrorAction SilentlyContinue)) {
+        return @{}
+    }
+
+    $required = Resolve-AzDevOpsTypeRequiredFields -Type $Type
+    if ($null -eq $required -or $required.Count -eq 0) {
+        return @{}
+    }
+
+    $resolved = @{}
+    foreach ($refName in $required.Keys) {
+        $value = $required[$refName]
+        if ("$value" -ieq 'prompt') {
+            $entered = Read-Host "Enter $refName"
+            $resolved[$refName] = $entered
+        } else {
+            $resolved[$refName] = $value
+        }
+    }
+
     return $resolved
 }
 
@@ -2717,11 +3000,21 @@ function az-New-AzDevOpsUserStory {
     }
 
     if ($Priority -lt 1 -or $Priority -gt 4) {
-        $Priority = Read-AzDevOpsPriority
+        $typePriority = Resolve-AzDevOpsTypeDefaultPriority -Type 'USER_STORY'
+        if ($typePriority -ge 1 -and $typePriority -le 4) {
+            $Priority = $typePriority
+        } else {
+            $Priority = Read-AzDevOpsPriority
+        }
     }
 
     if ($StoryPoints -lt 0) {
-        $StoryPoints = Read-AzDevOpsStoryPoints
+        $typeStoryPoints = Resolve-AzDevOpsTypeDefaultStoryPoints -Type 'USER_STORY'
+        if ($typeStoryPoints -ge 0) {
+            $StoryPoints = $typeStoryPoints
+        } else {
+            $StoryPoints = Read-AzDevOpsStoryPoints
+        }
     }
 
     if (-not $PSBoundParameters.ContainsKey('AcceptanceCriteria')) {
@@ -2732,12 +3025,15 @@ function az-New-AzDevOpsUserStory {
         $FeatureId = Read-AzDevOpsFeaturePick -Hierarchy $hierarchy
     }
 
-    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'USER_STORY'
     if (-not $resolved.Ok) {
         return
     }
     $Iteration = $resolved.Iteration
     $Area      = $resolved.Area
+
+    $typeTags     = Resolve-AzDevOpsTypeTags -Type 'USER_STORY'
+    $extraFields  = Resolve-AzDevOpsRequiredFieldValues -Type 'USER_STORY'
 
     $createArgs = @{
         Title              = $Title
@@ -2747,6 +3043,13 @@ function az-New-AzDevOpsUserStory {
         AcceptanceCriteria = $AcceptanceCriteria
         Iteration          = $Iteration
         Area               = $Area
+    }
+
+    if ($typeTags -and $typeTags.Count -gt 0) {
+        $createArgs['Tags'] = $typeTags
+    }
+    if ($extraFields -and $extraFields.Count -gt 0) {
+        $createArgs['ExtraFields'] = $extraFields
     }
 
     $outcome = Invoke-AzDevOpsCreateAndLink `
@@ -2814,7 +3117,12 @@ function az-New-AzDevOpsFeature {
     }
 
     if ($Priority -lt 1 -or $Priority -gt 4) {
-        $Priority = Read-AzDevOpsPriority
+        $typePriority = Resolve-AzDevOpsTypeDefaultPriority -Type 'FEATURE'
+        if ($typePriority -ge 1 -and $typePriority -le 4) {
+            $Priority = $typePriority
+        } else {
+            $Priority = Read-AzDevOpsPriority
+        }
     }
 
     if (-not $PSBoundParameters.ContainsKey('AcceptanceCriteria')) {
@@ -2825,12 +3133,15 @@ function az-New-AzDevOpsFeature {
         $ParentEpicId = Read-AzDevOpsEpicPick -Hierarchy $hierarchy
     }
 
-    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'FEATURE'
     if (-not $resolved.Ok) {
         return
     }
     $Iteration = $resolved.Iteration
     $Area      = $resolved.Area
+
+    $typeTags    = Resolve-AzDevOpsTypeTags -Type 'FEATURE'
+    $extraFields = Resolve-AzDevOpsRequiredFieldValues -Type 'FEATURE'
 
     $createArgs = @{
         Type               = 'Feature'
@@ -2840,6 +3151,13 @@ function az-New-AzDevOpsFeature {
         AcceptanceCriteria = $AcceptanceCriteria
         Iteration          = $Iteration
         Area               = $Area
+    }
+
+    if ($typeTags -and $typeTags.Count -gt 0) {
+        $createArgs['Tags'] = $typeTags
+    }
+    if ($extraFields -and $extraFields.Count -gt 0) {
+        $createArgs['ExtraFields'] = $extraFields
     }
 
     $outcome = Invoke-AzDevOpsCreateAndLink `
@@ -2954,12 +3272,23 @@ function az-New-AzDevOpsFeatureStories {
         return $createdIds
     }
 
-    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'USER_STORY'
     if (-not $resolved.Ok) {
         return $createdIds
     }
     $Iteration = $resolved.Iteration
     $Area      = $resolved.Area
+
+    # Tags are static across the batch (board + type config is invariant for
+    # the duration of the loop). RequiredFields with literal values are also
+    # static; 'prompt' entries get re-asked per story so each child can carry
+    # its own value when that is what the schema requires.
+    $typeTags        = Resolve-AzDevOpsTypeTags -Type 'USER_STORY'
+    $requiredRaw     = if (Get-Command Resolve-AzDevOpsTypeRequiredFields -ErrorAction SilentlyContinue) {
+        Resolve-AzDevOpsTypeRequiredFields -Type 'USER_STORY'
+    } else {
+        @{}
+    }
 
     Write-Host ""
     Write-Host "Batch-creating child User Stories under Feature $ParentId" -ForegroundColor Cyan
@@ -2967,10 +3296,21 @@ function az-New-AzDevOpsFeatureStories {
     Write-Host "  Iteration : $Iteration"
     Write-Host "  (empty title at the next prompt ends the batch cleanly)"
 
+    $typeDefaultPriority    = Resolve-AzDevOpsTypeDefaultPriority    -Type 'USER_STORY'
+    $typeDefaultStoryPoints = Resolve-AzDevOpsTypeDefaultStoryPoints -Type 'USER_STORY'
+
     $failedTitles        = @()
     $createdUrls         = @()
-    $previousPriority    = -1
-    $previousStoryPoints = -1
+    $previousPriority    = if ($typeDefaultPriority -ge 1 -and $typeDefaultPriority -le 4) {
+        $typeDefaultPriority
+    } else {
+        -1
+    }
+    $previousStoryPoints = if ($typeDefaultStoryPoints -ge 0) {
+        $typeDefaultStoryPoints
+    } else {
+        -1
+    }
     $iterationNumber     = 1
 
     while ($true) {
@@ -2986,6 +3326,18 @@ function az-New-AzDevOpsFeatureStories {
         $priority           = Read-AzDevOpsPriority    -Previous $previousPriority
         $storyPoints        = Read-AzDevOpsStoryPoints -Previous $previousStoryPoints
 
+        # Resolve RequiredFields per child so 'prompt' entries are re-asked.
+        $extraFields = @{}
+        foreach ($refName in $requiredRaw.Keys) {
+            $value = $requiredRaw[$refName]
+            if ("$value" -ieq 'prompt') {
+                $entered = Read-Host "Enter $refName"
+                $extraFields[$refName] = $entered
+            } else {
+                $extraFields[$refName] = $value
+            }
+        }
+
         $createArgs = @{
             Title              = $title
             Description        = ''
@@ -2994,6 +3346,13 @@ function az-New-AzDevOpsFeatureStories {
             AcceptanceCriteria = $acceptanceCriteria
             Iteration          = $Iteration
             Area               = $Area
+        }
+
+        if ($typeTags -and $typeTags.Count -gt 0) {
+            $createArgs['Tags'] = $typeTags
+        }
+        if ($extraFields.Count -gt 0) {
+            $createArgs['ExtraFields'] = $extraFields
         }
 
         $outcome = Invoke-AzDevOpsCreateAndLink `

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -2864,6 +2864,53 @@ function Resolve-AzDevOpsIterationArea {
 }
 
 
+function Resolve-AzDevOpsPriorityWithDefault {
+    # Three-step priority resolution shared by every az-New-AzDevOps* creator
+    # (CLAUDE.md extract-repeated-branches): explicit -Priority param wins,
+    # then the active project's Types.<TYPE>.DefaultPriority, then an
+    # interactive Read-AzDevOpsPriority prompt.
+    param(
+        [int]    $Current,
+        [Parameter(Mandatory)] [string] $Type
+    )
+
+    if ($Current -ge 1 -and $Current -le 4) {
+        return $Current
+    }
+
+    $typePriority = Resolve-AzDevOpsTypeDefaultPriority -Type $Type
+    if ($typePriority -ge 1 -and $typePriority -le 4) {
+        return $typePriority
+    }
+
+    $picked = Read-AzDevOpsPriority
+    return $picked
+}
+
+
+function Resolve-AzDevOpsStoryPointsWithDefault {
+    # Three-step story-points resolution shared by az-New-AzDevOps* creators
+    # that carry story points. Mirrors Resolve-AzDevOpsPriorityWithDefault's
+    # explicit -> type-default -> prompt walk.
+    param(
+        [int]    $Current,
+        [Parameter(Mandatory)] [string] $Type
+    )
+
+    if ($Current -ge 0) {
+        return $Current
+    }
+
+    $typeStoryPoints = Resolve-AzDevOpsTypeDefaultStoryPoints -Type $Type
+    if ($typeStoryPoints -ge 0) {
+        return $typeStoryPoints
+    }
+
+    $picked = Read-AzDevOpsStoryPoints
+    return $picked
+}
+
+
 function Resolve-AzDevOpsRequiredFieldValues {
     # Walks the Types..RequiredFields hashtable returned by
     # Resolve-AzDevOpsTypeRequiredFields and produces a flat hashtable of
@@ -2999,23 +3046,8 @@ function az-New-AzDevOpsUserStory {
         $Description = Read-Host 'What is the description?'
     }
 
-    if ($Priority -lt 1 -or $Priority -gt 4) {
-        $typePriority = Resolve-AzDevOpsTypeDefaultPriority -Type 'USER_STORY'
-        if ($typePriority -ge 1 -and $typePriority -le 4) {
-            $Priority = $typePriority
-        } else {
-            $Priority = Read-AzDevOpsPriority
-        }
-    }
-
-    if ($StoryPoints -lt 0) {
-        $typeStoryPoints = Resolve-AzDevOpsTypeDefaultStoryPoints -Type 'USER_STORY'
-        if ($typeStoryPoints -ge 0) {
-            $StoryPoints = $typeStoryPoints
-        } else {
-            $StoryPoints = Read-AzDevOpsStoryPoints
-        }
-    }
+    $Priority    = Resolve-AzDevOpsPriorityWithDefault    -Current $Priority    -Type 'USER_STORY'
+    $StoryPoints = Resolve-AzDevOpsStoryPointsWithDefault -Current $StoryPoints -Type 'USER_STORY'
 
     if (-not $PSBoundParameters.ContainsKey('AcceptanceCriteria')) {
         $AcceptanceCriteria = Read-AzDevOpsAcceptanceCriteria
@@ -3116,14 +3148,7 @@ function az-New-AzDevOpsFeature {
         $Description = Read-Host 'What is the description?'
     }
 
-    if ($Priority -lt 1 -or $Priority -gt 4) {
-        $typePriority = Resolve-AzDevOpsTypeDefaultPriority -Type 'FEATURE'
-        if ($typePriority -ge 1 -and $typePriority -le 4) {
-            $Priority = $typePriority
-        } else {
-            $Priority = Read-AzDevOpsPriority
-        }
-    }
+    $Priority = Resolve-AzDevOpsPriorityWithDefault -Current $Priority -Type 'FEATURE'
 
     if (-not $PSBoundParameters.ContainsKey('AcceptanceCriteria')) {
         $AcceptanceCriteria = Read-AzDevOpsAcceptanceCriteria
@@ -3296,21 +3321,15 @@ function az-New-AzDevOpsFeatureStories {
     Write-Host "  Iteration : $Iteration"
     Write-Host "  (empty title at the next prompt ends the batch cleanly)"
 
-    $typeDefaultPriority    = Resolve-AzDevOpsTypeDefaultPriority    -Type 'USER_STORY'
-    $typeDefaultStoryPoints = Resolve-AzDevOpsTypeDefaultStoryPoints -Type 'USER_STORY'
-
+    # Resolve-AzDevOpsTypeDefault{Priority,StoryPoints} already returns -1
+    # when no map / no override / out-of-range, so the values can seed the
+    # Read-* "previous" reuse hint directly. The first iteration's Enter
+    # accepts the default; subsequent iterations roll forward the user's
+    # last answer (existing behavior preserved).
     $failedTitles        = @()
     $createdUrls         = @()
-    $previousPriority    = if ($typeDefaultPriority -ge 1 -and $typeDefaultPriority -le 4) {
-        $typeDefaultPriority
-    } else {
-        -1
-    }
-    $previousStoryPoints = if ($typeDefaultStoryPoints -ge 0) {
-        $typeDefaultStoryPoints
-    } else {
-        -1
-    }
+    $previousPriority    = Resolve-AzDevOpsTypeDefaultPriority    -Type 'USER_STORY'
+    $previousStoryPoints = Resolve-AzDevOpsTypeDefaultStoryPoints -Type 'USER_STORY'
     $iterationNumber     = 1
 
     while ($true) {

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -56,6 +56,13 @@ if ($azdevops_db -ne $NULL) {
     Write-Host "no azdevops_db.ps1"
 }
 
+$azdevops_projects = Get-Content "$path_to_bashcuts\powcuts_by_cli\azdevops_projects.ps1"
+if ($azdevops_projects -ne $NULL) {
+ . "$path_to_bashcuts\powcuts_by_cli\azdevops_projects.ps1"
+} else {
+    Write-Host "no azdevops_projects.ps1"
+}
+
 $azdevops_workitems = Get-Content "$path_to_bashcuts\powcuts_by_cli\azdevops_workitems.ps1"
 if ($azdevops_workitems -ne $NULL) {
  . "$path_to_bashcuts\powcuts_by_cli\azdevops_workitems.ps1"


### PR DESCRIPTION
<!-- toc:start -->
## Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #56 |
| [Changes](#changes) | ✅ 3 files |
| [Test Plan](#test-plan) | 6 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/60#issuecomment-4416686507) |
| 💠 PowerShell Engineer Review | ✅ APPROVE (1 MEDIUM, fixed in `eddd2b7`) — [View](https://github.com/jdschleicher/bashcuts/pull/60#issuecomment-4416689465) |
| 🛡️ Security Audit | ✅ PASS (1 LOW, fixed in `eddd2b7`) — [View](https://github.com/jdschleicher/bashcuts/pull/60#issuecomment-4416690491) |
| 🧼 Clean-Code Engineer Review | ⚠️ REQUEST CHANGES → all 3 HIGH fixed in `eddd2b7` — [View](https://github.com/jdschleicher/bashcuts/pull/60#issuecomment-4416690744) |
| 📚 Docs Check | ⚠️ STALE — deferred to #57 — [View](https://github.com/jdschleicher/bashcuts/pull/60#issuecomment-4416705821) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/60#issuecomment-4416708949) |
| 📐 AzDO Diagrams Check | ✅ CURRENT (auto-fixed in `fd85e09`) — [View](https://github.com/jdschleicher/bashcuts/pull/60#issuecomment-4416721375) |
<!-- toc:end -->

## Summary
Ships Phase A (project map infrastructure) and Phase B (wire defaults into create paths) together — issue #56 explicitly builds on Phase A, but Phase A had not yet landed, so both are delivered in one branch.

- **Phase A** — new `powcuts_by_cli/azdevops_projects.ps1`: `$global:AzDevOpsProjectMap` switcher (`az-Use-AzDevOpsProject`, `az-Show-AzDevOpsProject`, `az-Get-AzDevOpsProjects`), per-type resolver layer (`Resolve-AzDevOpsType{Area,Iteration,Tags,DefaultPriority,DefaultStoryPoints,RequiredFields,ParentScope}`), type-key normalizer, cache slug, silent auto-hydrate. Hierarchy WIQL + converter now carry `System.AreaPath` so the new parent-scope filter has data on first sync.
- **Phase B** — `Resolve-AzDevOpsIterationArea -Type`, `Invoke-AzDevOpsWorkItemCreate -Tags` / `-ExtraFields`, `Read-AzDevOpsParentPick -AreaPaths` (equal-or-sub-path), `Read-AzDevOpsFeaturePick`/`EpicPick` consult `ParentScope`, `az-New-AzDevOpsUserStory`/`Feature`/`FeatureStories` walk every per-type default, new `az-Confirm-AzDevOpsProjectMap` orchestrator step inserted between `EnvVars` (3) and `Login` (4).
- Cache root namespaced by project slug — `~/.bashcuts-cache/azure-devops/<slug>/` when a project is active; legacy path when not.
- Without `$global:AzDevOpsProjectMap` defined, every code path is byte-identical to today (full backward compatibility).

### Review fixes (commit `eddd2b7`)
- **Clean-code HIGH × 3** — extracted `Get-AzDevOpsTypeStringProperty` (collapses `Resolve-AzDevOpsType{Area,Iteration}`), `Get-AzDevOpsTypeIntegerDefault` (collapses `Resolve-AzDevOpsTypeDefault{Priority,StoryPoints}`), `Resolve-AzDevOps{Priority,StoryPoints}WithDefault` (collapses the "use type default else prompt" pattern across all three creators). Net: −17 lines duplicate branching in the creators, 4 new shared helpers.
- **PowerShell MEDIUM** — `az-Use-AzDevOpsProject` now checks `$LASTEXITCODE` after `az devops configure --defaults` and surfaces the failure in red.
- **Security LOW** — `Get-AzDevOpsProjectCacheSlug` regex tightened to strip `.` from the allow-list, blocking `..` traversal of the cache root.

### Diagram refresh (commit `fd85e09`)
- Diagram 2 (`az-Connect-AzDevOps`) renumbered to 7-step with `az-Confirm-AzDevOpsProjectMap` as Step 4.
- Diagram 11 (function dependency map) gained the Multi-project switcher + resolver-layer clusters (22 new nodes + edges).

## Issue
Closes #56

## Changes
| File | Change |
|------|--------|
| `powcuts_by_cli/azdevops_projects.ps1` (new) | Phase A foundation |
| `powcuts_by_cli/azdevops_workitems.ps1` | Cache namespacing, AreaPath in hierarchy, type-aware resolvers wired into every `az-New-*` + orchestrator step |
| `powcuts_home.ps1` | Dot-source `azdevops_projects.ps1` before `azdevops_workitems.ps1` |
| `docs/azure-devops-diagrams.md` | Diagrams 2 + 11 refreshed for multi-project + resolver layer |

## Test Plan
- [ ] **No-map baseline** — open a fresh pwsh terminal without `$global:AzDevOpsProjectMap`. `az-New-AzDevOpsUserStory` prompts for priority/SP/area/iteration/AC exactly as before; cache writes to `~/.bashcuts-cache/azure-devops/` (no subdir).
- [ ] **Two-project map** — set `$global:AzDevOpsProjectMap` with two projects in `$profile`. Run `az-Use-AzDevOpsProject ProjectABC`; verify `az-Show-AzDevOpsProject` reports the new active project and env vars. Run `az-Sync-AzDevOpsCache` — confirm `~/.bashcuts-cache/azure-devops/ProjectABC/` is created.
- [ ] **Type defaults** — in a project with `Types.USER_STORY.DefaultPriority/DefaultStoryPoints/Tags/RequiredFields` set, run `az-New-AzDevOpsUserStory`. Priority/SP prompts are skipped; tags are appended; `RequiredFields = 'prompt'` triggers a Read-Host; `System.Tags` appears in the created work item.
- [ ] **ParentScope.AreaPaths filter** — set `Types.USER_STORY.ParentScope.AreaPaths = @('Project ABC\Portfolio\R&D')`. Run `az-New-AzDevOpsUserStory` — the Feature parent picker should only surface Features whose AreaPath equals or is a sub-path of that scope.
- [ ] **Orchestrator** — run `az-Connect-AzDevOps`. Verify 7 steps; step 4 shows `(single-project mode)` gray dash when no map is set, or `OK Active project: …` when wired in. With map defined but no `$global:AzDevOpsDefaultProject`, step 4 prompts for project selection.
- [ ] **pwsh parse** — `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/azdevops_projects.ps1', [ref]$null, [ref]$null) | Out-Null; [System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/azdevops_workitems.ps1', [ref]$null, [ref]$null) | Out-Null"` exits 0.