### PR TITLE
Auto-register Azure DevOps sync schedule on first shell startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ After `az-Connect-AzDevOps` reports `READY` once, later commands in the AzDevOps
 
 ### Day-to-day work-item shortcuts
 
-These read the local cache populated by `az-Sync-AzDevOpsCache` (and the recurring `az-Register-AzDevOpsSyncSchedule` job). They never call `az` directly, so they return instantly.
+These read the local cache populated by `az-Sync-AzDevOpsCache` (and the recurring `az-Register-AzDevOpsSyncSchedule` job, which self-registers on first PowerShell terminal so you don't have to remember to run it). They never call `az` directly, so they return instantly.
 
 ```powershell
 az-Get-AzDevOpsAssigned                       # everything assigned to you (excludes Closed/Removed)

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -481,28 +481,27 @@ Helpers introduced for this flow (named in CLAUDE.md's "extract repeated branche
 
 ---
 
-## 10. `az-Register-/az-Unregister-AzDevOpsSyncSchedule` — platform branch
+## 10. Schedule helpers (`az-Register-/az-Unregister-AzDevOpsSyncSchedule`, `Test-AzDevOpsSyncScheduleRegistered`) — platform dispatch
 
-Both functions delegate the OS check to `Get-AzDevOpsPlatform` so the branch lives in one place. The cron line itself is built by `Get-AzDevOpsCronLine` (also reused) so register and unregister stay symmetric.
+All three functions delegate the OS branch to `Invoke-AzDevOpsByPlatform`, which routes to one of three caller-supplied scriptblocks (`-OnWindows / -OnPosix / -OnUnsupported`) and returns the result. `Test-AzDevOpsSyncScheduleRegistered` is called from `powcuts_home.ps1` on every shell startup; if it returns `$false`, the profile silently calls `az-Register-AzDevOpsSyncSchedule -Quiet` so the schedule self-installs on the first terminal after install. On unsupported OSes `Test-` returns `$true` to keep the bootstrap a no-op.
 
 ```mermaid
 flowchart TD
-    Reg([az-Register-AzDevOpsSyncSchedule]) --> P1{Get-AzDevOpsPlatform}
-    P1 -- Windows --> WReg["New-ScheduledTaskAction + Trigger<br/>Register-ScheduledTask -TaskName<br/>Get-AzDevOpsScheduledTaskName<br/>(every Get-AzDevOpsSyncIntervalHours)"]
-    P1 -- Posix --> PReg["Get-AzDevOpsCronLine -PwshPath<br/>+ Get-AzDevOpsCrontabSplit<br/>append + crontab -"]
-    P1 -- Unknown --> ErrR([Unsupported OS])
+    Reg([az-Register-AzDevOpsSyncSchedule]) --> Disp{Invoke-AzDevOpsByPlatform}
+    Unreg([az-Unregister-AzDevOpsSyncSchedule]) --> Disp
+    TestReg([Test-AzDevOpsSyncScheduleRegistered]) --> Disp
 
-    Unreg([az-Unregister-AzDevOpsSyncSchedule]) --> P2{Get-AzDevOpsPlatform}
-    P2 -- Windows --> WUn["Get-ScheduledTask?<br/>Unregister-ScheduledTask -Confirm:$false"]
-    P2 -- Posix --> PUn["Get-AzDevOpsCrontabSplit<br/>(filter Get-AzDevOpsCronTag)<br/>crontab -"]
-    P2 -- Unknown --> ErrU([Unsupported OS])
+    Disp -- Windows --> Win["Register: New-ScheduledTaskAction + Register-ScheduledTask<br/>Unregister: Get-ScheduledTask? + Unregister-ScheduledTask<br/>Test: Get-ScheduledTask -ErrorAction SilentlyContinue"]
+    Disp -- Posix --> Pos["Register: Get-AzDevOpsCronLine + Get-AzDevOpsCrontabSplit + crontab -<br/>Unregister: Get-AzDevOpsCrontabSplit + crontab -<br/>Test: Get-AzDevOpsCrontabSplit.HadBashcuts"]
+    Disp -- Unknown --> Unk["Register / Unregister: Unsupported OS message<br/>Test: returns $true (prevents bootstrap loop)"]
 
     classDef shared fill:#3a2a5f,stroke:#a070ff,color:#fff
-    class P1,P2 shared
+    class Disp shared
 ```
 
 Shared private helpers (named in CLAUDE.md):
 
+- `Invoke-AzDevOpsByPlatform -OnWindows -OnPosix [-OnUnsupported]` → centralized dispatch; each scriptblock returns the per-platform result
 - `Get-AzDevOpsPlatform` → `'Windows' | 'Posix' | 'Unknown'`
 - `Get-AzDevOpsScheduledTaskName` → `'BashcutsAzDevOpsSync'`
 - `Get-AzDevOpsSyncIntervalHours` → `5`
@@ -528,6 +527,7 @@ graph LR
     Status(["az-Get-AzDevOpsCacheStatus"]):::pub
     Reg(["az-Register-AzDevOpsSyncSchedule"]):::pub
     Unreg(["az-Unregister-AzDevOpsSyncSchedule"]):::pub
+    TestReg(["Test-AzDevOpsSyncScheduleRegistered"]):::pub
     GetA(["az-Get-AzDevOpsAssigned"]):::pub
     OpenA(["az-Open-AzDevOpsAssigned"]):::pub
     GetM(["az-Get-AzDevOpsMentions"]):::pub
@@ -586,6 +586,7 @@ graph LR
     EchoLn[Write-AzDevOpsQueryEcho]:::priv
 
     %% Schedule helpers
+    Disp[Invoke-AzDevOpsByPlatform]:::priv
     Plat[Get-AzDevOpsPlatform]:::priv
     TaskName[Get-AzDevOpsScheduledTaskName]:::priv
     Interval[Get-AzDevOpsSyncIntervalHours]:::priv
@@ -695,14 +696,18 @@ graph LR
 
     Status --> Age --> Paths
     Status --> StatusRows --> ShowRows
-    Reg --> Plat
+    Reg --> Disp
+    Unreg --> Disp
+    TestReg --> Disp
+    Disp --> Plat
     Reg --> TaskName
     Reg --> Interval
     Reg --> CronLine --> CronTag
     Reg --> CronSplit --> CronTag
-    Unreg --> Plat
     Unreg --> TaskName
     Unreg --> CronSplit
+    TestReg --> TaskName
+    TestReg --> CronSplit
 
     ReadA --> ReadJson --> Paths
     ReadA --> ConvA

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -853,89 +853,125 @@ function Get-AzDevOpsCrontabSplit {
 }
 
 
-function Test-AzDevOpsSyncScheduleRegistered {
-    # Cheap "is the schedule already in place?" check so the profile bootstrap
-    # can no-op on every shell startup after the first one.
+function Invoke-AzDevOpsByPlatform {
+    # Centralizes the Windows / Posix / Unsupported branch shape used by the
+    # schedule helpers (Test-/Register-/Unregister-AzDevOpsSyncSchedule) so
+    # each function supplies only the platform-specific work. CLAUDE.md's
+    # "extract repeated branches into private helpers" rule.
+    param(
+        [Parameter(Mandatory)] [scriptblock] $OnWindows,
+        [Parameter(Mandatory)] [scriptblock] $OnPosix,
+        [scriptblock] $OnUnsupported
+    )
+
     $platform = Get-AzDevOpsPlatform
 
     if ($platform -eq 'Windows') {
-        $taskName = Get-AzDevOpsScheduledTaskName
-        $task     = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
-        return ($null -ne $task)
+        $windowsResult = & $OnWindows
+        return $windowsResult
     }
 
     if ($platform -eq 'Posix') {
-        $split = Get-AzDevOpsCrontabSplit
-        return $split.HadBashcuts
+        $posixResult = & $OnPosix
+        return $posixResult
     }
 
-    return $false
+    if ($OnUnsupported) {
+        $unsupportedResult = & $OnUnsupported
+        return $unsupportedResult
+    }
+
+    return $null
+}
+
+
+function Test-AzDevOpsSyncScheduleRegistered {
+    # Cheap "is the schedule already in place?" check so the profile bootstrap
+    # can no-op on every shell startup after the first one. Unsupported
+    # platforms report registered=$true so the bootstrap doesn't loop into
+    # az-Register-...'s red error message on every new shell.
+    $registered = Invoke-AzDevOpsByPlatform `
+        -OnWindows {
+            $taskName = Get-AzDevOpsScheduledTaskName
+            $task     = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+            $exists   = ($null -ne $task)
+            return $exists
+        } `
+        -OnPosix {
+            $split    = Get-AzDevOpsCrontabSplit
+            $hasEntry = $split.HadBashcuts
+            return $hasEntry
+        } `
+        -OnUnsupported {
+            return $true
+        }
+
+    return $registered
 }
 
 
 function az-Register-AzDevOpsSyncSchedule {
+    [CmdletBinding()]
     param([switch] $Quiet)
 
-    $platform = Get-AzDevOpsPlatform
     # Loads the user's $profile so $env:AZ_* and the dot-sourced module are
     # available; without -NoProfile, the scheduled invocation has the same
     # context as an interactive shell.
     $pwshPath = (Get-Process -Id $PID).Path
     $hours    = Get-AzDevOpsSyncIntervalHours
 
-    if ($platform -eq 'Windows') {
-        $taskName = Get-AzDevOpsScheduledTaskName
-        $action   = New-ScheduledTaskAction -Execute $pwshPath -Argument "-Command `"az-Sync-AzDevOpsCache`""
-        $trigger  = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(5) `
-                        -RepetitionInterval (New-TimeSpan -Hours $hours)
-        Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Force | Out-Null
-        if (-not $Quiet) {
-            Write-Host "Registered: scheduled task '$taskName' (every $hours hours)" -ForegroundColor Green
-        }
-        return
-    }
+    Invoke-AzDevOpsByPlatform `
+        -OnWindows {
+            $taskName = Get-AzDevOpsScheduledTaskName
+            $action   = New-ScheduledTaskAction -Execute $pwshPath -Argument "-Command `"az-Sync-AzDevOpsCache`""
+            $trigger  = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(5) `
+                            -RepetitionInterval (New-TimeSpan -Hours $hours)
+            Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Force | Out-Null
 
-    if ($platform -eq 'Posix') {
-        $cronLine = Get-AzDevOpsCronLine -PwshPath $pwshPath
-        $split    = Get-AzDevOpsCrontabSplit
-        $newCron  = (@($split.Other) + $cronLine) -join "`n"
-        $newCron | crontab -
-        if (-not $Quiet) {
-            Write-Host "Registered: cron entry - $cronLine" -ForegroundColor Green
-        }
-        return
-    }
+            if (-not $Quiet) {
+                Write-Host "Registered: scheduled task '$taskName' (every $hours hours)" -ForegroundColor Green
+            }
+        } `
+        -OnPosix {
+            $cronLine = Get-AzDevOpsCronLine -PwshPath $pwshPath
+            $split    = Get-AzDevOpsCrontabSplit
+            $newCron  = (@($split.Other) + $cronLine) -join "`n"
+            $newCron | crontab -
 
-    Write-Host "Unsupported OS for az-Register-AzDevOpsSyncSchedule" -ForegroundColor Red
+            if (-not $Quiet) {
+                Write-Host "Registered: cron entry - $cronLine" -ForegroundColor Green
+            }
+        } `
+        -OnUnsupported {
+            Write-Host "Unsupported OS for az-Register-AzDevOpsSyncSchedule" -ForegroundColor Red
+        }
 }
 
 
 function az-Unregister-AzDevOpsSyncSchedule {
-    $platform = Get-AzDevOpsPlatform
+    Invoke-AzDevOpsByPlatform `
+        -OnWindows {
+            $taskName = Get-AzDevOpsScheduledTaskName
+            if (Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue) {
+                Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+                Write-Host "Unregistered: scheduled task '$taskName'" -ForegroundColor Green
+            } else {
+                Write-Host "No scheduled task '$taskName' to remove" -ForegroundColor Yellow
+            }
+        } `
+        -OnPosix {
+            $split = Get-AzDevOpsCrontabSplit
+            if (-not $split.HadBashcuts) {
+                Write-Host "No bashcuts-azdevops-sync cron entry to remove" -ForegroundColor Yellow
+                return
+            }
 
-    if ($platform -eq 'Windows') {
-        $taskName = Get-AzDevOpsScheduledTaskName
-        if (Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue) {
-            Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
-            Write-Host "Unregistered: scheduled task '$taskName'" -ForegroundColor Green
-        } else {
-            Write-Host "No scheduled task '$taskName' to remove" -ForegroundColor Yellow
+            ($split.Other -join "`n") | crontab -
+            Write-Host "Unregistered: removed bashcuts-azdevops-sync cron entry" -ForegroundColor Green
+        } `
+        -OnUnsupported {
+            Write-Host "Unsupported OS for az-Unregister-AzDevOpsSyncSchedule" -ForegroundColor Red
         }
-        return
-    }
-
-    if ($platform -eq 'Posix') {
-        $split = Get-AzDevOpsCrontabSplit
-        if (-not $split.HadBashcuts) {
-            Write-Host "No bashcuts-azdevops-sync cron entry to remove" -ForegroundColor Yellow
-            return
-        }
-        ($split.Other -join "`n") | crontab -
-        Write-Host "Unregistered: removed bashcuts-azdevops-sync cron entry" -ForegroundColor Green
-        return
-    }
-
-    Write-Host "Unsupported OS for az-Unregister-AzDevOpsSyncSchedule" -ForegroundColor Red
 }
 
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -853,7 +853,29 @@ function Get-AzDevOpsCrontabSplit {
 }
 
 
+function Test-AzDevOpsSyncScheduleRegistered {
+    # Cheap "is the schedule already in place?" check so the profile bootstrap
+    # can no-op on every shell startup after the first one.
+    $platform = Get-AzDevOpsPlatform
+
+    if ($platform -eq 'Windows') {
+        $taskName = Get-AzDevOpsScheduledTaskName
+        $task     = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+        return ($null -ne $task)
+    }
+
+    if ($platform -eq 'Posix') {
+        $split = Get-AzDevOpsCrontabSplit
+        return $split.HadBashcuts
+    }
+
+    return $false
+}
+
+
 function az-Register-AzDevOpsSyncSchedule {
+    param([switch] $Quiet)
+
     $platform = Get-AzDevOpsPlatform
     # Loads the user's $profile so $env:AZ_* and the dot-sourced module are
     # available; without -NoProfile, the scheduled invocation has the same
@@ -867,7 +889,9 @@ function az-Register-AzDevOpsSyncSchedule {
         $trigger  = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(5) `
                         -RepetitionInterval (New-TimeSpan -Hours $hours)
         Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Force | Out-Null
-        Write-Host "Registered: scheduled task '$taskName' (every $hours hours)" -ForegroundColor Green
+        if (-not $Quiet) {
+            Write-Host "Registered: scheduled task '$taskName' (every $hours hours)" -ForegroundColor Green
+        }
         return
     }
 
@@ -876,7 +900,9 @@ function az-Register-AzDevOpsSyncSchedule {
         $split    = Get-AzDevOpsCrontabSplit
         $newCron  = (@($split.Other) + $cronLine) -join "`n"
         $newCron | crontab -
-        Write-Host "Registered: cron entry - $cronLine" -ForegroundColor Green
+        if (-not $Quiet) {
+            Write-Host "Registered: cron entry - $cronLine" -ForegroundColor Green
+        }
         return
     }
 

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -69,3 +69,13 @@ if ($azdevops_projects -ne $NULL) {
 } else {
     Write-Host "no azdevops_projects.ps1"
 }
+
+# Auto-register the Azure DevOps cache sync schedule on first shell startup so
+# the user doesn't have to remember to run az-Register-AzDevOpsSyncSchedule.
+# Subsequent terminals see the existing task/cron entry and no-op.
+if ((Get-Command Test-AzDevOpsSyncScheduleRegistered -ErrorAction SilentlyContinue) -and
+    (Get-Command az-Register-AzDevOpsSyncSchedule -ErrorAction SilentlyContinue)) {
+    if (-not (Test-AzDevOpsSyncScheduleRegistered)) {
+        az-Register-AzDevOpsSyncSchedule -Quiet
+    }
+}


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #61 |
| [Changes](#changes) | ✅ 2 files (+ docs in follow-up commits) |
| [Test Plan](#test-plan) | 0/5 (manual verification by author) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/62#issuecomment-4416728857) |
| 💠 PowerShell Engineer Review (re-review f295cf3) | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/62#issuecomment-4417012708) · [initial](https://github.com/jdschleicher/bashcuts/pull/62#issuecomment-4416730803) |
| 🛡️ Security Audit | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/62#issuecomment-4416732167) |
| 🧼 Clean-Code Engineer Review (re-review f295cf3) | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/62#issuecomment-4417012691) · [initial](https://github.com/jdschleicher/bashcuts/pull/62#issuecomment-4416732011) |
| ✅ Criteria Check (#61) | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/62#issuecomment-4417035984) |
| 🗺️ AzDO Diagrams Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/62#issuecomment-4417053321) |
<!-- toc:end -->

## Summary
Profile (`powcuts_home.ps1`) now detects whether the Azure DevOps cache sync schedule is registered and, if not, silently registers it on the first PowerShell terminal — no more one-time `az-Register-AzDevOpsSyncSchedule` step to remember on a fresh machine.

## Issue
Closes #61

## Changes
- `powcuts_by_cli/azdevops_workitems.ps1`
  - Added `Invoke-AzDevOpsByPlatform` — private dispatcher that routes to one of three caller-supplied scriptblocks (`-OnWindows / -OnPosix / -OnUnsupported`), extracted from the previously-triplicated Windows/Posix/Unsupported ladder in `Register-/Unregister-/Test-AzDevOpsSyncSchedule…`
  - Added `Test-AzDevOpsSyncScheduleRegistered` — returns `$true` when the Windows scheduled task or bashcuts-tagged cron line is present; returns `$true` on unsupported OSes so the profile bootstrap doesn't loop
  - Added `[CmdletBinding()]` and `-Quiet` switch to `az-Register-AzDevOpsSyncSchedule` so the profile bootstrap stays noiseless
  - Refactored `az-Register-/az-Unregister-AzDevOpsSyncSchedule` to delegate to `Invoke-AzDevOpsByPlatform`
- `powcuts_home.ps1`
  - New guarded bootstrap block at the bottom: if both functions are defined and `Test-AzDevOpsSyncScheduleRegistered` returns `$false`, calls `az-Register-AzDevOpsSyncSchedule -Quiet`
- `README.md`
  - Line 195 now notes that the recurring job self-registers on first PowerShell terminal
- `docs/azure-devops-diagrams.md`
  - Diagram 10 rewritten to show the three schedule helpers (`Register-/Unregister-/Test-`) routing through `Invoke-AzDevOpsByPlatform` instead of two separate `Get-AzDevOpsPlatform` diamonds
  - Diagram 11 (function dependency map) adds `TestReg` (pub) and `Disp` (priv) nodes and rewires `Reg`/`Unreg`/`TestReg` through `Disp --> Plat`

## Test Plan
- [ ] Open a fresh PowerShell terminal on a machine with no prior schedule — terminal opens with no extra output; `Get-ScheduledTask -TaskName 'BashcutsAzDevOpsSync'` (Windows) or `crontab -l | grep bashcuts-azdevops-sync` (Posix) shows the entry
- [ ] Open a second terminal — no re-registration, no noise; `Test-AzDevOpsSyncScheduleRegistered` returns `$true`
- [ ] Run `az-Unregister-AzDevOpsSyncSchedule`, open a new terminal — schedule comes back silently
- [ ] `az-Register-AzDevOpsSyncSchedule` (no `-Quiet`) still prints the green "Registered ..." message when called interactively
- [ ] Pwsh parse: `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('powcuts_home.ps1', [ref]\$null, [ref]\$null); [System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/azdevops_workitems.ps1', [ref]\$null, [ref]\$null)"` exits clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWHAb7iCX93sWH1mXuiJpJ)_