### PR TITLE
docs: refresh AzDO diagrams for multi-project support (post-#59)

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -3,7 +3,7 @@
 Visual reference for the Azure DevOps work-item shortcuts in `powcuts_by_cli/azdevops_workitems.ps1`. Each diagram covers one subsystem; the last diagram is a cross-cutting function-dependency map.
 
 - [1. High-level architecture](#1-high-level-architecture)
-- [2. `az-Connect-AzDevOps` — 6-step orchestrator](#2-az-connect-azdevops--6-step-orchestrator)
+- [2. `az-Connect-AzDevOps` — 7-step orchestrator](#2-az-connect-azdevops--7-step-orchestrator)
 - [3. `az-Test-AzDevOpsAuth` — silent diagnostic chain](#3-az-test-azdevopsauth--silent-diagnostic-chain)
 - [4. `az-Sync-AzDevOpsCache` — dataset fan-out](#4-az-sync-azdevopscache--dataset-fan-out)
 - [5. Cache consumers (`az-Get-/az-Open-AzDevOps{Assigned,Mentions}`)](#5-cache-consumers-az-get-az-open-azdevopsassignedmentions)
@@ -107,9 +107,9 @@ flowchart LR
 
 ---
 
-## 2. `az-Connect-AzDevOps` — 6-step orchestrator
+## 2. `az-Connect-AzDevOps` — 7-step orchestrator
 
-Thin orchestrator: a hard-coded array of step descriptors. Each step is a `Confirm-*` function that prints its own status and returns `{Ok, FailMessage}`. First failure short-circuits with `NOT READY`.
+Thin orchestrator: a hard-coded array of step descriptors. Each step is a `Confirm-*` function that prints its own status and returns `{Ok, FailMessage}`. First failure short-circuits with `NOT READY`. Step 4 (`az-Confirm-AzDevOpsProjectMap`) is opt-in: it returns `Ok=$true` immediately when `$global:AzDevOpsProjectMap` is not defined, so single-project users skip it transparently.
 
 ```mermaid
 flowchart TD
@@ -118,9 +118,10 @@ flowchart TD
     S1["Step 1 — az-Confirm-AzDevOpsCli<br/>uses Test-AzDevOpsCliPresent"]
     S2["Step 2 — az-Confirm-AzDevOpsExtension<br/>uses Test-AzDevOpsExtensionInstalled<br/>+ optional 'az extension add'"]
     S3["Step 3 — az-Confirm-AzDevOpsEnvVars<br/>uses Get-AzDevOpsMissingEnvVars"]
-    S4["Step 4 — az-Confirm-AzDevOpsLogin<br/>uses Test-AzDevOpsLoggedIn<br/>+ optional 'az login'"]
-    S5["Step 5 — az-Set-AzDevOpsDefaults<br/>'az devops configure --defaults'"]
-    S6["Step 6 — az-Confirm-AzDevOpsSmokeQuery<br/>uses Invoke-AzDevOpsSmokeQuery"]
+    S4["Step 4 — az-Confirm-AzDevOpsProjectMap<br/>opt-in $global:AzDevOpsProjectMap<br/>+ optional az-Use-AzDevOpsProject prompt"]
+    S5["Step 5 — az-Confirm-AzDevOpsLogin<br/>uses Test-AzDevOpsLoggedIn<br/>+ optional 'az login'"]
+    S6["Step 6 — az-Set-AzDevOpsDefaults<br/>'az devops configure --defaults'"]
+    S7["Step 7 — az-Confirm-AzDevOpsSmokeQuery<br/>uses Invoke-AzDevOpsSmokeQuery"]
 
     Ready([READY])
     NotReady([NOT READY — blocked at step N])
@@ -130,7 +131,8 @@ flowchart TD
     S3 -- Ok --> S4
     S4 -- Ok --> S5
     S5 -- Ok --> S6
-    S6 -- Ok --> Ready
+    S6 -- Ok --> S7
+    S7 -- Ok --> Ready
 
     S1 -- fail --> NotReady
     S2 -- fail --> NotReady
@@ -138,9 +140,10 @@ flowchart TD
     S4 -- fail --> NotReady
     S5 -- fail --> NotReady
     S6 -- fail --> NotReady
+    S7 -- fail --> NotReady
 
     classDef step fill:#1f3a5f,stroke:#4ea3ff,color:#fff
-    class S1,S2,S3,S4,S5,S6 step
+    class S1,S2,S3,S4,S5,S6,S7 step
 ```
 
 Helpers used by every step:
@@ -514,7 +517,7 @@ Shared private helpers (named in CLAUDE.md):
 
 ## 11. Function dependency map
 
-Public functions on the left, private helpers on the right. Helpers under "Shared scaffolding" exist specifically because their bodies were duplicated across the parallel `Get-/Open-` pairs and the parallel `Register-/Unregister-` pairs.
+Public functions on the left, private helpers on the right. Helpers under "Shared scaffolding" exist specifically because their bodies were duplicated across the parallel `Get-/Open-` pairs and the parallel `Register-/Unregister-` pairs. The "Multi-project resolver layer" cluster collects the opt-in `$global:AzDevOpsProjectMap` switcher (`az-Use-/Show-/Get-AzDevOpsProject(s)`) plus every `Resolve-AzDevOpsType*` helper consumed by the `az-New-*` creators; when no map is defined, all resolvers return `$null`/`-1`/`@()` and the create paths fall through to today's prompt-driven flow.
 
 ```mermaid
 graph LR
@@ -541,10 +544,16 @@ graph LR
     NewSB(["az-New-AzDevOpsFeatureStories"]):::pub
     Find(["az-Find-AzDevOpsWorkItem"]):::pub
 
+    %% Multi-project switcher (azdevops_projects.ps1)
+    UseProj(["az-Use-AzDevOpsProject"]):::pub
+    ShowProj(["az-Show-AzDevOpsProject"]):::pub
+    GetProjs(["az-Get-AzDevOpsProjects"]):::pub
+
     %% Step helpers
     C1[az-Confirm-AzDevOpsCli]:::priv
     C2[az-Confirm-AzDevOpsExtension]:::priv
     C3[az-Confirm-AzDevOpsEnvVars]:::priv
+    CMap[az-Confirm-AzDevOpsProjectMap]:::priv
     C4[az-Confirm-AzDevOpsLogin]:::priv
     C5[az-Set-AzDevOpsDefaults]:::priv
     C6[az-Confirm-AzDevOpsSmokeQuery]:::priv
@@ -655,6 +664,30 @@ graph LR
     ResIA[Resolve-AzDevOpsIterationArea]:::priv
     CrLink[Invoke-AzDevOpsCreateAndLink]:::priv
 
+    %% Multi-project resolver layer (azdevops_projects.ps1)
+    MapDef[Test-AzDevOpsProjectMapDefined]:::priv
+    TypeKey[ConvertTo-AzDevOpsTypeKey]:::priv
+    ActName[Get-AzDevOpsActiveProjectName]:::priv
+    ActCfg[Get-AzDevOpsActiveProjectConfig]:::priv
+    TypeCfg[Get-AzDevOpsTypeConfig]:::priv
+    Slug[Get-AzDevOpsActiveProjectSlug]:::priv
+    SetEnv[Set-AzDevOpsActiveProjectEnv]:::priv
+    RArea[Resolve-AzDevOpsTypeArea]:::priv
+    RIter[Resolve-AzDevOpsTypeIteration]:::priv
+    RTags[Resolve-AzDevOpsTypeTags]:::priv
+    RReq[Resolve-AzDevOpsTypeRequiredFields]:::priv
+    RPri[Resolve-AzDevOpsTypeDefaultPriority]:::priv
+    RPts[Resolve-AzDevOpsTypeDefaultStoryPoints]:::priv
+    RScope[Resolve-AzDevOpsTypeParentScope]:::priv
+
+    %% Phase B creator wiring (azdevops_workitems.ps1)
+    RPriP[Resolve-AzDevOpsTypePriorityOrPrompt]:::priv
+    RPtsP[Resolve-AzDevOpsTypeStoryPointsOrPrompt]:::priv
+    RTagsE[Resolve-AzDevOpsTypeTagsOrEmpty]:::priv
+    ReadReq[Read-AzDevOpsRequiredFields]:::priv
+    ScopePaths[Get-AzDevOpsParentScopeAreaPaths]:::priv
+    AreaMatch[Test-AzDevOpsAreaPathMatch]:::priv
+
     %% I/O sinks
     Az[(az CLI)]:::io
     FS[(cache files)]:::io
@@ -662,11 +695,16 @@ graph LR
     Connect --> C1 --> TCli
     Connect --> C2 --> TExt
     Connect --> C3 --> TEnv
+    Connect --> CMap
     Connect --> C4 --> TLog
     Connect --> C5
     Connect --> C6 --> TSmoke
-    C1 & C2 & C3 & C4 & C5 & C6 --> StepRes
+    C1 & C2 & C3 & CMap & C4 & C5 & C6 --> StepRes
     C2 & C4 --> YN
+    CMap --> MapDef
+    CMap --> ActName
+    CMap --> ActCfg
+    CMap --> UseProj
 
     TestAuth --> TCli
     TestAuth --> TEnv
@@ -824,6 +862,62 @@ graph LR
     %% Reusable-prompt hint
     Pri --> ReuseHint
     Pts --> ReuseHint
+
+    %% Multi-project switcher fan-out (azdevops_projects.ps1)
+    UseProj --> MapDef
+    UseProj --> SetEnv
+    UseProj --> Az
+    ShowProj --> ActName
+    ShowProj --> ActCfg
+    GetProjs --> MapDef
+    GetProjs --> ActName
+    Paths --> Slug
+    Slug --> ActName
+    ActCfg --> MapDef
+    ActCfg --> ActName
+    TypeCfg --> ActCfg
+    TypeCfg --> TypeKey
+
+    %% Resolver layer (shared lookup chain)
+    RArea --> TypeCfg
+    RArea --> ActCfg
+    RIter --> TypeCfg
+    RIter --> ActCfg
+    RTags --> TypeCfg
+    RTags --> ActCfg
+    RReq --> TypeCfg
+    RPri --> TypeCfg
+    RPts --> TypeCfg
+    RScope --> TypeCfg
+
+    %% Phase B creator wiring
+    ResIA --> RArea
+    ResIA --> RIter
+    RPriP --> RPri
+    RPriP --> Pri
+    RPtsP --> RPts
+    RPtsP --> Pts
+    RTagsE --> RTags
+    ReadReq --> RReq
+
+    NewS --> RPriP
+    NewS --> RPtsP
+    NewS --> RTagsE
+    NewS --> ReadReq
+    NewF --> RPriP
+    NewF --> RTagsE
+    NewF --> ReadReq
+    NewSB --> RPriP
+    NewSB --> RPtsP
+    NewSB --> RTagsE
+    NewSB --> ReadReq
+
+    InvCreate -.System.Tags + ExtraFields.-> NewWI
+
+    %% ParentScope.AreaPaths filter (Phase B)
+    PFeat --> ScopePaths --> RScope
+    PEpic --> ScopePaths
+    PParent --> AreaMatch
 ```
 
 ---


### PR DESCRIPTION
## Summary
PR #59 shipped Phase A + Phase B for issue #56 but didn't update `docs/azure-devops-diagrams.md`. After the merge, Diagram 2 still says "6-step orchestrator" even though `az-Connect-AzDevOps` runs 7 steps now, and Diagram 11 (function dependency map) is missing every one of the 24 new functions the multi-project map introduced.

This PR closes that gap. Doc-only — no source code changes.

## Background
This is a doc-only follow-up to merged PR #59. Closed PR #60 attempted to ship Phase A + Phase B with diagram updates as a single change, but #59 landed first via an independent branch. Rather than rebase the conflicting source code, this branch starts fresh from the post-#59 main and ports just the diagram refresh, rewritten to use the function names that actually exist on main (`Test-AzDevOpsProjectMapDefined`, `Get-AzDevOpsActiveProject{Name,Config,Slug}`, `Resolve-AzDevOpsType{Priority,StoryPoints}OrPrompt`, etc.).

## Changes

### Diagram 2 — `az-Connect-AzDevOps` orchestrator
- Heading + ToC entry: "6-step orchestrator" → "7-step orchestrator"
- Added Step 4 `az-Confirm-AzDevOpsProjectMap` (opt-in: returns `Ok=$true` immediately when `$global:AzDevOpsProjectMap` undefined)
- Renumbered Login / Defaults / Smoke as steps 5 / 6 / 7
- Updated edges + classDef list to include S7

### Diagram 11 — Function dependency map
Two new clusters:

- **Multi-project switcher** — `az-Use-AzDevOpsProject`, `az-Show-AzDevOpsProject`, `az-Get-AzDevOpsProjects`, `az-Confirm-AzDevOpsProjectMap`
- **Multi-project resolver layer** — `Test-AzDevOpsProjectMapDefined`, `ConvertTo-AzDevOpsTypeKey`, `Get-AzDevOpsActiveProjectName`, `Get-AzDevOpsActiveProjectConfig`, `Get-AzDevOpsTypeConfig`, `Get-AzDevOpsActiveProjectSlug`, `Set-AzDevOpsActiveProjectEnv`, all seven `Resolve-AzDevOpsType*` resolvers, plus the Phase B creator wiring helpers (`Resolve-AzDevOpsType{Priority,StoryPoints}OrPrompt`, `Resolve-AzDevOpsTypeTagsOrEmpty`, `Read-AzDevOpsRequiredFields`, `Get-AzDevOpsParentScopeAreaPaths`, `Test-AzDevOpsAreaPathMatch`)

Edges added:
- `Connect → CMap → {MapDef, ActName, ActCfg, UseProj}`
- `ResIA → {RArea, RIter}`
- `NewS / NewF / NewSB → {RPriP, RPtsP, RTagsE, ReadReq}`
- `Get-AzDevOpsCachePaths → Slug → ActName`
- `Read-AzDevOpsFeaturePick / EpicPick → Get-AzDevOpsParentScopeAreaPaths → Resolve-AzDevOpsTypeParentScope`
- `Read-AzDevOpsParentPick → Test-AzDevOpsAreaPathMatch`

Preamble note expanded to call out the opt-in / silent-no-op semantics so readers know the resolver layer only activates with `$global:AzDevOpsProjectMap` defined.

## Verification
- Inventory check: all 24 functions added by PR #59 are referenced at least once in the updated diagram doc.
- Doc-only change — no PowerShell / bash files touched.

## Out of scope
The schema subsystem (`Get-AzDevOpsSchema*`, `Read/Write-AzDevOpsSchemaFile`, `ConvertFrom/To-AzDevOpsSchema*`, `Initialize-AzDevOpsSchemaDir`, `Invoke-AzDevOpsWorkItemTypeShow`, `New-AzDevOpsSchemaStub`, `Resolve-AzDevOpsEditor`, `Get-AzDevOpsWorkItemTypeDefinition`) has 16 helpers missing from Diagram 11. That drift is pre-existing (came from PRs #13 / #25) and unrelated to this change.

## Test Plan
- [ ] Open `docs/azure-devops-diagrams.md` on GitHub — both updated diagrams render with no mermaid parse errors.
- [ ] Diagram 2 shows 7 steps with Step 4 = `az-Confirm-AzDevOpsProjectMap`.
- [ ] Diagram 11 includes the new Multi-project switcher + resolver-layer clusters with edges flowing into the existing creator scaffolding.
- [ ] ToC link `[2. ... — 7-step orchestrator]` resolves to the renamed anchor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjELRAGdA4QzcZRffWEbDM)_