### PR TITLE
feat(#65): externalize hierarchy WIQL into user-machine config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,20 @@ In a fresh PowerShell terminal:
 az-Connect-AzDevOps
 ```
 
-This walks through six checks (Azure CLI present, `azure-devops` extension installed, env vars set, `az login` session active, `az devops` defaults configured, smoke `az boards query` succeeds) and prints a clear `READY` or `NOT READY` verdict at the end. It will offer to install the extension and run `az login` for you if either is missing.
+This walks through seven checks (Azure CLI present, `azure-devops` extension installed, env vars set, `az login` session active, `az devops` defaults configured, user-machine WIQL query files seeded, smoke `az boards query` succeeds) and prints a clear `READY` or `NOT READY` verdict at the end. It will offer to install the extension and run `az login` for you if either is missing.
 
 After `az-Connect-AzDevOps` reports `READY` once, later commands in the AzDevOps batch use the silent `az-Test-AzDevOpsAuth` check at startup to confirm the environment is still good before they hit the cache.
+
+### Customizing WIQL queries
+
+The `hierarchy` dataset that `az-Sync-AzDevOpsCache` writes into `hierarchy.json` is driven by a WIQL file on your own machine, not by code in this repo:
+
+- POSIX: `~/.bashcuts-config/azure-devops/queries/hierarchy.wiql`
+- Windows: `%USERPROFILE%\.bashcuts-config\azure-devops\queries\hierarchy.wiql`
+
+`az-Connect-AzDevOps` (and the first run of `az-Sync-AzDevOpsCache` if you skipped Connect) seeds the file with a sensible default — Epic / Feature / RequirementCategory items under `{{AZ_AREA}}`, where `{{AZ_AREA}}` is substituted from `$env:AZ_AREA` at read time. Edit the file to add fields to the SELECT clause, filter by state, scope by tag, or otherwise tailor what lands in `hierarchy.json`. Re-run `az-Sync-AzDevOpsCache` to pick up your changes — no `reinit` needed, since the file is read every sync.
+
+If you delete the file, the next sync writes the default back. The placeholder `{{AZ_AREA}}` is the only one currently supported; everything else in the file is passed through to `az boards query --wiql` verbatim.
 
 ### Day-to-day work-item shortcuts
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -19,7 +19,8 @@
 #   az-Confirm-AzDevOpsEnvVars          - step 3 (required $profile env vars set)
 #   az-Confirm-AzDevOpsLogin            - step 4 (az login session; offers login)
 #   az-Set-AzDevOpsDefaults             - step 5 (az devops configure --defaults)
-#   az-Confirm-AzDevOpsSmokeQuery       - step 6 (az boards query smoke test)
+#   az-Confirm-AzDevOpsQueryFiles       - step 6 (seed ~/.bashcuts-config WIQL files)
+#   az-Confirm-AzDevOpsSmokeQuery       - step 7 (az boards query smoke test)
 #
 # Silent diagnostic helpers (pure checks, no I/O — used by az-Test-AzDevOpsAuth):
 #   Test-AzDevOpsCliPresent          - is the `az` CLI on PATH?
@@ -302,6 +303,20 @@ function az-Set-AzDevOpsDefaults {
 }
 
 
+function az-Confirm-AzDevOpsQueryFiles {
+    $init = Initialize-AzDevOpsQueryFiles
+
+    if ($init.SeededHierarchy) {
+        Write-Host "  OK  Wrote default hierarchy.wiql to $($init.Paths.HierarchyQuery)" -ForegroundColor Green
+        Write-Host "      Edit this file to customize what az-Sync-AzDevOpsCache pulls into hierarchy.json." -ForegroundColor DarkGray
+    } else {
+        Write-Host "  OK  Query files at $($init.Paths.QueriesDir)" -ForegroundColor Green
+    }
+
+    return New-AzDevOpsStepResult -Ok $true
+}
+
+
 function az-Confirm-AzDevOpsSmokeQuery {
     $count = Invoke-AzDevOpsSmokeQuery
     if ($null -eq $count) {
@@ -335,7 +350,8 @@ function az-Connect-AzDevOps {
         @{ Num = 4; Name = 'Project map (multi-project)'; Action = { az-Confirm-AzDevOpsProjectMap } },
         @{ Num = 5; Name = 'Azure login session'; Action = { az-Confirm-AzDevOpsLogin } },
         @{ Num = 6; Name = 'Configure az devops defaults'; Action = { az-Set-AzDevOpsDefaults } },
-        @{ Num = 7; Name = 'Smoke test (az boards query)'; Action = { az-Confirm-AzDevOpsSmokeQuery } }
+        @{ Num = 7; Name = 'User-machine query files'; Action = { az-Confirm-AzDevOpsQueryFiles } },
+        @{ Num = 8; Name = 'Smoke test (az boards query)'; Action = { az-Confirm-AzDevOpsSmokeQuery } }
     )
 
     foreach ($step in $steps) {
@@ -410,6 +426,89 @@ function Initialize-AzDevOpsCacheDir {
         New-Item -ItemType Directory -Path $paths.Dir -Force | Out-Null
     }
     return $paths
+}
+
+
+# ---------------------------------------------------------------------------
+# User-machine config (queries)
+#
+# Config directory: $HOME/.bashcuts-config/azure-devops/queries/
+#   hierarchy.wiql  - WIQL pulled by the 'hierarchy' dataset in
+#                     Get-AzDevOpsSyncDatasets. Ships with a default that
+#                     filters by Epic/Feature/RequirementCategory under
+#                     {{AZ_AREA}}; users can edit this file to customize what
+#                     az-Sync-AzDevOpsCache writes into hierarchy.json without
+#                     touching tracked code.
+#
+# Placeholder tokens (substituted at read time by Get-AzDevOpsWiql):
+#   {{AZ_AREA}}  - $env:AZ_AREA. Keeps the file portable across machines /
+#                  projects without forcing users to hard-code their own area.
+# ---------------------------------------------------------------------------
+
+$script:AzDevOpsDefaultHierarchyWiql = @"
+Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.AreaPath] UNDER '{{AZ_AREA}}' AND ([System.WorkItemType] IN GROUP 'Microsoft.EpicCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.FeatureCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory')
+"@
+
+
+function Get-AzDevOpsConfigPaths {
+    $configDir  = Join-Path (Join-Path $HOME '.bashcuts-config') 'azure-devops'
+    $queriesDir = Join-Path $configDir 'queries'
+
+    return [PSCustomObject]@{
+        Dir            = $configDir
+        QueriesDir     = $queriesDir
+        HierarchyQuery = Join-Path $queriesDir 'hierarchy.wiql'
+    }
+}
+
+
+function Initialize-AzDevOpsQueryFiles {
+    # Idempotent: creates the queries directory if absent and seeds each
+    # default .wiql file only when the file does not already exist. Returns
+    # a hashtable describing what happened so callers (az-Connect-AzDevOps
+    # step + defensive call from Get-AzDevOpsSyncDatasets) can print a
+    # single, consistent status line.
+    $paths = Get-AzDevOpsConfigPaths
+
+    if (-not (Test-Path -LiteralPath $paths.QueriesDir)) {
+        New-Item -ItemType Directory -Path $paths.QueriesDir -Force | Out-Null
+    }
+
+    $seededHierarchy = $false
+    if (-not (Test-Path -LiteralPath $paths.HierarchyQuery)) {
+        Set-Content -LiteralPath $paths.HierarchyQuery -Value $script:AzDevOpsDefaultHierarchyWiql -Encoding UTF8
+        $seededHierarchy = $true
+    }
+
+    return [PSCustomObject]@{
+        Paths            = $paths
+        SeededHierarchy  = $seededHierarchy
+    }
+}
+
+
+function Get-AzDevOpsWiql {
+    # Reads a named WIQL file from the user-machine config dir, substituting
+    # known placeholder tokens. Defensively seeds defaults so callers don't
+    # need to remember to call Initialize-AzDevOpsQueryFiles first.
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('hierarchy')]
+        [string] $Name
+    )
+
+    $init = Initialize-AzDevOpsQueryFiles
+
+    $path = switch ($Name) {
+        'hierarchy' {
+            $init.Paths.HierarchyQuery
+        }
+    }
+
+    $raw = (Get-Content -LiteralPath $path -Raw).Trim()
+    $wiql = $raw.Replace('{{AZ_AREA}}', $env:AZ_AREA)
+
+    return $wiql
 }
 
 
@@ -510,20 +609,18 @@ function Get-AzDevOpsSyncDatasets {
     # populates the cache shape so downstream commands keep working.
     $mentionsToken = if ($env:AZ_USER_EMAIL) { "@$env:AZ_USER_EMAIL" } else { '@' }
 
-    $areaPathToken = $env:AZ_AREA
-
     $assignedWiql = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.ChangedDate] From WorkItems Where [System.AssignedTo] = @Me'
     $mentionsWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.ChangedBy], [System.AreaPath], [System.ChangedDate] From WorkItems Where [System.History] Contains '$mentionsToken'"
-    # Flat work-items query (not link-mode): az boards query resolves
-    # System.Parent + the rest of the fields for each item in one shot,
-    # giving az-Show-AzDevOpsTree everything it needs without re-calling az.
-    # IN GROUP queries by work-item-type *category* so this works on every
-    # process template - 'User Story' only exists in Agile; Scrum uses
-    # 'Product Backlog Item', CMMI uses 'Requirement', Basic uses 'Issue'.
-    # Project scope is supplied by --project on the az invocation
-    # (Invoke-AzDevOpsAzJson injects it from $env:AZ_PROJECT), so the WIQL
-    # itself no longer needs a [System.TeamProject] = @Project clause.
-    $hierarchyWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.AreaPath] UNDER '$areaPathToken' AND ([System.WorkItemType] IN GROUP 'Microsoft.EpicCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.FeatureCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory')"
+    # Hierarchy WIQL is sourced from ~/.bashcuts-config/azure-devops/queries/
+    # hierarchy.wiql so users can customize fields / filters per machine
+    # without modifying tracked code. Get-AzDevOpsWiql seeds the file with
+    # the default template-agnostic WIQL (Epic/Feature/RequirementCategory
+    # under {{AZ_AREA}}) on first call and substitutes {{AZ_AREA}} from
+    # $env:AZ_AREA at read time. Project scope is still supplied by
+    # --project on the az invocation (Invoke-AzDevOpsAzJson injects it from
+    # $env:AZ_PROJECT), so the WIQL itself does not need a
+    # [System.TeamProject] = @Project clause.
+    $hierarchyWiql = Get-AzDevOpsWiql -Name 'hierarchy'
 
     $rowCounter = { param($parsed) @($parsed).Count }
     $treeCounter = { param($parsed) Measure-AzDevOpsClassificationNodes -Node $parsed }


### PR DESCRIPTION
<!-- toc:start -->
## 🧭 Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#summary) | Closes #65 |
| [Files changed](#files-changed) | ✅ 2 files (+123 / -15) |
| [Verification plan](#verification-plan) | ✅ 6 steps |
| [Branch context](#branch-context) | ✅ |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/66#issuecomment-4431652897) |
| 💠 PowerShell Engineer Review | ✅ APPROVE (1 MED follow-up) — [View](https://github.com/jdschleicher/bashcuts/pull/66#issuecomment-4431661551) |
| 🛡️ Security Audit | ✅ PASS (1 MED, 3 LOW) — [View](https://github.com/jdschleicher/bashcuts/pull/66#issuecomment-4431664529) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE w/ follow-ups (2 MED, 3 LOW) — [View](https://github.com/jdschleicher/bashcuts/pull/66#issuecomment-4431665750) |
| 📚 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/66#issuecomment-4431674959) |
| ✅ Criteria Check | ✅ PASS (7 verified, 1 partial, 2 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/66#issuecomment-4431683289) |
| 📐 AzDO Diagrams Check | ⚠️ STALE (3 findings) — [View](https://github.com/jdschleicher/bashcuts/pull/66#issuecomment-4431701596) |

> Post-merge `/pr-flow` retrospective. PR merged 2026-05-12T14:41:26Z; all skill reports are informational follow-ups.
<!-- toc:end -->

## Summary

Closes #65.

Moves the hierarchy WIQL out of `azdevops_workitems.ps1` and into a per-machine config file at `~/.bashcuts-config/azure-devops/queries/hierarchy.wiql`, so users can customize fields and filters without modifying tracked code.

- New `Get-AzDevOpsWiql` reads the file at sync time and substitutes `{{AZ_AREA}}` from `$env:AZ_AREA`
- New `az-Confirm-AzDevOpsQueryFiles` step in `az-Connect-AzDevOps` (now 7 checks instead of 6) seeds the default WIQL on first run
- Default WIQL ships in `$script:AzDevOpsDefaultHierarchyWiql` — Epic / Feature / RequirementCategory under the user's area path
- Deleting the file is a supported reset: next sync writes the default back

## Files changed

- `powcuts_by_cli/azdevops_workitems.ps1` — new helpers, new Connect step, default WIQL constant
- `README.md` — new "Customizing WIQL queries" section, Connect step count bumped 6 → 7

## Verification plan

In a fresh PowerShell terminal:

```powershell
# 1. Source the profile so the new functions load
. $profile

# 2. Run the connect flow - should now show 7 checks, with step 7 seeding the WIQL file
az-Connect-AzDevOps

# 3. Confirm the file landed on disk with the default content
Get-Content ~/.bashcuts-config/azure-devops/queries/hierarchy.wiql

# 4. Confirm placeholder substitution works
$env:AZ_AREA = 'MyProject\MyArea'
az-Sync-AzDevOpsCache -Datasets hierarchy

# 5. Edit the file (e.g. add a [System.Tags] filter), re-sync, confirm hierarchy.json reflects the change
code ~/.bashcuts-config/azure-devops/queries/hierarchy.wiql
az-Sync-AzDevOpsCache -Datasets hierarchy

# 6. Delete the file, re-run Connect, confirm default is rewritten
Remove-Item ~/.bashcuts-config/azure-devops/queries/hierarchy.wiql
az-Connect-AzDevOps
```

Note: `pwsh` was not available in the sandbox, so the parse check is part of the verification plan rather than pre-validated locally.

## Branch context

This PR contains a single commit cherry-picked from a long-running working branch onto a fresh feature branch off `main`, so the diff scope matches the issue scope.

https://claude.ai/code/session_01FiHZECchbUr47AK1n1Etnt

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiHZECchbUr47AK1n1Etnt)_