### PR TITLE
refactor(#65 follow-up): harden WIQL substitution + refresh AzDO diagrams

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -3,7 +3,7 @@
 Visual reference for the Azure DevOps work-item shortcuts in `powcuts_by_cli/azdevops_workitems.ps1`. Each diagram covers one subsystem; the last diagram is a cross-cutting function-dependency map.
 
 - [1. High-level architecture](#1-high-level-architecture)
-- [2. `az-Connect-AzDevOps` — 7-step orchestrator](#2-az-connect-azdevops--7-step-orchestrator)
+- [2. `az-Connect-AzDevOps` — 8-step orchestrator](#2-az-connect-azdevops--8-step-orchestrator)
 - [3. `az-Test-AzDevOpsAuth` — silent diagnostic chain](#3-az-test-azdevopsauth--silent-diagnostic-chain)
 - [4. `az-Sync-AzDevOpsCache` — dataset fan-out](#4-az-sync-azdevopscache--dataset-fan-out)
 - [5. Cache consumers (`az-Get-/az-Open-AzDevOps{Assigned,Mentions}`)](#5-cache-consumers-az-get-az-open-azdevopsassignedmentions)
@@ -107,9 +107,9 @@ flowchart LR
 
 ---
 
-## 2. `az-Connect-AzDevOps` — 7-step orchestrator
+## 2. `az-Connect-AzDevOps` — 8-step orchestrator
 
-Thin orchestrator: a hard-coded array of step descriptors. Each step is a `Confirm-*` function that prints its own status and returns `{Ok, FailMessage}`. First failure short-circuits with `NOT READY`. Step 4 (`az-Confirm-AzDevOpsProjectMap`) is opt-in: it returns `Ok=$true` immediately when `$global:AzDevOpsProjectMap` is not defined, so single-project users skip it transparently.
+Thin orchestrator: a hard-coded array of step descriptors. Each step is a `Confirm-*` function that prints its own status and returns `{Ok, FailMessage}`. First failure short-circuits with `NOT READY`. Step 4 (`az-Confirm-AzDevOpsProjectMap`) is opt-in: it returns `Ok=$true` immediately when `$global:AzDevOpsProjectMap` is not defined, so single-project users skip it transparently. Step 7 (`az-Confirm-AzDevOpsQueryFiles`) seeds the user-machine WIQL config under `~/.bashcuts-config/azure-devops/queries/` so subsequent `az-Sync-AzDevOpsCache` runs can read a customizable `hierarchy.wiql` rather than an inline string.
 
 ```mermaid
 flowchart TD
@@ -121,7 +121,8 @@ flowchart TD
     S4["Step 4 — az-Confirm-AzDevOpsProjectMap<br/>opt-in $global:AzDevOpsProjectMap<br/>+ optional az-Use-AzDevOpsProject prompt"]
     S5["Step 5 — az-Confirm-AzDevOpsLogin<br/>uses Test-AzDevOpsLoggedIn<br/>+ optional 'az login'"]
     S6["Step 6 — az-Set-AzDevOpsDefaults<br/>'az devops configure --defaults'"]
-    S7["Step 7 — az-Confirm-AzDevOpsSmokeQuery<br/>uses Invoke-AzDevOpsSmokeQuery"]
+    S7["Step 7 — az-Confirm-AzDevOpsQueryFiles<br/>seeds ~/.bashcuts-config/.../hierarchy.wiql<br/>via Initialize-AzDevOpsQueryFiles"]
+    S8["Step 8 — az-Confirm-AzDevOpsSmokeQuery<br/>uses Invoke-AzDevOpsSmokeQuery"]
 
     Ready([READY])
     NotReady([NOT READY — blocked at step N])
@@ -132,7 +133,8 @@ flowchart TD
     S4 -- Ok --> S5
     S5 -- Ok --> S6
     S6 -- Ok --> S7
-    S7 -- Ok --> Ready
+    S7 -- Ok --> S8
+    S8 -- Ok --> Ready
 
     S1 -- fail --> NotReady
     S2 -- fail --> NotReady
@@ -141,9 +143,10 @@ flowchart TD
     S5 -- fail --> NotReady
     S6 -- fail --> NotReady
     S7 -- fail --> NotReady
+    S8 -- fail --> NotReady
 
     classDef step fill:#1f3a5f,stroke:#4ea3ff,color:#fff
-    class S1,S2,S3,S4,S5,S6,S7 step
+    class S1,S2,S3,S4,S5,S6,S7,S8 step
 ```
 
 Helpers used by every step:
@@ -214,7 +217,7 @@ flowchart TD
         direction LR
         D1["assigned<br/>WIQL System.AssignedTo = @Me"]
         D2["mentions<br/>WIQL System.History Contains '@email'"]
-        D3["hierarchy<br/>WIQL Epic/Feature/Story flat<br/>+ System.Parent"]
+        D3["hierarchy<br/>Get-AzDevOpsWiql -Name 'hierarchy'<br/>(reads ~/.bashcuts-config/.../hierarchy.wiql,<br/>substitutes {{AZ_AREA}})<br/>→ WIQL Epic/Feature/Story flat + System.Parent"]
         D4["iterations<br/>Get-AzDevOpsClassificationList -Kind Iteration<br/>→ az boards iteration project list --depth 5"]
         D5["areas<br/>Get-AzDevOpsClassificationList -Kind Area<br/>→ az boards area project list --depth 5"]
     end
@@ -557,6 +560,7 @@ graph LR
     C4[az-Confirm-AzDevOpsLogin]:::priv
     C5[az-Set-AzDevOpsDefaults]:::priv
     C6[az-Confirm-AzDevOpsSmokeQuery]:::priv
+    C7[az-Confirm-AzDevOpsQueryFiles]:::priv
     StepRes[New-AzDevOpsStepResult]:::priv
     YN[Read-AzDevOpsYesNo]:::priv
 
@@ -581,6 +585,12 @@ graph LR
     DStatus[New-AzDevOpsDatasetStatus]:::priv
     StderrW[Write-AzDevOpsSyncStderr]:::priv
     Measure[Measure-AzDevOpsClassificationNodes]:::priv
+
+    %% Query config (azdevops_workitems.ps1)
+    QPaths[Get-AzDevOpsConfigPaths]:::priv
+    QInit[Initialize-AzDevOpsQueryFiles]:::priv
+    QWiql[Get-AzDevOpsWiql]:::priv
+    MkDir[New-AzDevOpsDirectoryIfMissing]:::priv
 
     %% Data-plane wrappers (azdevops_db.ps1)
     AzJson[Invoke-AzDevOpsAzJson]:::priv
@@ -698,8 +708,9 @@ graph LR
     Connect --> CMap
     Connect --> C4 --> TLog
     Connect --> C5
+    Connect --> C7 --> QInit
     Connect --> C6 --> TSmoke
-    C1 & C2 & C3 & CMap & C4 & C5 & C6 --> StepRes
+    C1 & C2 & C3 & CMap & C4 & C5 & C6 & C7 --> StepRes
     C2 & C4 --> YN
     CMap --> MapDef
     CMap --> ActName
@@ -713,8 +724,12 @@ graph LR
 
     Sync --> TestAuth
     Sync --> InitDir --> Paths
+    InitDir --> MkDir
     Sync --> LogFn --> Paths
     Sync --> DSets
+    DSets --> QWiql --> QInit
+    QInit --> QPaths
+    QInit --> MkDir
     Sync --> InvokeDS
     InvokeDS --> Boards
     InvokeDS --> ClassList

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -313,7 +313,8 @@ function az-Confirm-AzDevOpsQueryFiles {
         Write-Host "  OK  Query files at $($init.Paths.QueriesDir)" -ForegroundColor Green
     }
 
-    return New-AzDevOpsStepResult -Ok $true
+    $stepResult = New-AzDevOpsStepResult -Ok $true
+    return $stepResult
 }
 
 
@@ -420,11 +421,21 @@ function Get-AzDevOpsCachePaths {
 }
 
 
+function New-AzDevOpsDirectoryIfMissing {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+
 function Initialize-AzDevOpsCacheDir {
     $paths = Get-AzDevOpsCachePaths
-    if (-not (Test-Path -LiteralPath $paths.Dir)) {
-        New-Item -ItemType Directory -Path $paths.Dir -Force | Out-Null
-    }
+    New-AzDevOpsDirectoryIfMissing -Path $paths.Dir
     return $paths
 }
 
@@ -444,6 +455,8 @@ function Initialize-AzDevOpsCacheDir {
 #   {{AZ_AREA}}  - $env:AZ_AREA. Keeps the file portable across machines /
 #                  projects without forcing users to hard-code their own area.
 # ---------------------------------------------------------------------------
+
+$script:AzDevOpsAreaToken = '{{AZ_AREA}}'
 
 $script:AzDevOpsDefaultHierarchyWiql = @"
 Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.AreaPath] UNDER '{{AZ_AREA}}' AND ([System.WorkItemType] IN GROUP 'Microsoft.EpicCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.FeatureCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory')
@@ -469,10 +482,7 @@ function Initialize-AzDevOpsQueryFiles {
     # step + defensive call from Get-AzDevOpsSyncDatasets) can print a
     # single, consistent status line.
     $paths = Get-AzDevOpsConfigPaths
-
-    if (-not (Test-Path -LiteralPath $paths.QueriesDir)) {
-        New-Item -ItemType Directory -Path $paths.QueriesDir -Force | Out-Null
-    }
+    New-AzDevOpsDirectoryIfMissing -Path $paths.QueriesDir
 
     $seededHierarchy = $false
     if (-not (Test-Path -LiteralPath $paths.HierarchyQuery)) {
@@ -505,8 +515,17 @@ function Get-AzDevOpsWiql {
         }
     }
 
-    $raw = (Get-Content -LiteralPath $path -Raw).Trim()
-    $wiql = $raw.Replace('{{AZ_AREA}}', $env:AZ_AREA)
+    if ([string]::IsNullOrWhiteSpace($env:AZ_AREA)) {
+        throw "Get-AzDevOpsWiql: `$env:AZ_AREA must be set to substitute $script:AzDevOpsAreaToken in $path."
+    }
+
+    $rawContent = Get-Content -LiteralPath $path -Raw
+    $raw = $rawContent.Trim()
+
+    # Escape single quotes for WIQL string-literal safety — area paths with apostrophes
+    # would otherwise break out of the [System.AreaPath] UNDER '...' literal.
+    $areaEscaped = $env:AZ_AREA.Replace("'", "''")
+    $wiql = $raw.Replace($script:AzDevOpsAreaToken, $areaEscaped)
 
     return $wiql
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #66. Addresses the `/pr-flow` review findings in two parts:

1. **Code hardening + clean-up** on `powcuts_by_cli/azdevops_workitems.ps1`
2. **Diagram refresh** on `docs/azure-devops-diagrams.md` for the AzDO subsystem changes in #65

## Issue
References #65 (merged via PR #66).

## Changes

### 🛡️ Code fixes (`powcuts_by_cli/azdevops_workitems.ps1`)

#### 1. `{{AZ_AREA}}` substitution hardening — `Get-AzDevOpsWiql`

Three problems flagged across the PowerShell, Security, and Clean-Code reviews on PR #66:

- **Null guard:** `String.Replace($null)` throws on Windows PowerShell 5.1 when `$env:AZ_AREA` is unset.
- **Quote-escape:** area paths containing an apostrophe break out of the `[System.AreaPath] UNDER '...'` literal.
- **Magic-string repetition:** `'{{AZ_AREA}}'` appeared as an inline literal in 3 places.

```powershell
$script:AzDevOpsAreaToken = '{{AZ_AREA}}'  # named once at module scope

# In Get-AzDevOpsWiql:
if ([string]::IsNullOrWhiteSpace($env:AZ_AREA)) {
    throw "Get-AzDevOpsWiql: `$env:AZ_AREA must be set to substitute $script:AzDevOpsAreaToken in $path."
}

$areaEscaped = $env:AZ_AREA.Replace("'", "''")
$wiql = $raw.Replace($script:AzDevOpsAreaToken, $areaEscaped)
```

#### 2. `return New-AzDevOpsStepResult -Ok $true` direct-return fix

CLAUDE.md "Never `return` a function call directly" rule. Capture in a named local:

```powershell
$stepResult = New-AzDevOpsStepResult -Ok $true
return $stepResult
```

Scope-limited to `az-Confirm-AzDevOpsQueryFiles:316` (the line PR #66 added). The same pattern is pre-existing throughout the file's other `az-Confirm-*` siblings; a broader sweep is out of scope for this follow-up.

#### 3. Extract `New-AzDevOpsDirectoryIfMissing` helper

CLAUDE.md "extract-repeated-branches" rule — the same `Test-Path / New-Item -ItemType Directory -Force | Out-Null` block lived in both `Initialize-AzDevOpsCacheDir` and `Initialize-AzDevOpsQueryFiles`. Extracted to a single private helper consumed by both.

### 📐 Diagram refresh (`docs/azure-devops-diagrams.md`)

Three findings from the `/azdevops-diagrams-check` post-merge audit on PR #66:

- **Diagram 2 (`az-Connect-AzDevOps`)** — `7-step` → `8-step`. New step 7 `az-Confirm-AzDevOpsQueryFiles` inserted between defaults and smoke; smoke renumbered to S8. Step list, edge graph, class binding, and TOC entry all updated.
- **Diagram 4 (`az-Sync-AzDevOpsCache`)** — `D3` hierarchy descriptor now explicitly shows the `Get-AzDevOpsWiql -Name 'hierarchy'` read of `~/.bashcuts-config/.../hierarchy.wiql` + `{{AZ_AREA}}` substitution before the WIQL hits `Invoke-AzDevOpsBoardsQuery`.
- **Diagram 11 (function dependency map)** — added four new private nodes (`C7 az-Confirm-AzDevOpsQueryFiles`, `QPaths Get-AzDevOpsConfigPaths`, `QInit Initialize-AzDevOpsQueryFiles`, `QWiql Get-AzDevOpsWiql`) plus `MkDir New-AzDevOpsDirectoryIfMissing` from this PR's helper extraction. Wired edges: `Connect→C7→QInit`, `DSets→QWiql→QInit`, `QInit→QPaths`, `QInit→MkDir`, `InitDir→MkDir`. Added C7 to the `StepRes` aggregator.

## Files changed

- `powcuts_by_cli/azdevops_workitems.ps1` — +30 / -10
- `docs/azure-devops-diagrams.md` — +23 / -8

## Verification plan

```powershell
# 1. Reload profile to pick up the new helper + hardened Get-AzDevOpsWiql
. $profile

# 2. Confirm parse succeeds (no syntax regression)
[System.Management.Automation.Language.Parser]::ParseFile(
    "$path_to_bashcuts\powcuts_by_cli\azdevops_workitems.ps1",
    [ref]$null, [ref]$null
) | Out-Null

# 3. Verify the null-guard fires cleanly
$env:AZ_AREA = $null
Get-AzDevOpsWiql -Name 'hierarchy'
# Expect: clear throw "Get-AzDevOpsWiql: $env:AZ_AREA must be set..."

# 4. Verify quote-escape works
$env:AZ_AREA = "Foo's Project\Area"
$wiql = Get-AzDevOpsWiql -Name 'hierarchy'
$wiql -match "UNDER 'Foo''s Project\\\\Area'"  # apostrophe doubled, literal closes correctly
# Expect: $true

# 5. Connect-AzDevOps still runs all 8 steps cleanly
az-Connect-AzDevOps
# Expect: 8 numbered checks, step 7 = "User-machine query files", step 8 = smoke

# 6. Re-run sync — defensive seeding still works via the shared helper
az-Sync-AzDevOpsCache -Datasets hierarchy
```

Diagrams: render `docs/azure-devops-diagrams.md` in any mermaid-aware previewer (GitHub renders inline). Confirm Diagram 2 shows 8 steps, Diagram 4 D3 shows the file-read chain, Diagram 11 has the 5 new nodes with their edges.

Note: `pwsh` not available in the sandbox, so the parse step is part of the verification plan.

## Related

- Issue #65 — externalize hierarchy WIQL (closed)
- PR #66 — original implementation (merged)
- Prior pattern: PR #59 → commit `6126635` ("docs: refresh AzDO diagrams for multi-project support post-#59") established the post-merge diagram-refresh convention this PR follows.

https://claude.ai/code/session_01FiHZECchbUr47AK1n1Etnt

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiHZECchbUr47AK1n1Etnt)_