### PR TITLE
feat(#68): add Start-TimerSession Pomodoro timer with integration picker + auto-debrief discussion comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 * [System Setup for bash and PowerShell Profiles](#system-setup)
 * [How to use bashcuts](#how-to)
 * [Azure DevOps work-item shortcuts](#azure-devops)
+* [Timer sessions](#timer-sessions)
 
 <br>
 
@@ -346,4 +347,65 @@ Schema file format (one entry per work-item type, each with `required` and `opti
 ```
 
 Supported `type` values: `string`, `int`, `picklist`, `bool`, `date`, `multiline`. Unknown types are treated as `string` with a warning from `az-Test-AzDevOpsSchema`.
+
+<br>
+
+***
+
+<br>
+
+# <a name="timer-sessions"></a>Timer sessions
+
+`Start-TimerSession` runs a focus-timer Pomodoro against an item from one of your registered integrations and auto-posts your debrief notes as a discussion comment on the chosen item. The Azure DevOps integration is registered out of the box — it reads your cached assigned items (`az-Sync-AzDevOpsCache`), shows them sorted by State + Priority, and posts the debrief via `az boards work-item update --discussion`.
+
+### Run a session
+
+```powershell
+# 25-minute default
+Start-TimerSession
+
+# Custom duration
+Start-TimerSession -Minutes 45
+
+# Skip the integration picker (one registered integration is also auto-selected)
+Start-TimerSession -Integration 'Azure DevOps - User Stories'
+```
+
+Flow:
+1. Pick an integration (skipped when `-Integration` is supplied or only one is registered)
+2. Pick an item from the integration's grid
+3. Snake-animation countdown runs for `$Minutes`
+4. Debrief prompts (`debrief notes`, `what's next`) → comment posted on the picked item
+
+### Interrupting a session
+
+Press **Esc** during the countdown to end the session early and still go through the debrief prompts. The posted comment header reflects the outcome:
+
+- Completed: `Pomodoro complete — 25:00`
+- Interrupted: `Session interrupted at 04:30 of 25:00`
+
+After an interrupted session's comment posts, you're asked `Start a new session? [Y/n]` so you can pivot to a different story / integration without retyping the command. **Ctrl-C** is still a hard exit — no debrief, no comment.
+
+### Registering your own integration
+
+Add to your `$profile` (or any file dot-sourced from it). Registering with an existing `Name` replaces the prior entry, so you can override the built-in AzDO integration without touching tracked code.
+
+```powershell
+Register-TimerIntegration `
+    -Name        'My Tracker' `
+    -Description 'Items from my custom tracker' `
+    -FetchItems  {
+        # Return rows with at least Id, Type, State, Title.
+        # Optional: Priority, Iteration, anything else you want in the picker.
+        Get-MyTrackerItems | Where-Object { $_.Status -ne 'Done' }
+    } `
+    -AddComment  {
+        param([Parameter(Mandatory)] [int] $Id, [Parameter(Mandatory)] [string] $Body)
+        Add-MyTrackerComment -Id $Id -Body $Body
+    } `
+    -ViewHint    {
+        param([Parameter(Mandatory)] [int] $Id)
+        "View: my-tracker open $Id"
+    }
+```
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -59,7 +59,7 @@ flowchart LR
     end
 
     subgraph AzCLI["Azure CLI"]
-        AzBoards["az boards query / work-item create / relation add"]
+        AzBoards["az boards query / work-item create / work-item update / relation add"]
         AzExt["az extension (azure-devops)"]
         AzAcct["az account show / az login"]
     end
@@ -598,6 +598,7 @@ graph LR
     ClassList[Get-AzDevOpsClassificationList]:::priv
     NewWI[New-AzDevOpsWorkItem]:::priv
     AddRel[Add-AzDevOpsWorkItemRelation]:::priv
+    AddDisc[Add-AzDevOpsDiscussionComment]:::priv
 
     %% Query echo helpers (azdevops_db.ps1)
     CmdDisp[Format-AzDevOpsCommandDisplay]:::priv
@@ -735,6 +736,7 @@ graph LR
     InvokeDS --> ClassList
     Boards --> AzJson
     ClassList --> AzJson
+    AddDisc --> AzJson
     Boards --> EchoLn
     AzJson --> CmdDisp
     AzJson --> CmdHead

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -284,6 +284,27 @@ function Add-AzDevOpsWorkItemRelation {
 }
 
 
+function Add-AzDevOpsDiscussionComment {
+    # `az boards work-item update --id <id> --discussion <body>` wrapper. Adds
+    # a comment to the Discussion / History thread of a work item. Returns the
+    # canonical { Json, Error, ExitCode } envelope; the parsed JSON is the
+    # updated work-item shape (same as `az boards work-item update`). The
+    # always-on echo from Invoke-AzDevOpsAzJson surfaces the assembled az
+    # command so the user can see exactly what was posted.
+    param(
+        [Parameter(Mandatory)] [int]    $Id,
+        [Parameter(Mandatory)] [string] $Body
+    )
+
+    $result = Invoke-AzDevOpsAzJson -ArgList @(
+        'boards', 'work-item', 'update',
+        '--id',         "$Id",
+        '--discussion', $Body
+    )
+    return $result
+}
+
+
 function Get-AzDevOpsWorkItemTypeDefinition {
     # `az devops invoke --area wit --resource workitemtypes` wrapper. Returns
     # the type's field-instance definitions inside the canonical envelope so

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -628,7 +628,7 @@ function Get-AzDevOpsSyncDatasets {
     # populates the cache shape so downstream commands keep working.
     $mentionsToken = if ($env:AZ_USER_EMAIL) { "@$env:AZ_USER_EMAIL" } else { '@' }
 
-    $assignedWiql = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.ChangedDate] From WorkItems Where [System.AssignedTo] = @Me'
+    $assignedWiql = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.ChangedDate], [Microsoft.VSTS.Common.Priority] From WorkItems Where [System.AssignedTo] = @Me'
     $mentionsWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.ChangedBy], [System.AreaPath], [System.ChangedDate] From WorkItems Where [System.History] Contains '$mentionsToken'"
     # Hierarchy WIQL is sourced from ~/.bashcuts-config/azure-devops/queries/
     # hierarchy.wiql so users can customize fields / filters per machine
@@ -1153,13 +1153,33 @@ function ConvertFrom-AzDevOpsAssignedItem {
     param([Parameter(Mandatory)] $Raw)
 
     $f = $Raw.fields
+
+    $id = if ($f.'System.Id') {
+        [int]$f.'System.Id'
+    } else {
+        [int]$Raw.id
+    }
+
+    $assignedAt = if ($f.'System.ChangedDate') {
+        [datetime]$f.'System.ChangedDate'
+    } else {
+        $null
+    }
+
+    $priority = if ($null -ne $f.'Microsoft.VSTS.Common.Priority') {
+        [int]$f.'Microsoft.VSTS.Common.Priority'
+    } else {
+        $null
+    }
+
     return [PSCustomObject]@{
-        Id         = if ($f.'System.Id') { [int]$f.'System.Id' } else { [int]$Raw.id }
+        Id         = $id
         Type       = $f.'System.WorkItemType'
         State      = $f.'System.State'
         Title      = $f.'System.Title'
         Iteration  = $f.'System.IterationPath'
-        AssignedAt = if ($f.'System.ChangedDate') { [datetime]$f.'System.ChangedDate' } else { $null }
+        Priority   = $priority
+        AssignedAt = $assignedAt
     }
 }
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -1077,8 +1077,7 @@ function az-Unregister-AzDevOpsSyncSchedule {
 # ---------------------------------------------------------------------------
 
 function Test-AzDevOpsGridAvailable {
-    $cmd = Get-Command Out-ConsoleGridView -ErrorAction SilentlyContinue
-    $available = ($null -ne $cmd)
+    $available = Test-ConsoleGridAvailable
     return $available
 }
 

--- a/powcuts_by_cli/pow_common.ps1
+++ b/powcuts_by_cli/pow_common.ps1
@@ -69,7 +69,7 @@ function kill-by-port() {
 }
 
 function pow_remove_property_from_field {
-    param( 
+    param(
         [Parameter(Mandatory=$true)]
         $property,
         [Parameter(Mandatory=$true)]
@@ -80,4 +80,16 @@ function pow_remove_property_from_field {
 
     $object
 
+}
+
+
+function Test-ConsoleGridAvailable {
+    # $true iff Out-ConsoleGridView (from Microsoft.PowerShell.ConsoleGuiTools)
+    # is loaded. Used by every cross-platform interactive picker - the TUI
+    # grid is much friendlier than a numbered Read-Host menu, but it only
+    # exists when the user has installed the module. Callers check this and
+    # fall back to their own numbered prompt when it's missing.
+    $cmd = Get-Command Out-ConsoleGridView -ErrorAction SilentlyContinue
+    $available = ($null -ne $cmd)
+    return $available
 }

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -1,0 +1,494 @@
+# ---------------------------------------------------------------------------
+# Timer sessions — integration-agnostic Pomodoro timer with auto-debrief
+#
+# Public surface:
+#   Start-TimerSession         - pick integration -> pick item -> run timer ->
+#                                prompt for debrief -> post comment.
+#                                Press Esc during the countdown to end early
+#                                and still post a debrief.
+#   Register-TimerIntegration  - add an integration (Name, Description,
+#                                FetchItems, AddComment, optional ViewHint).
+#                                Registering with an existing Name replaces it.
+#
+# Integration contract (each entry of $script:TimerIntegrations):
+#   Name        [string]      - display name shown in the picker
+#   Description [string]      - one-line subtitle
+#   FetchItems  [scriptblock] - returns rows with at least Id, Type, State,
+#                               Title; Priority/Iteration optional
+#   AddComment  [scriptblock] - param([int]$Id, [string]$Body); posts the
+#                               composed debrief comment on the chosen item
+#   ViewHint    [scriptblock] - param([int]$Id); returns a one-line string
+#                               printed after a successful comment post
+#                               (e.g. "View discussion: az-Open-AzDevOpsAssigned 1234")
+#
+# Azure DevOps integration is registered at the bottom of this file; reads
+# $HOME/.bashcuts-cache/azure-devops/assigned.json (populated by
+# az-Sync-AzDevOpsCache) and posts via Add-AzDevOpsDiscussionComment.
+# ---------------------------------------------------------------------------
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$script:TimerIconSnakeHead  = "$([char]0x1F40D)"
+$script:TimerIconSnakeBody  = "$([char]0x1F7E9)"
+$script:TimerIconApple      = "$([char]0x1F34E)"
+$script:TimerIconClock      = "$([char]0x23F0)"
+$script:TimerIconCheck      = "$([char]0x2705)"
+$script:TimerIconWarn       = "$([char]0x26A0)$([char]0xFE0F)"
+$script:TimerIconMemo       = "$([char]0x1F4DD)"
+$script:TimerIconRocket     = "$([char]0x1F680)"
+$script:TimerIconWave       = "$([char]0x1F44B)"
+$script:TimerIconFinish     = "$([char]0x1F3C1)"
+
+$script:TimerMaxSnakeLength = 15
+$script:TimerDefaultMinutes = 25
+$script:TimerPollIntervalMs = 100
+$script:TimerPollsPerSecond = 10
+
+$script:TimerIntegrations = @()
+
+
+function Test-TimerGridAvailable {
+    $cmd = Get-Command Out-ConsoleGridView -ErrorAction SilentlyContinue
+    $available = ($null -ne $cmd)
+    return $available
+}
+
+
+function Format-TimerElapsed {
+    param([Parameter(Mandatory)] [int] $Seconds)
+
+    $minutes = [math]::Floor($Seconds / 60)
+    $rem = $Seconds % 60
+    $display = '{0:D2}:{1:D2}' -f $minutes, $rem
+    return $display
+}
+
+
+function Read-TimerYesNo {
+    param(
+        [Parameter(Mandatory)] [string] $Prompt,
+        [switch] $DefaultYes
+    )
+
+    $suffix = if ($DefaultYes) {
+        '[Y/n]'
+    } else {
+        '[y/N]'
+    }
+
+    $raw = Read-Host "$Prompt $suffix"
+    if (-not $raw) {
+        $result = [bool]$DefaultYes
+        return $result
+    }
+
+    $normalized = $raw.Trim().ToLowerInvariant()
+    $result = ($normalized -eq 'y' -or $normalized -eq 'yes')
+    return $result
+}
+
+
+function Read-TimerNumberedPick {
+    # Fallback picker for terminals without Out-ConsoleGridView. Blank input
+    # cancels (returns $null); out-of-range / non-numeric input also cancels
+    # with a hint.
+    param(
+        [Parameter(Mandatory)] $Items,
+        [Parameter(Mandatory)] [string] $DisplayProperty,
+        [Parameter(Mandatory)] [string] $Title
+    )
+
+    $list = @($Items)
+    if ($list.Count -eq 0) {
+        return $null
+    }
+
+    Write-Host ""
+    Write-Host $Title -ForegroundColor Cyan
+    for ($i = 0; $i -lt $list.Count; $i++) {
+        $n = $i + 1
+        $label = $list[$i].$DisplayProperty
+        Write-Host "  [$n] $label"
+    }
+
+    $raw = Read-Host "Enter a number (blank to cancel)"
+    if (-not $raw) {
+        return $null
+    }
+
+    $idx = 0
+    if (-not [int]::TryParse($raw, [ref]$idx)) {
+        Write-Host "Not a number — exiting." -ForegroundColor Yellow
+        return $null
+    }
+
+    if ($idx -lt 1 -or $idx -gt $list.Count) {
+        Write-Host "Out of range — exiting." -ForegroundColor Yellow
+        return $null
+    }
+
+    $picked = $list[$idx - 1]
+    return $picked
+}
+
+
+function Register-TimerIntegration {
+    # Append (or replace by Name) an integration entry to
+    # $script:TimerIntegrations. Replace-on-collision lets the user override
+    # the built-in AzDO integration from their $profile without editing
+    # tracked code.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]      $Name,
+        [Parameter(Mandatory)] [string]      $Description,
+        [Parameter(Mandatory)] [scriptblock] $FetchItems,
+        [Parameter(Mandatory)] [scriptblock] $AddComment,
+        [scriptblock] $ViewHint
+    )
+
+    $entry = [PSCustomObject]@{
+        Name        = $Name
+        Description = $Description
+        FetchItems  = $FetchItems
+        AddComment  = $AddComment
+        ViewHint    = $ViewHint
+    }
+
+    $existing = @($script:TimerIntegrations | Where-Object { $_.Name -eq $Name })
+    if ($existing.Count -gt 0) {
+        Write-Host "Replacing existing timer integration '$Name'." -ForegroundColor Yellow
+        $script:TimerIntegrations = @($script:TimerIntegrations | Where-Object { $_.Name -ne $Name })
+    }
+
+    $script:TimerIntegrations = @($script:TimerIntegrations) + $entry
+}
+
+
+function Get-TimerIntegrationPick {
+    # When -Name is supplied, return the matching integration (or $null with
+    # a hint listing the registered names). Otherwise show the picker; with
+    # only one registered, return it without prompting.
+    param([string] $Name)
+
+    $integrations = @($script:TimerIntegrations)
+
+    if ($Name) {
+        $match = $integrations | Where-Object { $_.Name -eq $Name } | Select-Object -First 1
+        if (-not $match) {
+            Write-Host "No registered integration named '$Name'. Available:" -ForegroundColor Yellow
+            foreach ($i in $integrations) {
+                Write-Host "  - $($i.Name)" -ForegroundColor DarkGray
+            }
+            return $null
+        }
+        return $match
+    }
+
+    if ($integrations.Count -eq 1) {
+        return $integrations[0]
+    }
+
+    $rows = @($integrations | Select-Object Name, Description)
+    $title = "Pick a timer integration ($($integrations.Count) registered)"
+
+    if (Test-TimerGridAvailable) {
+        $picked = $rows | Out-ConsoleGridView -Title $title -OutputMode Single
+        if (-not $picked) {
+            return $null
+        }
+        $match = $integrations | Where-Object { $_.Name -eq $picked.Name } | Select-Object -First 1
+        return $match
+    }
+
+    $fallback = Read-TimerNumberedPick -Items $integrations -DisplayProperty 'Name' -Title $title
+    return $fallback
+}
+
+
+function Get-TimerItemPick {
+    param(
+        [Parameter(Mandatory)] $Items,
+        [Parameter(Mandatory)] [string] $IntegrationName
+    )
+
+    $rows = @($Items)
+    if ($rows.Count -eq 0) {
+        return $null
+    }
+
+    $title = "$IntegrationName — pick an item ($($rows.Count))"
+
+    if (Test-TimerGridAvailable) {
+        $picked = $rows | Out-ConsoleGridView -Title $title -OutputMode Single
+        return $picked
+    }
+
+    $fallback = Read-TimerNumberedPick -Items $rows -DisplayProperty 'Title' -Title $title
+    return $fallback
+}
+
+
+function Show-TimerCountdown {
+    # Snake-animation countdown. Each elapsed second redraws the frame; the
+    # per-second wait is split into ~100ms key polls so Esc interrupts feel
+    # immediate without making the animation flicker. Returns the outcome so
+    # the orchestrator can branch on Interrupted.
+    param([Parameter(Mandatory)] [int] $Seconds)
+
+    $iconSnakeHead = $script:TimerIconSnakeHead
+    $iconSnakeBody = $script:TimerIconSnakeBody
+    $iconApple     = $script:TimerIconApple
+    $iconClock     = $script:TimerIconClock
+
+    $maxSnakeLength = $script:TimerMaxSnakeLength
+    $pollIntervalMs = $script:TimerPollIntervalMs
+    $pollsPerSecond = $script:TimerPollsPerSecond
+
+    $interrupted = $false
+    $elapsed = 0
+
+    while ($elapsed -le $Seconds) {
+        $remaining = $Seconds - $elapsed
+        $currentLength = [math]::Floor(($elapsed / $Seconds) * $maxSnakeLength)
+        $snakeBody = $iconSnakeBody * $currentLength
+        $spacer = '  ' * ($maxSnakeLength - $currentLength)
+
+        Clear-Host
+        Write-Host "`n`n      SNAKE FOCUS SESSION" -ForegroundColor Green
+        Write-Host "      ┌────────────────────────────────────────┐"
+        Write-Host "      │ " -NoNewline
+        Write-Host "$snakeBody$iconSnakeHead" -NoNewline
+        Write-Host "$spacer" -NoNewline
+        Write-Host "$iconApple │"
+        Write-Host "      └────────────────────────────────────────┘"
+
+        $remainingDisplay = Format-TimerElapsed -Seconds $remaining
+        Write-Host "`n      $iconClock TIME UNTIL DEBRIEF: $remainingDisplay" -ForegroundColor Yellow
+        Write-Host "      (Press Esc to debrief early)" -ForegroundColor DarkGray
+
+        if ($remaining -le 0) {
+            break
+        }
+
+        for ($p = 0; $p -lt $pollsPerSecond; $p++) {
+            if ([Console]::KeyAvailable) {
+                $key = [Console]::ReadKey($true)
+                if ($key.Key -eq [ConsoleKey]::Escape) {
+                    $interrupted = $true
+                    break
+                }
+            }
+            Start-Sleep -Milliseconds $pollIntervalMs
+        }
+
+        if ($interrupted) {
+            break
+        }
+
+        $elapsed++
+    }
+
+    return [PSCustomObject]@{
+        ElapsedSeconds = $elapsed
+        TotalSeconds   = $Seconds
+        Interrupted    = $interrupted
+    }
+}
+
+
+function Format-TimerCommentBody {
+    # Compose the discussion-comment text. Header reflects outcome; body has
+    # labeled Debrief and Next sections; a trailing attribution line lets a
+    # reader trace the comment back to this command.
+    param(
+        [Parameter(Mandatory)] [bool]   $Interrupted,
+        [Parameter(Mandatory)] [int]    $ElapsedSeconds,
+        [Parameter(Mandatory)] [int]    $TotalSeconds,
+        [Parameter(Mandatory)] [string] $Debrief,
+        [Parameter(Mandatory)] [string] $Next
+    )
+
+    $iconCheck  = $script:TimerIconCheck
+    $iconWarn   = $script:TimerIconWarn
+    $iconMemo   = $script:TimerIconMemo
+    $iconRocket = $script:TimerIconRocket
+
+    $elapsedDisplay = Format-TimerElapsed -Seconds $ElapsedSeconds
+    $totalDisplay   = Format-TimerElapsed -Seconds $TotalSeconds
+    $timestamp      = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+
+    $header = if ($Interrupted) {
+        "$iconWarn Session interrupted at $elapsedDisplay of $totalDisplay"
+    } else {
+        "$iconCheck Pomodoro complete — $totalDisplay"
+    }
+
+    $lines = @(
+        $header,
+        "_$timestamp_",
+        '',
+        "$iconMemo Debrief:",
+        $Debrief,
+        '',
+        "$iconRocket Next:",
+        $Next,
+        '',
+        '_via bashcuts Start-TimerSession_'
+    )
+
+    $body = $lines -join "`r`n"
+    return $body
+}
+
+
+function Start-TimerSession {
+    # Orchestrator. Pick an integration (or use -Integration to skip),
+    # fetch + pick an item, run the snake countdown (Esc to end early),
+    # prompt for debrief notes, post the composed comment via the chosen
+    # integration's AddComment. On an Esc-interrupted session also prompt
+    # whether to start another session — same -Minutes, fresh integration
+    # / item pick so the user can pivot to a different story.
+    [CmdletBinding()]
+    param(
+        [ValidateRange(1, [int]::MaxValue)] [int] $Minutes = $script:TimerDefaultMinutes,
+        [string] $Integration
+    )
+
+    $integrations = @($script:TimerIntegrations)
+    if ($integrations.Count -eq 0) {
+        Write-Host "No timer integrations registered. Add one via Register-TimerIntegration." -ForegroundColor Yellow
+        return
+    }
+
+    $chosen = Get-TimerIntegrationPick -Name $Integration
+    if (-not $chosen) {
+        Write-Host "No integration selected — exiting." -ForegroundColor DarkGray
+        return
+    }
+
+    Write-Host "Fetching items from '$($chosen.Name)'..." -ForegroundColor Cyan
+    $items = & $chosen.FetchItems
+    if (-not $items -or @($items).Count -eq 0) {
+        Write-Host "No items returned from '$($chosen.Name)'." -ForegroundColor Yellow
+        return
+    }
+
+    $pickedItem = Get-TimerItemPick -Items $items -IntegrationName $chosen.Name
+    if (-not $pickedItem) {
+        Write-Host "No item selected — exiting." -ForegroundColor DarkGray
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Starting $Minutes-minute session on item $($pickedItem.Id): $($pickedItem.Title)" -ForegroundColor Green
+    Start-Sleep -Seconds 2
+
+    $seconds = $Minutes * 60
+    $countdownResult = Show-TimerCountdown -Seconds $seconds
+
+    Clear-Host
+    $finishIcon = $script:TimerIconFinish
+    Write-Host "$finishIcon SESSION COMPLETE! $finishIcon" -ForegroundColor Green
+
+    $memoIcon = $script:TimerIconMemo
+    $rocketIcon = $script:TimerIconRocket
+    $debrief = Read-Host "$memoIcon Enter your debrief notes"
+    $next    = Read-Host "$rocketIcon What's next"
+
+    $body = Format-TimerCommentBody `
+        -Interrupted    $countdownResult.Interrupted `
+        -ElapsedSeconds $countdownResult.ElapsedSeconds `
+        -TotalSeconds   $countdownResult.TotalSeconds `
+        -Debrief        $debrief `
+        -Next           $next
+
+    Write-Host ""
+    Write-Host "Posting debrief comment to item $($pickedItem.Id)..." -ForegroundColor Cyan
+    $commentResult = & $chosen.AddComment -Id $pickedItem.Id -Body $body
+
+    $exitCode = if ($commentResult -and $commentResult.PSObject.Properties['ExitCode']) {
+        $commentResult.ExitCode
+    } else {
+        0
+    }
+
+    $checkIcon = $script:TimerIconCheck
+    $warnIcon  = $script:TimerIconWarn
+
+    if ($exitCode -eq 0) {
+        Write-Host "$checkIcon Comment posted on item $($pickedItem.Id)." -ForegroundColor Green
+        if ($chosen.ViewHint) {
+            $hint = & $chosen.ViewHint -Id $pickedItem.Id
+            if ($hint) {
+                Write-Host "   $hint" -ForegroundColor DarkGray
+            }
+        }
+    } else {
+        Write-Host "$warnIcon Comment post failed (exit=$exitCode)." -ForegroundColor Red
+        if ($commentResult -and $commentResult.Error) {
+            Write-Host "   $($commentResult.Error)" -ForegroundColor Red
+        }
+    }
+
+    if ($countdownResult.Interrupted) {
+        $startAnother = Read-TimerYesNo -Prompt 'Start a new session?' -DefaultYes
+        if ($startAnother) {
+            Start-TimerSession -Minutes $Minutes
+            return
+        }
+        $waveIcon = $script:TimerIconWave
+        Write-Host "Goodbye $waveIcon" -ForegroundColor DarkGray
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Default integration: Azure DevOps - User Stories
+#
+# Reads the existing assigned-items cache (populated by az-Sync-AzDevOpsCache),
+# filters out closed states, sorts by State -> Priority asc -> AssignedAt desc
+# (null priorities sort last via [int]::MaxValue substitution), and surfaces
+# Id / Type / State / Priority / Title / Iteration in the picker. Posts the
+# debrief through the Add-AzDevOpsDiscussionComment wrapper in azdevops_db.ps1.
+# ---------------------------------------------------------------------------
+
+Register-TimerIntegration `
+    -Name        'Azure DevOps - User Stories' `
+    -Description 'Pick from cached AzDO assigned work items, sorted by State + Priority' `
+    -FetchItems  {
+        $cache = Read-AzDevOpsAssignedCache
+        if ($null -eq $cache) {
+            return @()
+        }
+
+        $active = Select-AzDevOpsActiveItems -Items $cache
+
+        $priorityExpr = {
+            if ($null -eq $_.Priority) {
+                [int]::MaxValue
+            } else {
+                $_.Priority
+            }
+        }
+
+        $sorted = $active | Sort-Object `
+            @{Expression = 'State'; Ascending = $true},
+            @{Expression = $priorityExpr; Ascending = $true},
+            @{Expression = 'AssignedAt'; Descending = $true}
+
+        $rows = @($sorted | Select-Object Id, Type, State, Priority, Title, Iteration)
+        return $rows
+    } `
+    -AddComment  {
+        param(
+            [Parameter(Mandatory)] [int]    $Id,
+            [Parameter(Mandatory)] [string] $Body
+        )
+        $result = Add-AzDevOpsDiscussionComment -Id $Id -Body $Body
+        return $result
+    } `
+    -ViewHint    {
+        param([Parameter(Mandatory)] [int] $Id)
+        $hint = "View discussion: az-Open-AzDevOpsAssigned $Id"
+        return $hint
+    }

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -26,8 +26,6 @@
 # az-Sync-AzDevOpsCache) and posts via Add-AzDevOpsDiscussionComment.
 # ---------------------------------------------------------------------------
 
-[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-
 $script:TimerIconSnakeHead  = "$([char]0x1F40D)"
 $script:TimerIconSnakeBody  = "$([char]0x1F7E9)"
 $script:TimerIconApple      = "$([char]0x1F34E)"
@@ -47,10 +45,24 @@ $script:TimerPollsPerSecond = 10
 $script:TimerIntegrations = @()
 
 
-function Test-TimerGridAvailable {
-    $cmd = Get-Command Out-ConsoleGridView -ErrorAction SilentlyContinue
-    $available = ($null -ne $cmd)
-    return $available
+function Test-TimerEscPressed {
+    # Non-blocking probe for an Esc keypress. Guarded so the timer still
+    # runs in hosts that don't expose [Console]::KeyAvailable / ReadKey
+    # (some VS Code integrated-terminal configs, pwsh -NonInteractive,
+    # redirected stdin) — in those hosts the Esc-to-debrief affordance is
+    # silently disabled and the timer runs to completion.
+    try {
+        if ([Console]::KeyAvailable) {
+            $key = [Console]::ReadKey($true)
+            if ($key.Key -eq [ConsoleKey]::Escape) {
+                return $true
+            }
+        }
+    } catch {
+        # Host does not expose console keyboard — treat as no key pressed.
+    }
+
+    return $false
 }
 
 
@@ -132,6 +144,31 @@ function Read-TimerNumberedPick {
 }
 
 
+function Read-TimerPick {
+    # Centralizes the grid-vs-fallback decision used by both picker
+    # functions. Returns the selected row (PSCustomObject) or $null on
+    # cancel / empty list.
+    param(
+        [Parameter(Mandatory)] $Items,
+        [Parameter(Mandatory)] [string] $DisplayProperty,
+        [Parameter(Mandatory)] [string] $Title
+    )
+
+    $rows = @($Items)
+    if ($rows.Count -eq 0) {
+        return $null
+    }
+
+    if (Test-ConsoleGridAvailable) {
+        $picked = $rows | Out-ConsoleGridView -Title $Title -OutputMode Single
+        return $picked
+    }
+
+    $fallback = Read-TimerNumberedPick -Items $rows -DisplayProperty $DisplayProperty -Title $Title
+    return $fallback
+}
+
+
 function Register-TimerIntegration {
     # Append (or replace by Name) an integration entry to
     # $script:TimerIntegrations. Replace-on-collision lets the user override
@@ -191,17 +228,13 @@ function Get-TimerIntegrationPick {
     $rows = @($integrations | Select-Object Name, Description)
     $title = "Pick a timer integration ($($integrations.Count) registered)"
 
-    if (Test-TimerGridAvailable) {
-        $picked = $rows | Out-ConsoleGridView -Title $title -OutputMode Single
-        if (-not $picked) {
-            return $null
-        }
-        $match = $integrations | Where-Object { $_.Name -eq $picked.Name } | Select-Object -First 1
-        return $match
+    $picked = Read-TimerPick -Items $rows -DisplayProperty 'Name' -Title $title
+    if (-not $picked) {
+        return $null
     }
 
-    $fallback = Read-TimerNumberedPick -Items $integrations -DisplayProperty 'Name' -Title $title
-    return $fallback
+    $match = $integrations | Where-Object { $_.Name -eq $picked.Name } | Select-Object -First 1
+    return $match
 }
 
 
@@ -217,14 +250,8 @@ function Get-TimerItemPick {
     }
 
     $title = "$IntegrationName — pick an item ($($rows.Count))"
-
-    if (Test-TimerGridAvailable) {
-        $picked = $rows | Out-ConsoleGridView -Title $title -OutputMode Single
-        return $picked
-    }
-
-    $fallback = Read-TimerNumberedPick -Items $rows -DisplayProperty 'Title' -Title $title
-    return $fallback
+    $picked = Read-TimerPick -Items $rows -DisplayProperty 'Title' -Title $title
+    return $picked
 }
 
 
@@ -271,12 +298,9 @@ function Show-TimerCountdown {
         }
 
         for ($p = 0; $p -lt $pollsPerSecond; $p++) {
-            if ([Console]::KeyAvailable) {
-                $key = [Console]::ReadKey($true)
-                if ($key.Key -eq [ConsoleKey]::Escape) {
-                    $interrupted = $true
-                    break
-                }
+            if (Test-TimerEscPressed) {
+                $interrupted = $true
+                break
             }
             Start-Sleep -Milliseconds $pollIntervalMs
         }
@@ -348,6 +372,11 @@ function Start-TimerSession {
     # integration's AddComment. On an Esc-interrupted session also prompt
     # whether to start another session — same -Minutes, fresh integration
     # / item pick so the user can pivot to a different story.
+    #
+    # UTF-8 encoding is applied around the snake animation so the emoji
+    # glyphs render in terminals that default to a non-UTF-8 codepage; the
+    # previous encoding is restored on exit (including Ctrl-C) so we don't
+    # leak a process-wide mutation back to the shell.
     [CmdletBinding()]
     param(
         [ValidateRange(1, [int]::MaxValue)] [int] $Minutes = $script:TimerDefaultMinutes,
@@ -360,84 +389,98 @@ function Start-TimerSession {
         return
     }
 
-    $chosen = Get-TimerIntegrationPick -Name $Integration
-    if (-not $chosen) {
-        Write-Host "No integration selected — exiting." -ForegroundColor DarkGray
-        return
-    }
+    $previousEncoding = [Console]::OutputEncoding
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
-    Write-Host "Fetching items from '$($chosen.Name)'..." -ForegroundColor Cyan
-    $items = & $chosen.FetchItems
-    if (-not $items -or @($items).Count -eq 0) {
-        Write-Host "No items returned from '$($chosen.Name)'." -ForegroundColor Yellow
-        return
-    }
+    try {
+        $shouldRestart = $false
+        do {
+            $shouldRestart = $false
 
-    $pickedItem = Get-TimerItemPick -Items $items -IntegrationName $chosen.Name
-    if (-not $pickedItem) {
-        Write-Host "No item selected — exiting." -ForegroundColor DarkGray
-        return
-    }
-
-    Write-Host ""
-    Write-Host "Starting $Minutes-minute session on item $($pickedItem.Id): $($pickedItem.Title)" -ForegroundColor Green
-    Start-Sleep -Seconds 2
-
-    $seconds = $Minutes * 60
-    $countdownResult = Show-TimerCountdown -Seconds $seconds
-
-    Clear-Host
-    $finishIcon = $script:TimerIconFinish
-    Write-Host "$finishIcon SESSION COMPLETE! $finishIcon" -ForegroundColor Green
-
-    $memoIcon = $script:TimerIconMemo
-    $rocketIcon = $script:TimerIconRocket
-    $debrief = Read-Host "$memoIcon Enter your debrief notes"
-    $next    = Read-Host "$rocketIcon What's next"
-
-    $body = Format-TimerCommentBody `
-        -Interrupted    $countdownResult.Interrupted `
-        -ElapsedSeconds $countdownResult.ElapsedSeconds `
-        -TotalSeconds   $countdownResult.TotalSeconds `
-        -Debrief        $debrief `
-        -Next           $next
-
-    Write-Host ""
-    Write-Host "Posting debrief comment to item $($pickedItem.Id)..." -ForegroundColor Cyan
-    $commentResult = & $chosen.AddComment -Id $pickedItem.Id -Body $body
-
-    $exitCode = if ($commentResult -and $commentResult.PSObject.Properties['ExitCode']) {
-        $commentResult.ExitCode
-    } else {
-        0
-    }
-
-    $checkIcon = $script:TimerIconCheck
-    $warnIcon  = $script:TimerIconWarn
-
-    if ($exitCode -eq 0) {
-        Write-Host "$checkIcon Comment posted on item $($pickedItem.Id)." -ForegroundColor Green
-        if ($chosen.ViewHint) {
-            $hint = & $chosen.ViewHint -Id $pickedItem.Id
-            if ($hint) {
-                Write-Host "   $hint" -ForegroundColor DarkGray
+            $chosen = Get-TimerIntegrationPick -Name $Integration
+            if (-not $chosen) {
+                Write-Host "No integration selected — exiting." -ForegroundColor DarkGray
+                return
             }
-        }
-    } else {
-        Write-Host "$warnIcon Comment post failed (exit=$exitCode)." -ForegroundColor Red
-        if ($commentResult -and $commentResult.Error) {
-            Write-Host "   $($commentResult.Error)" -ForegroundColor Red
-        }
-    }
 
-    if ($countdownResult.Interrupted) {
-        $startAnother = Read-TimerYesNo -Prompt 'Start a new session?' -DefaultYes
-        if ($startAnother) {
-            Start-TimerSession -Minutes $Minutes
-            return
-        }
-        $waveIcon = $script:TimerIconWave
-        Write-Host "Goodbye $waveIcon" -ForegroundColor DarkGray
+            Write-Host "Fetching items from '$($chosen.Name)'..." -ForegroundColor Cyan
+            $items = & $chosen.FetchItems
+            if (-not $items -or @($items).Count -eq 0) {
+                Write-Host "No items returned from '$($chosen.Name)'." -ForegroundColor Yellow
+                return
+            }
+
+            $pickedItem = Get-TimerItemPick -Items $items -IntegrationName $chosen.Name
+            if (-not $pickedItem) {
+                Write-Host "No item selected — exiting." -ForegroundColor DarkGray
+                return
+            }
+
+            Write-Host ""
+            Write-Host "Starting $Minutes-minute session on item $($pickedItem.Id): $($pickedItem.Title)" -ForegroundColor Green
+            Start-Sleep -Seconds 2
+
+            $seconds = $Minutes * 60
+            $countdownResult = Show-TimerCountdown -Seconds $seconds
+
+            Clear-Host
+            $finishIcon = $script:TimerIconFinish
+            Write-Host "$finishIcon SESSION COMPLETE! $finishIcon" -ForegroundColor Green
+
+            $memoIcon = $script:TimerIconMemo
+            $rocketIcon = $script:TimerIconRocket
+            $debrief = Read-Host "$memoIcon Enter your debrief notes"
+            $next    = Read-Host "$rocketIcon What's next"
+
+            $body = Format-TimerCommentBody `
+                -Interrupted    $countdownResult.Interrupted `
+                -ElapsedSeconds $countdownResult.ElapsedSeconds `
+                -TotalSeconds   $countdownResult.TotalSeconds `
+                -Debrief        $debrief `
+                -Next           $next
+
+            Write-Host ""
+            Write-Host "Posting debrief comment to item $($pickedItem.Id)..." -ForegroundColor Cyan
+            $commentResult = & $chosen.AddComment -Id $pickedItem.Id -Body $body
+
+            $exitCode = if ($commentResult -and $commentResult.PSObject.Properties['ExitCode']) {
+                $commentResult.ExitCode
+            } else {
+                0
+            }
+
+            $checkIcon = $script:TimerIconCheck
+            $warnIcon  = $script:TimerIconWarn
+
+            if ($exitCode -eq 0) {
+                Write-Host "$checkIcon Comment posted on item $($pickedItem.Id)." -ForegroundColor Green
+                if ($chosen.ViewHint) {
+                    $hint = & $chosen.ViewHint -Id $pickedItem.Id
+                    if ($hint) {
+                        Write-Host "   $hint" -ForegroundColor DarkGray
+                    }
+                }
+            } else {
+                Write-Host "$warnIcon Comment post failed (exit=$exitCode)." -ForegroundColor Red
+                if ($commentResult -and $commentResult.Error) {
+                    Write-Host "   $($commentResult.Error)" -ForegroundColor Red
+                }
+            }
+
+            if ($countdownResult.Interrupted) {
+                $startAnother = Read-TimerYesNo -Prompt 'Start a new session?' -DefaultYes
+                if ($startAnother) {
+                    $shouldRestart = $true
+                    $Integration = $null
+                } else {
+                    $waveIcon = $script:TimerIconWave
+                    Write-Host "Goodbye $waveIcon" -ForegroundColor DarkGray
+                }
+            }
+        } while ($shouldRestart)
+    }
+    finally {
+        [Console]::OutputEncoding = $previousEncoding
     }
 }
 

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -69,3 +69,10 @@ if ($azdevops_projects -ne $NULL) {
 } else {
     Write-Host "no azdevops_projects.ps1"
 }
+
+$pow_timer = Get-Content "$path_to_bashcuts\powcuts_by_cli\pow_timer.ps1"
+if ($pow_timer -ne $NULL) {
+ . "$path_to_bashcuts\powcuts_by_cli\pow_timer.ps1"
+} else {
+    Write-Host "no pow_timer.ps1"
+}


### PR DESCRIPTION
<!-- toc:start -->
## Table of Contents

| Section | Status |
|---------|--------|
| [How it works](#how-it-works) | 🗺️ |
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #68 |
| [Changes](#changes) | ✅ 5 files |
| [Test Plan](#test-plan) | 0/6 (manual, post-merge) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/70#issuecomment-4433068134) |
| 💠 PowerShell Engineer Review | ✅ APPROVE _(re-review)_ — [View](https://github.com/jdschleicher/bashcuts/pull/70#issuecomment-4433162509) |
| 🛡️ Security Audit | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/70#issuecomment-4433075506) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE _(re-review)_ — [View](https://github.com/jdschleicher/bashcuts/pull/70#issuecomment-4433165428) |
| 📚 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/70#issuecomment-4433175358) |
| ✅ Criteria Check | ✅ PASS (30/30 + 7 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/70#issuecomment-4433187185) |
| 📐 AzDO Diagrams Check | ✅ CURRENT (after `259a5ab`) — [View](https://github.com/jdschleicher/bashcuts/pull/70#issuecomment-4433211505) |
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

`Start-TimerSession` is the user-facing entry point: pick an integration from the registry, pick an item, run the snake-animation countdown, post a debrief comment on the chosen item. **Esc** during the countdown drops into the same debrief flow with an interrupted-status header and an optional restart loop that reuses `-Minutes` but re-picks the integration. `Register-TimerIntegration` is a separate `$profile`-time entry point that adds integrations to the registry consumed by `Start-TimerSession`.

```mermaid
flowchart TD
    %% Public entry points
    Reg(["Register-TimerIntegration<br/>profile-time"]):::pub
    Start(["Start-TimerSession<br/>-Minutes 25 -Integration name"]):::pub

    %% Registry state
    Store[("script:TimerIntegrations<br/>Name / FetchItems / AddComment / ViewHint")]:::io

    %% Private helpers in pow_timer.ps1
    PickInt["Get-TimerIntegrationPick<br/>via Read-TimerPick"]:::priv
    Fetch["Integration.FetchItems<br/>AzDO: Read-AzDevOpsAssignedCache<br/>→ Select-AzDevOpsActiveItems<br/>→ Sort State / Priority"]:::priv
    PickItem["Get-TimerItemPick<br/>via Read-TimerPick"]:::priv
    Countdown["Show-TimerCountdown<br/>snake animation +<br/>Test-TimerEscPressed poll"]:::priv
    Debrief["Read-Host debrief + next"]:::priv
    Body["Format-TimerCommentBody<br/>completed vs interrupted header"]:::priv
    Restart{"Start a new session?<br/>(interrupted only)"}

    %% External I/O
    Grid[("Out-ConsoleGridView<br/>or numbered fallback")]:::io
    Cache[("assigned.json cache")]:::io
    AddDisc(["Add-AzDevOpsDiscussionComment"]):::pub
    AzCli["az boards work-item update<br/>--id N --discussion BODY"]:::io
    Done(["exit"]):::priv

    %% Flow
    Reg --> Store
    Start --> PickInt
    PickInt -.reads.-> Store
    PickInt --> Grid
    PickInt --> Fetch
    Fetch -.reads.-> Cache
    Fetch --> PickItem
    PickItem --> Grid
    PickItem --> Countdown
    Countdown --> Debrief
    Debrief --> Body
    Body --> AddDisc
    AddDisc --> AzCli
    AzCli --> Restart
    Restart -- yes --> PickInt
    Restart -- no / completed --> Done

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Adds `Start-TimerSession`, a PowerShell-only Pomodoro timer that picks from registered integrations, runs a snake-animation countdown for a configurable duration (default 25 min), and posts the user's debrief notes as a discussion comment on the chosen item. **Esc** during the countdown ends the session early and still triggers the debrief flow; after an interrupted-session comment posts, the user is prompted to start another session so they can pivot to a different story without retyping the command.

The Azure DevOps integration ships out of the box: reads the existing assigned-items cache (`az-Sync-AzDevOpsCache`), sorts by State → Priority → AssignedAt, and posts via a new `Add-AzDevOpsDiscussionComment` wrapper around `az boards work-item update --discussion`.

## Issue

Closes #68

## Changes

- **New** `powcuts_by_cli/pow_timer.ps1` — integration registry (`$script:TimerIntegrations`), `Register-TimerIntegration`, `Start-TimerSession`, `Show-TimerCountdown` with guarded `[Console]::KeyAvailable` Esc-poll via `Test-TimerEscPressed`, named emoji-icon constants, status-aware comment header, "Start a new session?" `do/while` loop on the interrupted path only
- **New** `Add-AzDevOpsDiscussionComment` in `powcuts_by_cli/azdevops_db.ps1` — thin wrapper around `Invoke-AzDevOpsAzJson` for `az boards work-item update --id <id> --discussion <body>`
- **New** `Test-ConsoleGridAvailable` in `powcuts_by_cli/pow_common.ps1` — canonical capability check; `Test-AzDevOpsGridAvailable` collapses to a one-line passthrough
- `powcuts_by_cli/azdevops_workitems.ps1` — assigned-item WIQL gains `[Microsoft.VSTS.Common.Priority]`; `ConvertFrom-AzDevOpsAssignedItem` rewritten in CLAUDE.md multi-line-`if` style and adds nullable `Priority` property
- `powcuts_home.ps1` — dot-source block for `pow_timer.ps1` (loaded last so the AzDO integration sees `azdevops_db.ps1` + `azdevops_workitems.ps1`)
- `README.md` — new `# Timer sessions` section + ToC entry; documents `-Minutes` default, **Esc**-to-debrief-early affordance, Ctrl-C hard-exit caveat, and the `Register-TimerIntegration` shape
- `docs/azure-devops-diagrams.md` — Diagram 1 + Diagram 11 refreshed to include `Add-AzDevOpsDiscussionComment` and `az boards work-item update`

## Test Plan

- [ ] Open a fresh PowerShell terminal — `powershell starting` prints, no `no pow_timer.ps1` warning, no parse errors
- [ ] `az-Sync-AzDevOpsCache` — populates the new `Priority` field in `assigned.json`
- [ ] `Start-TimerSession -Minutes 1` — only one integration registered (auto-selected) → item picker shows stories sorted by State + Priority → pick one → snake animation runs 1 min → debrief prompts → comment posted with header `✅ Pomodoro complete — 01:00` (verify in browser)
- [ ] `Start-TimerSession -Minutes 5 -Integration 'Azure DevOps - User Stories'` → press **Esc** ~30s in → debrief prompts → comment header `⚠️ Session interrupted at 00:30 of 05:00` → `Start a new session? [Y/n]` → `Y` returns to the integration picker for a context switch
- [ ] Repeat with `N` → exits cleanly with `Goodbye 👋`; no chained re-invoke
- [ ] Press Esc on the item picker → exits cleanly, no timer, no comment

https://claude.ai/code/session_01JrwngUJ5hNkiPfCKHvmQLm