### PR TITLE
feat(#69): add az-Open-AzDevOpsHierarchyWiql shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ The `hierarchy` dataset that `az-Sync-AzDevOpsCache` writes into `hierarchy.json
 
 `az-Connect-AzDevOps` (and the first run of `az-Sync-AzDevOpsCache` if you skipped Connect) seeds the file with a sensible default — Epic / Feature / RequirementCategory items under `{{AZ_AREA}}`, where `{{AZ_AREA}}` is substituted from `$env:AZ_AREA` at read time. Edit the file to add fields to the SELECT clause, filter by state, scope by tag, or otherwise tailor what lands in `hierarchy.json`. Re-run `az-Sync-AzDevOpsCache` to pick up your changes — no `reinit` needed, since the file is read every sync.
 
+The fast way to open the file for editing is the dedicated shortcut:
+
+```powershell
+az-Open-AzDevOpsHierarchyWiql
+```
+
+It seeds the default WIQL if the file is missing (so it works on a fresh machine even before `az-Connect-AzDevOps`) and then opens the path in your OS default editor.
+
 If you delete the file, the next sync writes the default back. The placeholder `{{AZ_AREA}}` is the only one currently supported; everything else in the file is passed through to `az boards query --wiql` verbatim.
 
 ### Day-to-day work-item shortcuts

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -546,6 +546,7 @@ graph LR
     NewF(["az-New-AzDevOpsFeature"]):::pub
     NewSB(["az-New-AzDevOpsFeatureStories"]):::pub
     Find(["az-Find-AzDevOpsWorkItem"]):::pub
+    OpenHWiql(["az-Open-AzDevOpsHierarchyWiql"]):::pub
 
     %% Multi-project switcher (azdevops_projects.ps1)
     UseProj(["az-Use-AzDevOpsProject"]):::pub
@@ -730,6 +731,7 @@ graph LR
     DSets --> QWiql --> QInit
     QInit --> QPaths
     QInit --> MkDir
+    OpenHWiql --> QInit
     Sync --> InvokeDS
     InvokeDS --> Boards
     InvokeDS --> ClassList

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -5,10 +5,15 @@
 # Foundation file for Azure DevOps work-item navigation shortcuts.
 #
 # User-facing functions:
-#   az-Connect-AzDevOps   - interactive first-run auth + setup helper (run once
-#                        on a fresh machine, or any time auth feels stale)
-#   az-Test-AzDevOpsAuth  - silent yes/no auth assertion intended for callers
-#                        in later AzDevOps commands; returns $true / $false
+#   az-Connect-AzDevOps            - interactive first-run auth + setup helper
+#                                    (run once on a fresh machine, or any time
+#                                    auth feels stale)
+#   az-Test-AzDevOpsAuth           - silent yes/no auth assertion intended for
+#                                    callers in later AzDevOps commands;
+#                                    returns $true / $false
+#   az-Open-AzDevOpsHierarchyWiql  - open ~/.bashcuts-config/azure-devops/
+#                                    queries/hierarchy.wiql in the default
+#                                    editor (seeds default WIQL on first run)
 #
 # Step functions invoked by az-Connect-AzDevOps (also exposed for direct use,
 # e.g. to debug a single failing step). Each returns a [PSCustomObject]
@@ -315,6 +320,24 @@ function az-Confirm-AzDevOpsQueryFiles {
 
     $stepResult = New-AzDevOpsStepResult -Ok $true
     return $stepResult
+}
+
+
+function az-Open-AzDevOpsHierarchyWiql {
+    # Opens the user-machine hierarchy.wiql in the OS default editor. Defensively
+    # seeds the default WIQL via Initialize-AzDevOpsQueryFiles so a fresh
+    # machine that skipped az-Connect-AzDevOps can still discover and customize
+    # the query in one step (no "file not found" detour).
+    $init = Initialize-AzDevOpsQueryFiles
+    $path = $init.Paths.HierarchyQuery
+
+    if ($init.SeededHierarchy) {
+        Write-Host "Wrote default hierarchy.wiql to $path - opening for editing" -ForegroundColor Green
+    } else {
+        Write-Host "Opening $path" -ForegroundColor DarkGray
+    }
+
+    Start-Process $path
 }
 
 


### PR DESCRIPTION
<!-- pr-body-toc:start -->
## 📋 Review Hub

| Section | Verdict |
|---------|---------|
| [Summary](#summary) | — |
| [Issue](#issue) | — |
| [Changes](#changes) | — |
| [Test Plan](#test-plan) | — |
| 🐚 [Bash Engineer Review](https://github.com/jdschleicher/bashcuts/pull/71#issuecomment-4433098271) | N/A |
| 💠 [PowerShell Engineer Review](https://github.com/jdschleicher/bashcuts/pull/71#issuecomment-4433101818) | COMMENT |
| 🛡️ [Security Review](https://github.com/jdschleicher/bashcuts/pull/71#issuecomment-4433098669) | PASS |
| 🧼 [Clean-Code Engineer Review](https://github.com/jdschleicher/bashcuts/pull/71#issuecomment-4433103893) | APPROVE |
| 📚 [Docs Check](https://github.com/jdschleicher/bashcuts/pull/71#issuecomment-4433109603) | CURRENT |
| ✅ [Criteria Check](https://github.com/jdschleicher/bashcuts/pull/71#issuecomment-4433110888) | PASS |
| 🗺️ [AzDO Diagrams Check](https://github.com/jdschleicher/bashcuts/pull/71#issuecomment-4433114858) | DRIFT |
<!-- pr-body-toc:end -->

## Summary

Adds `az-Open-AzDevOpsHierarchyWiql` — a one-keystroke way to open the externalized hierarchy WIQL (`~/.bashcuts-config/azure-devops/queries/hierarchy.wiql`) in the OS default editor, so customizing what `az-Sync-AzDevOpsCache` pulls into `hierarchy.json` no longer requires typing the full config path.

The function defensively calls `Initialize-AzDevOpsQueryFiles` so it works even before `az-Connect-AzDevOps` has been run — fresh machines get the default WIQL seeded and the file opened in a single step.

## Issue

Closes #69

## Changes

- `powcuts_by_cli/azdevops_workitems.ps1` — adds `az-Open-AzDevOpsHierarchyWiql` after `az-Confirm-AzDevOpsQueryFiles`; updates the user-facing-functions banner.
- `README.md` — adds the shortcut as the recommended editor entry point in the &#34;Customizing WIQL queries&#34; section.
- `docs/azure-devops-diagrams.md` — adds public node `OpenHWiql` and the `OpenHWiql --&gt; QInit` edge to the function-dependency map (section 11).

## Test Plan

- [ ] Open a fresh PowerShell terminal so the updated `azdevops_workitems.ps1` is sourced.
- [ ] `Remove-Item ~/.bashcuts-config/azure-devops/queries/hierarchy.wiql -ErrorAction SilentlyContinue` to simulate a fresh machine.
- [ ] Run `az-Open-AzDevOpsHierarchyWiql` — expect green &#34;Wrote default hierarchy.wiql to … - opening for editing&#34; and the file opens in the default editor with the default WIQL.
- [ ] Close, re-run `az-Open-AzDevOpsHierarchyWiql` — expect dark-gray &#34;Opening …&#34; (no re-seed) and the file opens.
- [ ] Type `az-Open-` and press tab — confirm `az-Open-AzDevOpsHierarchyWiql` appears alongside `az-Open-AzDevOpsAssigned` / `az-Open-AzDevOpsMention`.
- [ ] `pwsh -NoProfile -Command &#34;[System.Management.Automation.Language.Parser]::ParseFile(&#39;powcuts_by_cli/azdevops_workitems.ps1&#39;, [ref]\$null, [ref]\$null) | Out-Null&#34;` parses with zero errors.

https://claude.ai/code/session_01Hegpmdqf6YhHBN45AF23g5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hegpmdqf6YhHBN45AF23g5)_