### PR TITLE
fix: build AzDO hierarchy from three per-tier WIQLs filtered by area

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,22 +192,24 @@ After `az-Connect-AzDevOps` reports `READY` once, later commands in the AzDevOps
 
 ### Customizing WIQL queries
 
-The `hierarchy` dataset that `az-Sync-AzDevOpsCache` writes into `hierarchy.json` is driven by a WIQL file on your own machine, not by code in this repo:
+The `hierarchy` dataset that `az-Sync-AzDevOpsCache` writes into `hierarchy.json` is built from three per-tier WIQL files on your own machine, not from code in this repo:
 
-- POSIX: `~/.bashcuts-config/azure-devops/queries/hierarchy.wiql`
-- Windows: `%USERPROFILE%\.bashcuts-config\azure-devops\queries\hierarchy.wiql`
+- POSIX: `~/.bashcuts-config/azure-devops/queries/{epics,features,user-stories}.wiql`
+- Windows: `%USERPROFILE%\.bashcuts-config\azure-devops\queries\{epics,features,user-stories}.wiql`
 
-`az-Connect-AzDevOps` (and the first run of `az-Sync-AzDevOpsCache` if you skipped Connect) seeds the file with a sensible default — Epic / Feature / RequirementCategory items under `{{AZ_AREA}}`, where `{{AZ_AREA}}` is substituted from `$env:AZ_AREA` at read time. Edit the file to add fields to the SELECT clause, filter by state, scope by tag, or otherwise tailor what lands in `hierarchy.json`. Re-run `az-Sync-AzDevOpsCache` to pick up your changes — no `reinit` needed, since the file is read every sync.
+Each sync fires one `az boards query` per file (epics, then features, then user stories) and merges the results into a single `hierarchy.json`. Splitting per tier sidesteps the partial-result behavior that the previous single combined query hit on larger projects, and lets you tune each tier's filter independently.
 
-The fast way to open the file for editing is the dedicated shortcut:
+`az-Connect-AzDevOps` (and the first run of `az-Sync-AzDevOpsCache` if you skipped Connect) seeds each file with a sensible default — items under `{{AZ_AREA}}` scoped to one of `Microsoft.EpicCategory` / `Microsoft.FeatureCategory` / `Microsoft.RequirementCategory`, where `{{AZ_AREA}}` is substituted from `$env:AZ_AREA` at read time. Edit any file to add fields to the SELECT clause, filter by state, scope by tag, or otherwise tailor what lands in `hierarchy.json`. Re-run `az-Sync-AzDevOpsCache` to pick up your changes — no `reinit` needed, since the files are read every sync.
+
+The fast way to open all three for editing is the dedicated shortcut:
 
 ```powershell
-az-Open-AzDevOpsHierarchyWiql
+az-Open-AzDevOpsHierarchyWiqls
 ```
 
-It seeds the default WIQL if the file is missing (so it works on a fresh machine even before `az-Connect-AzDevOps`) and then opens the path in your OS default editor.
+It seeds any missing defaults (so it works on a fresh machine even before `az-Connect-AzDevOps`) and then opens each path in your OS default editor.
 
-If you delete the file, the next sync writes the default back. The placeholder `{{AZ_AREA}}` is the only one currently supported; everything else in the file is passed through to `az boards query --wiql` verbatim.
+If you delete a file, the next sync writes that default back. The placeholder `{{AZ_AREA}}` is the only one currently supported; everything else in each file is passed through to `az boards query --wiql` verbatim.
 
 ### Day-to-day work-item shortcuts
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -591,6 +591,9 @@ graph LR
     QPaths[Get-AzDevOpsConfigPaths]:::priv
     QInit[Initialize-AzDevOpsQueryFiles]:::priv
     QWiql[Get-AzDevOpsWiql]:::priv
+    QDefaults[Get-AzDevOpsHierarchyQueryDefaults]:::priv
+    QNames[Get-AzDevOpsHierarchyQueryNames]:::priv
+    InvHier[Invoke-AzDevOpsHierarchyQueries]:::priv
     MkDir[New-AzDevOpsDirectoryIfMissing]:::priv
 
     %% Data-plane wrappers (azdevops_db.ps1)
@@ -728,11 +731,15 @@ graph LR
     InitDir --> MkDir
     Sync --> LogFn --> Paths
     Sync --> DSets
-    DSets --> QWiql --> QInit
+    Sync --> InvokeDS
+    InvokeDS --> InvHier
+    InvHier --> QNames --> QDefaults --> QPaths
+    InvHier --> QWiql --> QInit
+    InvHier --> Boards
+    QInit --> QDefaults
     QInit --> QPaths
     QInit --> MkDir
     OpenHWiql --> QInit
-    Sync --> InvokeDS
     InvokeDS --> Boards
     InvokeDS --> ClassList
     Boards --> AzJson

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -109,7 +109,7 @@ flowchart LR
 
 ## 2. `az-Connect-AzDevOps` — 8-step orchestrator
 
-Thin orchestrator: a hard-coded array of step descriptors. Each step is a `Confirm-*` function that prints its own status and returns `{Ok, FailMessage}`. First failure short-circuits with `NOT READY`. Step 4 (`az-Confirm-AzDevOpsProjectMap`) is opt-in: it returns `Ok=$true` immediately when `$global:AzDevOpsProjectMap` is not defined, so single-project users skip it transparently. Step 7 (`az-Confirm-AzDevOpsQueryFiles`) seeds the user-machine WIQL config under `~/.bashcuts-config/azure-devops/queries/` so subsequent `az-Sync-AzDevOpsCache` runs can read a customizable `hierarchy.wiql` rather than an inline string.
+Thin orchestrator: a hard-coded array of step descriptors. Each step is a `Confirm-*` function that prints its own status and returns `{Ok, FailMessage}`. First failure short-circuits with `NOT READY`. Step 4 (`az-Confirm-AzDevOpsProjectMap`) is opt-in: it returns `Ok=$true` immediately when `$global:AzDevOpsProjectMap` is not defined, so single-project users skip it transparently. Step 7 (`az-Confirm-AzDevOpsQueryFiles`) seeds the three user-machine WIQL files under `~/.bashcuts-config/azure-devops/queries/` (`epics.wiql`, `features.wiql`, `user-stories.wiql`) so subsequent `az-Sync-AzDevOpsCache` runs can build the hierarchy from customizable per-tier queries rather than an inline string.
 
 ```mermaid
 flowchart TD
@@ -121,7 +121,7 @@ flowchart TD
     S4["Step 4 — az-Confirm-AzDevOpsProjectMap<br/>opt-in $global:AzDevOpsProjectMap<br/>+ optional az-Use-AzDevOpsProject prompt"]
     S5["Step 5 — az-Confirm-AzDevOpsLogin<br/>uses Test-AzDevOpsLoggedIn<br/>+ optional 'az login'"]
     S6["Step 6 — az-Set-AzDevOpsDefaults<br/>'az devops configure --defaults'"]
-    S7["Step 7 — az-Confirm-AzDevOpsQueryFiles<br/>seeds ~/.bashcuts-config/.../hierarchy.wiql<br/>via Initialize-AzDevOpsQueryFiles"]
+    S7["Step 7 — az-Confirm-AzDevOpsQueryFiles<br/>seeds ~/.bashcuts-config/.../{epics,features,user-stories}.wiql<br/>via Initialize-AzDevOpsQueryFiles"]
     S8["Step 8 — az-Confirm-AzDevOpsSmokeQuery<br/>uses Invoke-AzDevOpsSmokeQuery"]
 
     Ready([READY])
@@ -217,7 +217,7 @@ flowchart TD
         direction LR
         D1["assigned<br/>WIQL System.AssignedTo = @Me"]
         D2["mentions<br/>WIQL System.History Contains '@email'"]
-        D3["hierarchy<br/>Get-AzDevOpsWiql -Name 'hierarchy'<br/>(reads ~/.bashcuts-config/.../hierarchy.wiql,<br/>substitutes {{AZ_AREA}})<br/>→ WIQL Epic/Feature/Story flat + System.Parent"]
+        D3["hierarchy<br/>Invoke-AzDevOpsHierarchyQueries<br/>(reads ~/.bashcuts-config/.../{epics,features,user-stories}.wiql,<br/>substitutes {{AZ_AREA}}, fires one WIQL per tier,<br/>merges into Epic + Feature + Story flat + System.Parent)"]
         D4["iterations<br/>Get-AzDevOpsClassificationList -Kind Iteration<br/>→ az boards iteration project list --depth 5"]
         D5["areas<br/>Get-AzDevOpsClassificationList -Kind Area<br/>→ az boards area project list --depth 5"]
     end
@@ -286,9 +286,9 @@ flowchart LR
 
 ## 6. `az-Show-AzDevOpsTree` — Epic → Feature → requirement-tier render
 
-Pure cache read, no `az`. The hierarchy WIQL pulled `[System.Parent]` per row, so a single pass into a `byParent` hashtable is enough — no follow-up queries.
+Pure cache read, no `az`. Each of the three hierarchy WIQLs (epics / features / user-stories) selects `[System.Parent]` per row, and `Invoke-AzDevOpsHierarchyQueries` merges them into a single flat array on disk, so a single pass into a `byParent` hashtable is enough — no follow-up queries.
 
-The leaf-tier filter checks `Type -in $script:AzDevOpsRequirementTypes` — the four stock requirement-tier names across process templates (`User Story` on Agile, `Product Backlog Item` on Scrum, `Requirement` on CMMI, `Issue` on Basic) — so the same render code works on every template the hierarchy WIQL fetches via `Microsoft.RequirementCategory`.
+The leaf-tier filter checks `Type -in $script:AzDevOpsRequirementTypes` — the four stock requirement-tier names across process templates (`User Story` on Agile, `Product Backlog Item` on Scrum, `Requirement` on CMMI, `Issue` on Basic) — so the same render code works on every template the user-stories WIQL fetches via `Microsoft.RequirementCategory`.
 
 ```mermaid
 flowchart TD
@@ -546,7 +546,7 @@ graph LR
     NewF(["az-New-AzDevOpsFeature"]):::pub
     NewSB(["az-New-AzDevOpsFeatureStories"]):::pub
     Find(["az-Find-AzDevOpsWorkItem"]):::pub
-    OpenHWiql(["az-Open-AzDevOpsHierarchyWiql"]):::pub
+    OpenHWiql(["az-Open-AzDevOpsHierarchyWiqls"]):::pub
 
     %% Multi-project switcher (azdevops_projects.ps1)
     UseProj(["az-Use-AzDevOpsProject"]):::pub

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -654,7 +654,18 @@ function Invoke-AzDevOpsHierarchyQueries {
             return $errEnvelope
         }
 
-        $parsed = $result.Json | ConvertFrom-Json
+        try {
+            $parsed = $result.Json | ConvertFrom-Json
+        }
+        catch {
+            $parseErrEnvelope = [PSCustomObject]@{
+                Json     = ''
+                Error    = "[$name] parse failed: $($_.Exception.Message)"
+                ExitCode = 1
+            }
+            return $parseErrEnvelope
+        }
+
         foreach ($item in @($parsed)) {
             if ($null -ne $item) {
                 $merged.Add($item)
@@ -662,8 +673,11 @@ function Invoke-AzDevOpsHierarchyQueries {
         }
     }
 
-    # -AsArray forces [{...}] shape even for zero/one items so hierarchy.json
-    # stays a JSON array and downstream Read-AzDevOpsJsonCache iterates cleanly.
+    # Invoke-AzDevOpsAzDataset re-parses + re-serializes Json before writing
+    # the cache, and it applies its own -AsArray when the descriptor sets
+    # AsArray=$true (the hierarchy descriptor does). The -Depth 10 here is
+    # only for the in-flight envelope passed back to that helper; downstream
+    # depth is governed by the descriptor's JsonDepth.
     $mergedJson = ConvertTo-Json -InputObject @($merged) -Depth 10 -AsArray
 
     $envelope = [PSCustomObject]@{
@@ -797,6 +811,7 @@ function Get-AzDevOpsSyncDatasets {
             Fetch    = { Invoke-AzDevOpsBoardsQuery -Wiql $assignedWiql }.GetNewClosure()
             Counter  = $rowCounter
             RowLabel = 'rows'
+            AsArray  = $true
         },
         @{
             Name     = 'mentions'
@@ -805,6 +820,7 @@ function Get-AzDevOpsSyncDatasets {
             Fetch    = { Invoke-AzDevOpsBoardsQuery -Wiql $mentionsWiql }.GetNewClosure()
             Counter  = $rowCounter
             RowLabel = 'rows'
+            AsArray  = $true
         },
         @{
             Name     = 'hierarchy'
@@ -813,6 +829,7 @@ function Get-AzDevOpsSyncDatasets {
             Fetch    = { Invoke-AzDevOpsHierarchyQueries }
             Counter  = $rowCounter
             RowLabel = 'rows'
+            AsArray  = $true
         },
         @{
             Name      = 'iterations'
@@ -845,6 +862,12 @@ function Invoke-AzDevOpsAzDataset {
     # for the count noun (rows / nodes), and the on-disk JSON depth. Replaces
     # the previously-duplicated WIQL- and classification-specific sync paths
     # per CLAUDE.md's extract-repeated-branches rule.
+    #
+    # -AsArray forces the on-disk JSON to keep [{...}] shape even when the
+    # parsed payload is a single object or $null. Required for the WIQL-style
+    # datasets (assigned / mentions / hierarchy) whose downstream readers index
+    # the JSON as an array; classification trees (iterations / areas) leave it
+    # off so their root object stays an object.
     param(
         [Parameter(Mandatory)] [string]      $Name,
         [Parameter(Mandatory)] [string]      $Label,
@@ -852,7 +875,8 @@ function Invoke-AzDevOpsAzDataset {
         [Parameter(Mandatory)] [scriptblock] $Fetch,
         [scriptblock] $Counter = { param($parsed) @($parsed).Count },
         [string]      $RowLabel = 'rows',
-        [int]         $JsonDepth = 10
+        [int]         $JsonDepth = 10,
+        [switch]      $AsArray
     )
 
     Write-Host "-> Querying $Name ($Label)..." -ForegroundColor Cyan
@@ -885,7 +909,13 @@ function Invoke-AzDevOpsAzDataset {
     }
 
     $count = & $Counter $parsed
-    $pretty = $parsed | ConvertTo-Json -Depth $JsonDepth
+
+    $pretty = if ($AsArray) {
+        ConvertTo-Json -InputObject @($parsed) -Depth $JsonDepth -AsArray
+    } else {
+        $parsed | ConvertTo-Json -Depth $JsonDepth
+    }
+
     Write-AzDevOpsCacheFile -Path $Path -Content $pretty
     Write-Host "  OK  $Name - $count $RowLabel in $elapsed" -ForegroundColor Green
     Write-AzDevOpsSyncLog "$Name wrote $count $RowLabel in $elapsed"

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -11,9 +11,10 @@
 #   az-Test-AzDevOpsAuth           - silent yes/no auth assertion intended for
 #                                    callers in later AzDevOps commands;
 #                                    returns $true / $false
-#   az-Open-AzDevOpsHierarchyWiql  - open ~/.bashcuts-config/azure-devops/
-#                                    queries/hierarchy.wiql in the default
-#                                    editor (seeds default WIQL on first run)
+#   az-Open-AzDevOpsHierarchyWiqls - open each ~/.bashcuts-config/azure-devops/
+#                                    queries/{epics,features,user-stories}.wiql
+#                                    in the default editor (seeds the defaults
+#                                    on first run)
 #
 # Step functions invoked by az-Connect-AzDevOps (also exposed for direct use,
 # e.g. to debug a single failing step). Each returns a [PSCustomObject]
@@ -311,9 +312,13 @@ function az-Set-AzDevOpsDefaults {
 function az-Confirm-AzDevOpsQueryFiles {
     $init = Initialize-AzDevOpsQueryFiles
 
-    if ($init.SeededHierarchy) {
-        Write-Host "  OK  Wrote default hierarchy.wiql to $($init.Paths.HierarchyQuery)" -ForegroundColor Green
-        Write-Host "      Edit this file to customize what az-Sync-AzDevOpsCache pulls into hierarchy.json." -ForegroundColor DarkGray
+    $newlySeeded = @($init.Seeded | Where-Object { $_.Seeded })
+
+    if ($newlySeeded.Count -gt 0) {
+        foreach ($entry in $newlySeeded) {
+            Write-Host "  OK  Wrote default $($entry.Name).wiql to $($entry.Path)" -ForegroundColor Green
+        }
+        Write-Host "      Edit these files to customize what az-Sync-AzDevOpsCache pulls into hierarchy.json." -ForegroundColor DarkGray
     } else {
         Write-Host "  OK  Query files at $($init.Paths.QueriesDir)" -ForegroundColor Green
     }
@@ -323,21 +328,23 @@ function az-Confirm-AzDevOpsQueryFiles {
 }
 
 
-function az-Open-AzDevOpsHierarchyWiql {
-    # Opens the user-machine hierarchy.wiql in the OS default editor. Defensively
-    # seeds the default WIQL via Initialize-AzDevOpsQueryFiles so a fresh
-    # machine that skipped az-Connect-AzDevOps can still discover and customize
-    # the query in one step (no "file not found" detour).
+function az-Open-AzDevOpsHierarchyWiqls {
+    # Opens each of the user-machine hierarchy WIQL files (epics, features,
+    # user-stories) in the OS default editor. Defensively seeds the defaults
+    # via Initialize-AzDevOpsQueryFiles so a fresh machine that skipped
+    # az-Connect-AzDevOps can still discover and customize the queries in one
+    # step (no "file not found" detour).
     $init = Initialize-AzDevOpsQueryFiles
-    $path = $init.Paths.HierarchyQuery
 
-    if ($init.SeededHierarchy) {
-        Write-Host "Wrote default hierarchy.wiql to $path - opening for editing" -ForegroundColor Green
-    } else {
-        Write-Host "Opening $path" -ForegroundColor DarkGray
+    foreach ($entry in $init.Seeded) {
+        if ($entry.Seeded) {
+            Write-Host "Wrote default $($entry.Name).wiql to $($entry.Path) - opening for editing" -ForegroundColor Green
+        } else {
+            Write-Host "Opening $($entry.Path)" -ForegroundColor DarkGray
+        }
+
+        Start-Process $entry.Path
     }
-
-    Start-Process $path
 }
 
 
@@ -467,22 +474,39 @@ function Initialize-AzDevOpsCacheDir {
 # User-machine config (queries)
 #
 # Config directory: $HOME/.bashcuts-config/azure-devops/queries/
-#   hierarchy.wiql  - WIQL pulled by the 'hierarchy' dataset in
-#                     Get-AzDevOpsSyncDatasets. Ships with a default that
-#                     filters by Epic/Feature/RequirementCategory under
-#                     {{AZ_AREA}}; users can edit this file to customize what
-#                     az-Sync-AzDevOpsCache writes into hierarchy.json without
-#                     touching tracked code.
+#   epics.wiql         - WIQL for the Epic tier of the hierarchy. Filtered by
+#                        [System.AreaPath] UNDER '{{AZ_AREA}}' and category
+#                        group 'Microsoft.EpicCategory'.
+#   features.wiql      - WIQL for the Feature tier. Same area filter, category
+#                        group 'Microsoft.FeatureCategory'.
+#   user-stories.wiql  - WIQL for the User Story tier. Same area filter,
+#                        category group 'Microsoft.RequirementCategory'
+#                        (covers User Story / Product Backlog Item /
+#                        Requirement / Issue across process templates).
+#
+# The three files together drive the 'hierarchy' dataset in
+# Get-AzDevOpsSyncDatasets: az-Sync-AzDevOpsCache fires one WIQL per tier and
+# merges the results into hierarchy.json. Splitting per-tier dodges the
+# combined-IN-GROUP query's partial-result behavior under large projects and
+# lets users tune each tier's filter independently.
 #
 # Placeholder tokens (substituted at read time by Get-AzDevOpsWiql):
-#   {{AZ_AREA}}  - $env:AZ_AREA. Keeps the file portable across machines /
+#   {{AZ_AREA}}  - $env:AZ_AREA. Keeps the files portable across machines /
 #                  projects without forcing users to hard-code their own area.
 # ---------------------------------------------------------------------------
 
 $script:AzDevOpsAreaToken = '{{AZ_AREA}}'
 
-$script:AzDevOpsDefaultHierarchyWiql = @"
-Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.AreaPath] UNDER '{{AZ_AREA}}' AND ([System.WorkItemType] IN GROUP 'Microsoft.EpicCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.FeatureCategory' OR [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory')
+$script:AzDevOpsDefaultEpicsWiql = @"
+Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.AreaPath] UNDER '{{AZ_AREA}}' AND [System.WorkItemType] IN GROUP 'Microsoft.EpicCategory'
+"@
+
+$script:AzDevOpsDefaultFeaturesWiql = @"
+Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.AreaPath] UNDER '{{AZ_AREA}}' AND [System.WorkItemType] IN GROUP 'Microsoft.FeatureCategory'
+"@
+
+$script:AzDevOpsDefaultUserStoriesWiql = @"
+Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.AreaPath] UNDER '{{AZ_AREA}}' AND [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory'
 "@
 
 
@@ -491,32 +515,82 @@ function Get-AzDevOpsConfigPaths {
     $queriesDir = Join-Path $configDir 'queries'
 
     return [PSCustomObject]@{
-        Dir            = $configDir
-        QueriesDir     = $queriesDir
-        HierarchyQuery = Join-Path $queriesDir 'hierarchy.wiql'
+        Dir              = $configDir
+        QueriesDir       = $queriesDir
+        EpicsQuery       = Join-Path $queriesDir 'epics.wiql'
+        FeaturesQuery    = Join-Path $queriesDir 'features.wiql'
+        UserStoriesQuery = Join-Path $queriesDir 'user-stories.wiql'
     }
+}
+
+
+function Get-AzDevOpsHierarchyQueryDefaults {
+    # Single source of truth for the three hierarchy-tier WIQL files: their
+    # logical name (also the -Name parameter for Get-AzDevOpsWiql), their
+    # on-disk path, and the default WIQL seeded on first run. Initialize,
+    # read, sync, and the user-facing open shortcut all iterate this list,
+    # so adding a fourth tier later is a one-place edit.
+    $paths = Get-AzDevOpsConfigPaths
+
+    $defaults = @(
+        [PSCustomObject]@{
+            Name    = 'epics'
+            Path    = $paths.EpicsQuery
+            Default = $script:AzDevOpsDefaultEpicsWiql
+        },
+        [PSCustomObject]@{
+            Name    = 'features'
+            Path    = $paths.FeaturesQuery
+            Default = $script:AzDevOpsDefaultFeaturesWiql
+        },
+        [PSCustomObject]@{
+            Name    = 'user-stories'
+            Path    = $paths.UserStoriesQuery
+            Default = $script:AzDevOpsDefaultUserStoriesWiql
+        }
+    )
+
+    return $defaults
 }
 
 
 function Initialize-AzDevOpsQueryFiles {
     # Idempotent: creates the queries directory if absent and seeds each
     # default .wiql file only when the file does not already exist. Returns
-    # a hashtable describing what happened so callers (az-Connect-AzDevOps
-    # step + defensive call from Get-AzDevOpsSyncDatasets) can print a
-    # single, consistent status line.
+    # the resolved paths plus per-file Seeded flags so callers (the
+    # az-Connect-AzDevOps step and az-Open-AzDevOpsHierarchyWiqls) can print
+    # consistent status lines.
     $paths = Get-AzDevOpsConfigPaths
     New-AzDevOpsDirectoryIfMissing -Path $paths.QueriesDir
 
-    $seededHierarchy = $false
-    if (-not (Test-Path -LiteralPath $paths.HierarchyQuery)) {
-        Set-Content -LiteralPath $paths.HierarchyQuery -Value $script:AzDevOpsDefaultHierarchyWiql -Encoding UTF8
-        $seededHierarchy = $true
+    $defaults = Get-AzDevOpsHierarchyQueryDefaults
+    $seeded = New-Object System.Collections.Generic.List[PSCustomObject]
+
+    foreach ($entry in $defaults) {
+        $wasSeeded = $false
+        if (-not (Test-Path -LiteralPath $entry.Path)) {
+            Set-Content -LiteralPath $entry.Path -Value $entry.Default -Encoding UTF8
+            $wasSeeded = $true
+        }
+
+        $seeded.Add([PSCustomObject]@{
+            Name   = $entry.Name
+            Path   = $entry.Path
+            Seeded = $wasSeeded
+        })
     }
 
     return [PSCustomObject]@{
-        Paths            = $paths
-        SeededHierarchy  = $seededHierarchy
+        Paths  = $paths
+        Seeded = @($seeded)
     }
+}
+
+
+function Get-AzDevOpsHierarchyQueryNames {
+    $defaults = Get-AzDevOpsHierarchyQueryDefaults
+    $names = @($defaults | ForEach-Object { $_.Name })
+    return $names
 }
 
 
@@ -526,17 +600,14 @@ function Get-AzDevOpsWiql {
     # need to remember to call Initialize-AzDevOpsQueryFiles first.
     param(
         [Parameter(Mandatory)]
-        [ValidateSet('hierarchy')]
+        [ValidateSet('epics', 'features', 'user-stories')]
         [string] $Name
     )
 
     $init = Initialize-AzDevOpsQueryFiles
 
-    $path = switch ($Name) {
-        'hierarchy' {
-            $init.Paths.HierarchyQuery
-        }
-    }
+    $entry = $init.Seeded | Where-Object { $_.Name -eq $Name } | Select-Object -First 1
+    $path = $entry.Path
 
     if ([string]::IsNullOrWhiteSpace($env:AZ_AREA)) {
         throw "Get-AzDevOpsWiql: `$env:AZ_AREA must be set to substitute $script:AzDevOpsAreaToken in $path."
@@ -551,6 +622,56 @@ function Get-AzDevOpsWiql {
     $wiql = $raw.Replace($script:AzDevOpsAreaToken, $areaEscaped)
 
     return $wiql
+}
+
+
+function Invoke-AzDevOpsHierarchyQueries {
+    # Runs the three per-tier hierarchy WIQLs (epics, features, user-stories)
+    # sequentially, each filtered by [System.AreaPath] UNDER '{{AZ_AREA}}',
+    # and returns the merged work-item array in the same { Json, Error,
+    # ExitCode } envelope that Invoke-AzDevOpsBoardsQuery emits. Splitting the
+    # prior single-query hierarchy into three category-scoped calls dodges the
+    # combined IN-GROUP query's partial-result behavior under larger projects
+    # and lets each tier's filter be tuned independently.
+    #
+    # On the first failing tier we short-circuit and return the underlying
+    # exit code + stderr (prefixed with the tier name) so Invoke-AzDevOpsAzDataset
+    # treats the dataset as failed and skips the cache write.
+
+    $names = Get-AzDevOpsHierarchyQueryNames
+    $merged = New-Object System.Collections.Generic.List[object]
+
+    foreach ($name in $names) {
+        $wiql = Get-AzDevOpsWiql -Name $name
+        $result = Invoke-AzDevOpsBoardsQuery -Wiql $wiql
+
+        if ($result.ExitCode -ne 0) {
+            $errEnvelope = [PSCustomObject]@{
+                Json     = ''
+                Error    = "[$name] $($result.Error)"
+                ExitCode = $result.ExitCode
+            }
+            return $errEnvelope
+        }
+
+        $parsed = $result.Json | ConvertFrom-Json
+        foreach ($item in @($parsed)) {
+            if ($null -ne $item) {
+                $merged.Add($item)
+            }
+        }
+    }
+
+    # -AsArray forces [{...}] shape even for zero/one items so hierarchy.json
+    # stays a JSON array and downstream Read-AzDevOpsJsonCache iterates cleanly.
+    $mergedJson = ConvertTo-Json -InputObject @($merged) -Depth 10 -AsArray
+
+    $envelope = [PSCustomObject]@{
+        Json     = $mergedJson
+        Error    = ''
+        ExitCode = 0
+    }
+    return $envelope
 }
 
 
@@ -653,16 +774,17 @@ function Get-AzDevOpsSyncDatasets {
 
     $assignedWiql = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.ChangedDate] From WorkItems Where [System.AssignedTo] = @Me'
     $mentionsWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.ChangedBy], [System.AreaPath], [System.ChangedDate] From WorkItems Where [System.History] Contains '$mentionsToken'"
-    # Hierarchy WIQL is sourced from ~/.bashcuts-config/azure-devops/queries/
-    # hierarchy.wiql so users can customize fields / filters per machine
-    # without modifying tracked code. Get-AzDevOpsWiql seeds the file with
-    # the default template-agnostic WIQL (Epic/Feature/RequirementCategory
-    # under {{AZ_AREA}}) on first call and substitutes {{AZ_AREA}} from
-    # $env:AZ_AREA at read time. Project scope is still supplied by
-    # --project on the az invocation (Invoke-AzDevOpsAzJson injects it from
-    # $env:AZ_PROJECT), so the WIQL itself does not need a
-    # [System.TeamProject] = @Project clause.
-    $hierarchyWiql = Get-AzDevOpsWiql -Name 'hierarchy'
+    # Hierarchy is built from three per-tier WIQL files under
+    # ~/.bashcuts-config/azure-devops/queries/ (epics.wiql / features.wiql /
+    # user-stories.wiql). Invoke-AzDevOpsHierarchyQueries runs each WIQL
+    # sequentially via az boards query, then merges the work items into a
+    # single JSON array so hierarchy.json keeps its existing flat-list shape
+    # (Read-AzDevOpsHierarchyCache + az-Show-AzDevOpsTree are unchanged).
+    # Each WIQL filters by [System.AreaPath] UNDER '{{AZ_AREA}}' and one
+    # category group, which sidesteps the previous combined IN-GROUP query
+    # that returned partial results on larger projects. Project scope is
+    # still supplied by --project on each az invocation (Invoke-AzDevOpsAzJson
+    # injects it from $env:AZ_PROJECT).
 
     $rowCounter = { param($parsed) @($parsed).Count }
     $treeCounter = { param($parsed) Measure-AzDevOpsClassificationNodes -Node $parsed }
@@ -686,9 +808,9 @@ function Get-AzDevOpsSyncDatasets {
         },
         @{
             Name     = 'hierarchy'
-            Label    = 'Epic/Feature/Requirement-tier hierarchy'
+            Label    = 'Epic + Feature + User Story tiers (3 area-filtered WIQLs)'
             Path     = $Paths.Hierarchy
-            Fetch    = { Invoke-AzDevOpsBoardsQuery -Wiql $hierarchyWiql }.GetNewClosure()
+            Fetch    = { Invoke-AzDevOpsHierarchyQueries }
             Counter  = $rowCounter
             RowLabel = 'rows'
         },

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -7,13 +7,6 @@ if ($pow_sfdxcli -ne $NULL) {
     Write-Host "no sfdx cli"
 }
 
-$pow_azcli = Get-Content "$path_to_bashcuts\powcuts_by_cli\pow_az_cli.ps1"
-if ($pow_azcli -ne $NULL) {
- . "$path_to_bashcuts\powcuts_by_cli\pow_az_cli.ps1"
-} else {
-    Write-Host "no az cli"
-}
-
 $pow_common = Get-Content "$path_to_bashcuts\powcuts_by_cli\pow_common.ps1"
 if ($pow_common -ne $NULL) {
  . "$path_to_bashcuts\powcuts_by_cli\pow_common.ps1"


### PR DESCRIPTION
<!-- toc:start -->
## Navigation

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Changes](#changes) | ✅ 4 files |
| [Test Plan](#test-plan) | ✅ 7 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/72#issuecomment-4433326181) |
| 💠 PowerShell Engineer Review | ✅ APPROVE (HIGH + MED fixed in `3284472`) — [View](https://github.com/jdschleicher/bashcuts/pull/72#issuecomment-4433339374) |
| 🛡️ Security Audit | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/72#issuecomment-4433340112) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/72#issuecomment-4433347728) |
| 📚 Docs Check | ✅ CURRENT (dead `pow_az_cli.ps1` reference fixed in `17d1a82`) |
| 📐 AzDO Diagrams Check | ✅ CURRENT (Diagram 9 synced in `dcb63b7`) |
| ✅ Criteria Check | ⏭️ N/A — no linked GitHub issue |
| 🔀 Merge | ✅ main integrated in `3f6c9aa` (PR #73 state-dir refactor) |
<!-- toc:end -->
<!-- pr-diagram:start -->
## How it works

This PR replaces the old single-WIQL hierarchy with a three-tier flow. `az-Sync-AzDevOpsCache` still drives the hierarchy descriptor through `Invoke-AzDevOpsAzDataset`, but the descriptor's `Fetch` now hands off to the new `Invoke-AzDevOpsHierarchyQueries`, which iterates a single-source-of-truth defaults table (`Get-AzDevOpsHierarchyQueryDefaults`), seeds any missing `.wiql` files, fires one `az boards query` per tier, and returns a merged-array envelope that the writer persists to `hierarchy.json` (now `-AsArray`-preserved). A second public surface, `az-Open-AzDevOpsHierarchyWiqls`, ensures the three files exist and opens them in the user's editor.

```mermaid
flowchart TD
    Sync([az-Sync-AzDevOpsCache]):::pub
    Open([az-Open-AzDevOpsHierarchyWiqls]):::pub

    InvDS[Invoke-AzDevOpsAzDataset<br/>+ -AsArray switch]:::priv
    InvHier[Invoke-AzDevOpsHierarchyQueries]:::priv

    Defaults[Get-AzDevOpsHierarchyQueryDefaults<br/>SSOT: Name + Path + Default]:::priv
    Names[Get-AzDevOpsHierarchyQueryNames]:::priv
    Init[Initialize-AzDevOpsQueryFiles<br/>per-file seed]:::priv
    Wiql["Get-AzDevOpsWiql -Name<br/>epics | features | user-stories"]:::priv

    EpicsFile[(epics.wiql)]:::io
    FeaturesFile[(features.wiql)]:::io
    StoriesFile[(user-stories.wiql)]:::io
    AzCli["az boards query<br/>x3 (one per tier)"]:::io
    HierJson[(hierarchy.json)]:::io

    Sync --> InvDS
    InvDS -- hierarchy descriptor --> InvHier
    InvHier --> Names --> Defaults
    InvHier --> Wiql --> Init --> Defaults
    Init -. seed if missing .-> EpicsFile
    Init -. seed if missing .-> FeaturesFile
    Init -. seed if missing .-> StoriesFile
    InvHier --> AzCli
    InvHier -- merged Json envelope --> InvDS
    InvDS -- ConvertTo-Json -AsArray --> HierJson

    Open --> Init
    Open -. opens .-> EpicsFile
    Open -. opens .-> FeaturesFile
    Open -. opens .-> StoriesFile

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

- Replaces the single combined hierarchy WIQL (Epic/Feature/Requirement `IN GROUP`) — which returned partial results on larger projects — with three per-tier WIQL files (`epics.wiql`, `features.wiql`, `user-stories.wiql`) under `~/.bashcuts-az-devops-app/config/queries/`.
- Each file filters `[System.AreaPath] UNDER '{{AZ_AREA}}'` and scopes to one category group, so each tier's filter can be tuned independently.
- `Invoke-AzDevOpsHierarchyQueries` runs the three WIQLs sequentially via `Invoke-AzDevOpsBoardsQuery`, short-circuits on the first non-zero exit (prefixing the tier name to stderr), and merges results into the existing flat-array `hierarchy.json` shape — so `Read-AzDevOpsHierarchyCache`, `az-Show-AzDevOpsTree`, `Get-AzDevOpsTreeRows`, and parent-pickers are unchanged.
- Renames the user shortcut `az-Open-AzDevOpsHierarchyWiql` → `az-Open-AzDevOpsHierarchyWiqls` (opens all three files).
- README + `docs/azure-devops-diagrams.md` updated to reflect the three-file design and the renamed shortcut.
- Merged `main` (`3f6c9aa`) to integrate the AzDO state-directory consolidation from PR #73 — the three-file hierarchy design now lives under the new `~/.bashcuts-az-devops-app/config/queries/` base.

## Changes

- `powcuts_by_cli/azdevops_workitems.ps1` — three new `$script:` default WIQL constants; `Get-AzDevOpsConfigPaths` exposes `EpicsQuery` / `FeaturesQuery` / `UserStoriesQuery` (routed through main's `Get-AzDevOpsAppRoot`); new `Get-AzDevOpsHierarchyQueryDefaults` is the single source of truth; `Initialize-AzDevOpsQueryFiles` seeds each missing file and reports per-file `Seeded` flags; `Get-AzDevOpsWiql -Name` now accepts `epics` / `features` / `user-stories`; new `Invoke-AzDevOpsHierarchyQueries` merges the three results into one `{Json, Error, ExitCode}` envelope using `ConvertTo-Json -AsArray` with a try/catch parse guard; dataset descriptor + `az-Confirm-AzDevOpsQueryFiles` + `az-Open-AzDevOpsHierarchyWiqls` updated. Also adds `[switch] $AsArray` to `Invoke-AzDevOpsAzDataset` so the array shape survives to disk for `assigned`/`mentions`/`hierarchy` (commit `3284472`).
- `powcuts_home.ps1` — removes dead `pow_az_cli.ps1` dot-source block left over from PR #71 (commit `17d1a82`; same fix landed independently on main as `0368f60`).
- `README.md` — "Customizing WIQL queries" section rewritten for three files under the new state directory.
- `docs/azure-devops-diagrams.md` — Connect step 7, sync dataset node, tree-render explanation, and Diagram 9 (function dependency map) updated; new `Get-AzDevOpsHierarchyQueryDefaults` / `Get-AzDevOpsHierarchyQueryNames` / `Invoke-AzDevOpsHierarchyQueries` nodes wired into the dispatch chain (commit `dcb63b7`).

## Test Plan

- [ ] In a fresh PowerShell terminal: `az-Confirm-AzDevOpsQueryFiles` seeds three files on a clean machine and prints one OK line per file
- [ ] `ls ~/.bashcuts-az-devops-app/config/queries/` shows `epics.wiql`, `features.wiql`, `user-stories.wiql`
- [ ] `Get-AzDevOpsWiql -Name epics` / `-Name features` / `-Name 'user-stories'` each return a WIQL string with `{{AZ_AREA}}` substituted
- [ ] `az-Sync-AzDevOpsCache` fires three `az boards query` calls (visible in the echo) and writes a populated `hierarchy.json` under `~/.bashcuts-az-devops-app/cache/`
- [ ] `az-Show-AzDevOpsTree` renders the Epic → Feature → User Story tree correctly from the merged cache
- [ ] `az-Open-AzDevOpsHierarchyWiqls` opens all three files in the OS default editor
- [ ] Negative path: rename `~/.bashcuts-az-devops-app/config/queries/user-stories.wiql` → `user-stories.wiql.bak`, re-run `az-Sync-AzDevOpsCache`, confirm the default gets reseeded and the sync still succeeds

https://claude.ai/code/session_01Y9RmYgggvZCEwyv51AYAtG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9RmYgggvZCEwyv51AYAtG)_