### PR TITLE
refactor: consolidate AzDevOps state under ~/.bashcuts-az-devops-app/

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ After `az-Connect-AzDevOps` reports `READY` once, later commands in the AzDevOps
 
 The `hierarchy` dataset that `az-Sync-AzDevOpsCache` writes into `hierarchy.json` is driven by a WIQL file on your own machine, not by code in this repo:
 
-- POSIX: `~/.bashcuts-config/azure-devops/queries/hierarchy.wiql`
-- Windows: `%USERPROFILE%\.bashcuts-config\azure-devops\queries\hierarchy.wiql`
+- POSIX: `~/.bashcuts-az-devops-app/config/queries/hierarchy.wiql`
+- Windows: `%USERPROFILE%\.bashcuts-az-devops-app\config\queries\hierarchy.wiql`
 
 `az-Connect-AzDevOps` (and the first run of `az-Sync-AzDevOpsCache` if you skipped Connect) seeds the file with a sensible default — Epic / Feature / RequirementCategory items under `{{AZ_AREA}}`, where `{{AZ_AREA}}` is substituted from `$env:AZ_AREA` at read time. Edit the file to add fields to the SELECT clause, filter by state, scope by tag, or otherwise tailor what lands in `hierarchy.json`. Re-run `az-Sync-AzDevOpsCache` to pick up your changes — no `reinit` needed, since the file is read every sync.
 
@@ -319,7 +319,7 @@ az-New-AzDevOpsFeatureStories -ParentId 1240 `
 
 Every Azure DevOps org configures its own required + custom fields via process templates (e.g. a "Customer Impact" required field on every User Story, or a "Compliance Risk" picklist). The schema-management commands let you declare those fields once per org so future schema-aware updates to `az-New-AzDevOpsUserStory`, `az-Get-AzDevOpsAssigned`, `az-Show-AzDevOpsTree`, etc. can prompt for / surface them automatically.
 
-The schema lives at `$HOME/.bashcuts/azure-devops/schema-<org>.json` (per-org keyed off `$env:AZ_DEVOPS_ORG`; falls back to `schema.json` when unset). The directory is created with `0700` permissions on macOS / Linux; Windows inherits the user-only ACL from `%USERPROFILE%`.
+The schema lives at `$HOME/.bashcuts-az-devops-app/schema/schema-<org>.json` (per-org keyed off `$env:AZ_DEVOPS_ORG`; falls back to `schema.json` when unset). The directory is created with `0700` permissions on macOS / Linux; Windows inherits the user-only ACL from `%USERPROFILE%`.
 
 ```powershell
 az-Initialize-AzDevOpsSchema     # introspect your org via

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -48,7 +48,7 @@ flowchart LR
         NewStoryBatch["az-New-AzDevOpsFeatureStories"]
     end
 
-    subgraph Cache["$HOME/.bashcuts-cache/azure-devops/"]
+    subgraph Cache["$HOME/.bashcuts-az-devops-app/cache/"]
         AssignedJson["assigned.json"]
         MentionsJson["mentions.json"]
         HierJson["hierarchy.json"]
@@ -109,7 +109,7 @@ flowchart LR
 
 ## 2. `az-Connect-AzDevOps` — 8-step orchestrator
 
-Thin orchestrator: a hard-coded array of step descriptors. Each step is a `Confirm-*` function that prints its own status and returns `{Ok, FailMessage}`. First failure short-circuits with `NOT READY`. Step 4 (`az-Confirm-AzDevOpsProjectMap`) is opt-in: it returns `Ok=$true` immediately when `$global:AzDevOpsProjectMap` is not defined, so single-project users skip it transparently. Step 7 (`az-Confirm-AzDevOpsQueryFiles`) seeds the user-machine WIQL config under `~/.bashcuts-config/azure-devops/queries/` so subsequent `az-Sync-AzDevOpsCache` runs can read a customizable `hierarchy.wiql` rather than an inline string.
+Thin orchestrator: a hard-coded array of step descriptors. Each step is a `Confirm-*` function that prints its own status and returns `{Ok, FailMessage}`. First failure short-circuits with `NOT READY`. Step 4 (`az-Confirm-AzDevOpsProjectMap`) is opt-in: it returns `Ok=$true` immediately when `$global:AzDevOpsProjectMap` is not defined, so single-project users skip it transparently. Step 7 (`az-Confirm-AzDevOpsQueryFiles`) seeds the user-machine WIQL config under `~/.bashcuts-az-devops-app/config/queries/` so subsequent `az-Sync-AzDevOpsCache` runs can read a customizable `hierarchy.wiql` rather than an inline string.
 
 ```mermaid
 flowchart TD
@@ -121,7 +121,7 @@ flowchart TD
     S4["Step 4 — az-Confirm-AzDevOpsProjectMap<br/>opt-in $global:AzDevOpsProjectMap<br/>+ optional az-Use-AzDevOpsProject prompt"]
     S5["Step 5 — az-Confirm-AzDevOpsLogin<br/>uses Test-AzDevOpsLoggedIn<br/>+ optional 'az login'"]
     S6["Step 6 — az-Set-AzDevOpsDefaults<br/>'az devops configure --defaults'"]
-    S7["Step 7 — az-Confirm-AzDevOpsQueryFiles<br/>seeds ~/.bashcuts-config/.../hierarchy.wiql<br/>via Initialize-AzDevOpsQueryFiles"]
+    S7["Step 7 — az-Confirm-AzDevOpsQueryFiles<br/>seeds ~/.bashcuts-az-devops-app/config/.../hierarchy.wiql<br/>via Initialize-AzDevOpsQueryFiles"]
     S8["Step 8 — az-Confirm-AzDevOpsSmokeQuery<br/>uses Invoke-AzDevOpsSmokeQuery"]
 
     Ready([READY])
@@ -217,7 +217,7 @@ flowchart TD
         direction LR
         D1["assigned<br/>WIQL System.AssignedTo = @Me"]
         D2["mentions<br/>WIQL System.History Contains '@email'"]
-        D3["hierarchy<br/>Get-AzDevOpsWiql -Name 'hierarchy'<br/>(reads ~/.bashcuts-config/.../hierarchy.wiql,<br/>substitutes {{AZ_AREA}})<br/>→ WIQL Epic/Feature/Story flat + System.Parent"]
+        D3["hierarchy<br/>Get-AzDevOpsWiql -Name 'hierarchy'<br/>(reads ~/.bashcuts-az-devops-app/config/.../hierarchy.wiql,<br/>substitutes {{AZ_AREA}})<br/>→ WIQL Epic/Feature/Story flat + System.Parent"]
         D4["iterations<br/>Get-AzDevOpsClassificationList -Kind Iteration<br/>→ az boards iteration project list --depth 5"]
         D5["areas<br/>Get-AzDevOpsClassificationList -Kind Area<br/>→ az boards area project list --depth 5"]
     end

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -11,7 +11,7 @@
 #   az-Test-AzDevOpsAuth           - silent yes/no auth assertion intended for
 #                                    callers in later AzDevOps commands;
 #                                    returns $true / $false
-#   az-Open-AzDevOpsHierarchyWiql  - open ~/.bashcuts-config/azure-devops/
+#   az-Open-AzDevOpsHierarchyWiql  - open ~/.bashcuts-az-devops-app/config/
 #                                    queries/hierarchy.wiql in the default
 #                                    editor (seeds default WIQL on first run)
 #
@@ -24,7 +24,7 @@
 #   az-Confirm-AzDevOpsEnvVars          - step 3 (required $profile env vars set)
 #   az-Confirm-AzDevOpsLogin            - step 4 (az login session; offers login)
 #   az-Set-AzDevOpsDefaults             - step 5 (az devops configure --defaults)
-#   az-Confirm-AzDevOpsQueryFiles       - step 6 (seed ~/.bashcuts-config WIQL files)
+#   az-Confirm-AzDevOpsQueryFiles       - step 6 (seed ~/.bashcuts-az-devops-app/config WIQL files)
 #   az-Confirm-AzDevOpsSmokeQuery       - step 7 (az boards query smoke test)
 #
 # Silent diagnostic helpers (pure checks, no I/O — used by az-Test-AzDevOpsAuth):
@@ -395,9 +395,22 @@ function az-Connect-AzDevOps {
 
 
 # ---------------------------------------------------------------------------
+# Single hidden parent folder under $HOME that contains every AzDevOps state
+# subdirectory (cache/, config/, schema/). Consolidates what used to be three
+# separate top-level dotfolders (.bashcuts-cache, .bashcuts-config, .bashcuts)
+# into one easy-to-find location.
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsAppRoot {
+    $root = Join-Path $HOME '.bashcuts-az-devops-app'
+    return $root
+}
+
+
+# ---------------------------------------------------------------------------
 # Local cache + scheduled refresh
 #
-# Cache directory: $HOME/.bashcuts-cache/azure-devops/
+# Cache directory: $HOME/.bashcuts-az-devops-app/cache/
 #   assigned.json   - items where [System.AssignedTo] = @Me
 #   mentions.json   - items where the user's email (or '@') appears in
 #                     [System.History] (best-effort - WIQL has no first-class
@@ -421,7 +434,7 @@ function Get-AzDevOpsCachePaths {
     # hierarchy / assigned / mentions data across projects. Falls back to the
     # legacy unsegmented layout when no project map is active, which keeps
     # single-project users unaffected (no migration needed for them).
-    $rootDir = Join-Path (Join-Path $HOME '.bashcuts-cache') 'azure-devops'
+    $rootDir = Join-Path (Get-AzDevOpsAppRoot) 'cache'
     $cacheDir = $rootDir
 
     if (Get-Command Get-AzDevOpsActiveProjectSlug -ErrorAction SilentlyContinue) {
@@ -466,7 +479,7 @@ function Initialize-AzDevOpsCacheDir {
 # ---------------------------------------------------------------------------
 # User-machine config (queries)
 #
-# Config directory: $HOME/.bashcuts-config/azure-devops/queries/
+# Config directory: $HOME/.bashcuts-az-devops-app/config/queries/
 #   hierarchy.wiql  - WIQL pulled by the 'hierarchy' dataset in
 #                     Get-AzDevOpsSyncDatasets. Ships with a default that
 #                     filters by Epic/Feature/RequirementCategory under
@@ -487,7 +500,7 @@ Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [Syst
 
 
 function Get-AzDevOpsConfigPaths {
-    $configDir  = Join-Path (Join-Path $HOME '.bashcuts-config') 'azure-devops'
+    $configDir  = Join-Path (Get-AzDevOpsAppRoot) 'config'
     $queriesDir = Join-Path $configDir 'queries'
 
     return [PSCustomObject]@{
@@ -653,7 +666,7 @@ function Get-AzDevOpsSyncDatasets {
 
     $assignedWiql = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.ChangedDate] From WorkItems Where [System.AssignedTo] = @Me'
     $mentionsWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.ChangedBy], [System.AreaPath], [System.ChangedDate] From WorkItems Where [System.History] Contains '$mentionsToken'"
-    # Hierarchy WIQL is sourced from ~/.bashcuts-config/azure-devops/queries/
+    # Hierarchy WIQL is sourced from ~/.bashcuts-az-devops-app/config/queries/
     # hierarchy.wiql so users can customize fields / filters per machine
     # without modifying tracked code. Get-AzDevOpsWiql seeds the file with
     # the default template-agnostic WIQL (Epic/Feature/RequirementCategory
@@ -1163,7 +1176,7 @@ function Read-AzDevOpsGridPick {
 #   az-Get-AzDevOpsMentions   - table of work items where I've been @-mentioned
 #   az-Open-AzDevOpsMention   - open a single mentioned item in the browser
 #
-# All four read $HOME/.bashcuts-cache/azure-devops/{assigned,mentions}.json
+# All four read $HOME/.bashcuts-az-devops-app/cache/{assigned,mentions}.json
 # (built by az-Sync-AzDevOpsCache). They never call `az` directly - if the cache
 # is missing, they print a hint and bail.
 #
@@ -1602,7 +1615,7 @@ function az-Open-AzDevOpsMention {
 #                          relies on Out-ConsoleGridView's column group-by.
 #                          Defined further down in its own section.
 #
-# Reads $HOME/.bashcuts-cache/azure-devops/hierarchy.json (built by
+# Reads $HOME/.bashcuts-az-devops-app/cache/hierarchy.json (built by
 # az-Sync-AzDevOpsCache). The hierarchy WIQL selects [System.Parent] so each
 # item carries its parent link directly - no follow-up resolution needed.
 # ---------------------------------------------------------------------------
@@ -1877,7 +1890,7 @@ function az-Show-AzDevOpsTree {
 #                            so Out-ConsoleGridView's built-in group-by-State
 #                            handles the kanban affordance interactively.
 #
-# Reuses the same $HOME/.bashcuts-cache/azure-devops/hierarchy.json that
+# Reuses the same $HOME/.bashcuts-az-devops-app/cache/hierarchy.json that
 # az-Show-AzDevOpsTree consumes; never calls `az` directly. Default -Type list
 # matches what the hierarchy WIQL pulls (Epic / Feature / requirement-tier).
 # Default -State filter excludes closed states via Select-AzDevOpsActiveItems;
@@ -1920,7 +1933,7 @@ function az-Show-AzDevOpsBoard {
 #                              branches in one session and emits picked
 #                              work-item ids on the pipeline.
 #
-# Reads the same $HOME/.bashcuts-cache/azure-devops/hierarchy.json that
+# Reads the same $HOME/.bashcuts-az-devops-app/cache/hierarchy.json that
 # az-Show-AzDevOpsTree consumes; never calls `az` directly. Modeled on the
 # while ($running) { ... } + ".. [Go Back]" pattern from issue #39.
 # ---------------------------------------------------------------------------
@@ -3570,9 +3583,9 @@ function az-New-AzDevOpsFeatureStories {
 # ---------------------------------------------------------------------------
 # Local field-schema config
 #
-# Schema directory: $HOME/.bashcuts/azure-devops/   (separate from the
-#                   auto-managed $HOME/.bashcuts-cache/ tree)
-# Schema file:      schema-<orgslug>.json           (per-org keyed off
+# Schema directory: $HOME/.bashcuts-az-devops-app/schema/   (separate from the
+#                   auto-managed cache/ subtree under the same parent)
+# Schema file:      schema-<orgslug>.json                   (per-org keyed off
 #                   $env:AZ_DEVOPS_ORG; falls back to schema.json when unset)
 #
 # Public functions:
@@ -3676,7 +3689,7 @@ function Get-AzDevOpsSchemaOrgSlug {
 
 
 function Get-AzDevOpsSchemaPaths {
-    $configDir = Join-Path (Join-Path $HOME '.bashcuts') 'azure-devops'
+    $configDir = Join-Path (Get-AzDevOpsAppRoot) 'schema'
     $slug = Get-AzDevOpsSchemaOrgSlug
 
     $fileName = if ($slug) {
@@ -3695,8 +3708,8 @@ function Get-AzDevOpsSchemaPaths {
 
 
 function Initialize-AzDevOpsSchemaDir {
-    # Creates $HOME/.bashcuts/azure-devops with 0700 on Unix. Windows gets
-    # default NTFS ACLs inherited from %USERPROFILE%, which are user-only
+    # Creates $HOME/.bashcuts-az-devops-app/schema with 0700 on Unix. Windows
+    # gets default NTFS ACLs inherited from %USERPROFILE%, which are user-only
     # for files created under $HOME.
     $paths = Get-AzDevOpsSchemaPaths
 

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -7,13 +7,6 @@ if ($pow_sfdxcli -ne $NULL) {
     Write-Host "no sfdx cli"
 }
 
-$pow_azcli = Get-Content "$path_to_bashcuts\powcuts_by_cli\pow_az_cli.ps1"
-if ($pow_azcli -ne $NULL) {
- . "$path_to_bashcuts\powcuts_by_cli\pow_az_cli.ps1"
-} else {
-    Write-Host "no az cli"
-}
-
 $pow_common = Get-Content "$path_to_bashcuts\powcuts_by_cli\pow_common.ps1"
 if ($pow_common -ne $NULL) {
  . "$path_to_bashcuts\powcuts_by_cli\pow_common.ps1"


### PR DESCRIPTION
<!-- toc:start -->
## 📋 PR Navigation

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Motivation](#motivation) | ✅ |
| [Changes](#changes) | ✅ 4 files |
| [Resulting layout](#resulting-layout) | ✅ |
| [Migration](#migration) | ⚠️ Clean break |
| [Test Plan](#test-plan) | 0/5 manual items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/73#issuecomment-4433368940) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/73#issuecomment-4433374554) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/73#issuecomment-4433375387) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/73#issuecomment-4433376804) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/73#issuecomment-4433424290) |
| 📚 Docs Check | ⚠️ STALE → fixed in `0368f60` (dead `pow_az_cli.ps1` dot-source removed) |
| 📊 AzDO Diagrams Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/73#issuecomment-4433435327) |
<!-- toc:end -->

## Summary
Consolidate Azure DevOps state directories under a single hidden parent folder `~/.bashcuts-az-devops-app/` so users have one easy-to-find location instead of three top-level dotfolders scattered across `$HOME`.

## Motivation
Today AzDO state is split across three different parents:
- `~/.bashcuts-cache/azure-devops/` — auto-managed cache
- `~/.bashcuts-config/azure-devops/queries/` — user WIQL files
- `~/.bashcuts/azure-devops/` — per-org schema files

This is hard to discover, hard to back up, and hard to clean up. One parent is the natural shape.

## Changes
- New private helper `Get-AzDevOpsAppRoot` in `powcuts_by_cli/azdevops_workitems.ps1` returns `~/.bashcuts-az-devops-app`
- `Get-AzDevOpsCachePaths` → derives `cache/` from helper
- `Get-AzDevOpsConfigPaths` → derives `config/queries/` from helper
- `Get-AzDevOpsSchemaPaths` / `Initialize-AzDevOpsSchemaDir` → derive `schema/` from helper
- All in-file doc comments updated to the new paths
- `README.md` WIQL section + schema section paths updated
- `docs/azure-devops-diagrams.md` cache subgraph label + WIQL config references updated
- Drive-by: removed dead `pow_az_cli.ps1` dot-source block from `powcuts_home.ps1` (file was deleted upstream but the hook lingered)

## Resulting layout
```
~/.bashcuts-az-devops-app/
├── cache/          (auto-managed: assigned.json, mentions.json, hierarchy.json, ...)
├── config/queries/ (user-editable: hierarchy.wiql)
└── schema/         (per-org: schema-<org>.json)
```

## Migration
Clean break — no migration code. Existing cache JSON gets re-synced on the next `az-Sync-AzDevOpsCache`. Anyone with a customized `hierarchy.wiql` should move it by hand to `~/.bashcuts-az-devops-app/config/queries/`.

## Test Plan
- [ ] Open a fresh PowerShell terminal
- [ ] `(Get-AzDevOpsCachePaths).Dir` ends in `\.bashcuts-az-devops-app\cache`
- [ ] `(Get-AzDevOpsConfigPaths).QueriesDir` ends in `\.bashcuts-az-devops-app\config\queries`
- [ ] `(Get-AzDevOpsSchemaPaths).Dir` ends in `\.bashcuts-az-devops-app\schema`
- [ ] `az-Sync-AzDevOpsCache` writes JSON under the new cache dir
- [ ] `az-Open-AzDevOpsHierarchyWiql` opens / seeds the file under the new config dir