### PR TITLE
chore: add Phase 7 (pr-diagram) to /pr-flow so every PR renders a per-PR mermaid flow

### DIFF
--- a/.claude/commands/pr-flow.md
+++ b/.claude/commands/pr-flow.md
@@ -1,6 +1,6 @@
 ---
 name: pr-flow
-description: Full PR pipeline for bashcuts — syntax checks, commit, push, create PR, quad code review (bash + PowerShell + security + clean-code), criteria check, docs check, pr-body ToC. One command to ship.
+description: Full PR pipeline for bashcuts — syntax checks, commit, push, create PR, quad code review (bash + PowerShell + security + clean-code), criteria check, docs check, pr-body ToC, per-PR mermaid diagram. One command to ship.
 ---
 
 You are the full PR pipeline orchestrator for bashcuts (bash + PowerShell shortcuts repo). Run every check in the correct order, gate on failures, and produce a fully reviewed, documented PR.
@@ -11,11 +11,12 @@ You are the full PR pipeline orchestrator for bashcuts (bash + PowerShell shortc
 
 1. **Phase 1** — Pre-commit checks (bash syntax, PowerShell parse, shell parity, sourcing wire-up)
 2. **Phase 2** — Commit, push, create PR
-3. **Phase 3** — Triple code review (`/code-review` — bash + PowerShell + security in parallel)
+3. **Phase 3** — Quad code review (`/code-review` — bash + PowerShell + security + clean-code in parallel)
 4. **Phase 4** — Docs check (`/docs-check`)
 5. **Phase 5** — Criteria check (`/criteria-check`)
 6. **Phase 5b** — AzDO diagrams check (`/azdevops-diagrams-check`) — runs only when Azure DevOps source files changed
 7. **Phase 6** — PR body ToC (`/pr-body`)
+8. **Phase 7** — PR mermaid diagram (`/pr-diagram`) — per-PR flow drawn into the body below the ToC
 
 Each phase gates on the previous. If Phase 1 fails, stop.
 
@@ -192,6 +193,14 @@ Invoke `/pr-body` to aggregate all skill report verdicts and update the PR body 
 
 ---
 
+## Phase 7 — PR Mermaid Diagram
+
+Invoke `/pr-diagram` to render a per-PR flow diagram (mermaid `flowchart TD`) of the new public functions and their hand-offs, and embed it in the PR body between idempotent markers. The diagram lands just below the ToC and just above `## Summary`, so a reviewer landing on the PR sees one picture of the delta before the prose.
+
+**Not gated** — diagram-generation failure is informational, not blocking. If the skill reports `no public functions added`, skip without complaint (e.g. doc-only or refactor-only PRs).
+
+---
+
 ## Final Summary
 
 ```
@@ -213,6 +222,7 @@ Invoke `/pr-body` to aggregate all skill report verdicts and update the PR body 
 | Criteria Check | ✅ PASS / ⏭️ no AC section |
 | AzDO Diagrams Check | ✅ CURRENT / ⏭️ N/A / ⚠️ <stale sections> |
 | PR Body | ✅ Updated |
+| PR Diagram | ✅ Rendered / ⏭️ no public functions added |
 
 ### PR
 **#<number>** — <title>


### PR DESCRIPTION
## Summary

`/pr-diagram` already existed as a skill — it generates a focused mermaid `flowchart TD` of the new functions introduced by a PR and embeds it in the PR body between idempotent markers. But it wasn't wired into the `/pr-flow` pipeline, so PRs shipped via `/pr-flow` never got the reviewer-facing per-PR diagram unless the diagram skill was invoked manually.

This adds **Phase 7 — PR Mermaid Diagram** at the end of `/pr-flow`. It runs after `/pr-body` builds the ToC, so the diagram lands just below the ToC and just above `## Summary` per pr-diagram's own placement rules.

## Issue

No tracking issue — small workflow follow-up to #68 (where the user noticed the missing diagram on PR #70).

## Changes

- `.claude/commands/pr-flow.md` — added Phase 7 invocation (`/pr-diagram`); updated the Overview enumeration and the Final Summary table to include the new phase
- Phase 7 is explicitly **non-blocking** — refactor-only or doc-only PRs that add no public functions just skip it without complaint

## Test Plan

- [ ] Open a fresh Claude Code session on a branch with at least one new public function
- [ ] Run `/pr-flow`
- [ ] Confirm Phase 7 fires after Phase 6 and embeds the mermaid block between `<!-- pr-diagram:start -->` / `<!-- pr-diagram:end -->` markers
- [ ] Confirm Phase 7 is reported in the Final Summary table
- [ ] On a doc-only branch, confirm Phase 7 reports `⏭️ no public functions added` and `/pr-flow` still completes cleanly

https://claude.ai/code/session_01JrwngUJ5hNkiPfCKHvmQLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrwngUJ5hNkiPfCKHvmQLm)_