### PR TITLE
fix(azdevops): parse workitemtypes payload with -AsHashtable

### DIFF
--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -4107,7 +4107,11 @@ function Invoke-AzDevOpsWorkItemTypeShow {
     }
 
     try {
-        $parsed = $result.Json | ConvertFrom-Json
+        # -AsHashtable because the workitemtypes REST payload contains
+        # properties with empty-string names (typically in _links / extension
+        # blocks); PS 7's default ConvertFrom-Json refuses those with
+        # "provided JSON includes a property whose name is an empty string".
+        $parsed = $result.Json | ConvertFrom-Json -AsHashtable
         return [PSCustomObject]@{ Ok = $true; Error = $null; Type = $parsed }
     }
     catch {


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #75 |
| [Changes](#changes) | ✅ 1 file |
| [Test Plan](#test-plan) | ✅ 4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/77#issuecomment-4436481101) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/77#issuecomment-4436486803) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/77#issuecomment-4436485261) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/77#issuecomment-4436489104) |
| ✅ Criteria Check | ✅ PASS (3 verified, 3 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/77#issuecomment-4436496714) |
| 📚 Docs Check | ✅ CURRENT — no PR comment (no doc drift introduced by this PR) |
| 🗺️ AzDO Diagrams Check | ✅ CURRENT (for this PR's delta) — no PR comment (no fns or `az` subcommands added/removed) |
<!-- toc:end -->

## Summary
`az-Initialize-AzDevOpsSchema` was skipping every work-item type. The `az devops invoke --area wit --resource workitemtypes` payload contains properties with empty-string names (typically in `_links` / extension blocks), and PS 7's default `ConvertFrom-Json` refuses those with "The provided JSON includes a property whose name is an empty string. This is only supported using the -AsHashtable switch." `Invoke-AzDevOpsWorkItemTypeShow` caught the exception into its error envelope, so the caller printed `! skipped '<wiType>'` for every type and wrote an empty schema file.

Fix: parse with `ConvertFrom-Json -AsHashtable`. Downstream consumers in `az-Initialize-AzDevOpsSchema` and `az-Test-AzDevOpsSchema` only use dot-notation field access (`$fi.field.referenceName`, `$fi.alwaysRequired`, `$fi.allowedValues`), which works the same on hashtables in PS 7+ — no caller changes needed.

## Issue
Closes #75

## Changes
- `powcuts_by_cli/azdevops_workitems.ps1` — `Invoke-AzDevOpsWorkItemTypeShow` switches its `ConvertFrom-Json` to `-AsHashtable` with a 4-line comment naming the reason

## Test Plan
- [ ] Open a fresh PowerShell 7 terminal and run `az-Connect-AzDevOps`
- [ ] Run `az-Initialize-AzDevOpsSchema` — expect `OK '<wiType>' - N required, M optional` for each type (Epic, Feature, User Story), not `! skipped '<wiType>': parse failed: ...`
- [ ] Run `az-Test-AzDevOpsSchema` — expect `VALID` / `STALE` / `INVALID`, not `could not introspect '<wiType>'`
- [ ] Sanity-check failure path: `Invoke-AzDevOpsWorkItemTypeShow -Type 'BogusType'` returns `Ok=$false` with a non-empty `Error` (no throw)