### PR TITLE
feat(azdevops): symmetry across az-Get / az-Show / az-Find for classification + project nouns (#76)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,9 +164,12 @@ o-sfdx   o-git   o-gh   o-az   o-cci
 ├── powcuts_by_cli/                     # PowerShell counterparts
 │   ├── pow_common.ps1                  # Shared helpers
 │   ├── pow_open.ps1                    # "Open-" shortcuts
+│   ├── pow_timer.ps1                   # Pomodoro / timer helpers
 │   ├── sfdx_cli.ps1
 │   ├── git_common.ps1
-│   ├── pow_az_cli.ps1
+│   ├── azdevops_db.ps1                 # Azure DevOps `az boards` data-plane wrappers
+│   ├── azdevops_workitems.ps1          # Azure DevOps work-item shortcuts (cache, pickers, creators)
+│   ├── azdevops_projects.ps1           # Multi-project map + active-project switcher
 │   ├── pester.ps1                      # Pester test helpers
 │   └── jira_automations.ps1
 └── vscode_snippets/                    # VS Code snippets synced via VS Code Settings Sync

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ az-New-AzDevOpsUserStory `
     -NoOpen
 ```
 
-`-FeatureId 0` creates an orphan (no parent link). `-NoOpen` skips the browser launch and just echoes the new work-item URL — handy in scripts. The existing `az-create-userstory` in `pow_az_cli.ps1` is left in place for users who prefer the original flow.
+`-FeatureId 0` creates an orphan (no parent link). `-NoOpen` skips the browser launch and just echoes the new work-item URL — handy in scripts.
 
 ### Creating a new Feature
 

--- a/README.md
+++ b/README.md
@@ -241,8 +241,16 @@ az-Show-AzDevOpsBoard -Type Bug,Task          # custom-template work-item types 
 az-Show-AzDevOpsAreas                         # print the project's area-path tree (cache-first, live fallback)
 az-Show-AzDevOpsIterations                    # print the project's iteration-path tree (with start/finish dates)
 
+az-Get-AzDevOpsAreas                          # pipeable rows for the area tree (Depth / Name / Path / HasChildren)
+az-Get-AzDevOpsIterations                     # pipeable iteration rows + [datetime]? StartDate / FinishDate, e.g.:
+az-Get-AzDevOpsIterations | Where-Object { $_.StartDate -le (Get-Date) -and $_.FinishDate -ge (Get-Date) }  # the current sprint
+
 az-Find-AzDevOpsWorkItem                      # interactive drill-down: pick an Epic, then a Feature, then a Story; '.. [Go Back]' climbs a tier; '.. [Open this <Type>]' launches the browser; loops until you pick 'EXIT' or hit Esc
 az-Find-AzDevOpsWorkItem -IncludeClosed       # include Closed/Removed items in the drill-down grids
+az-Find-AzDevOpsArea                          # pick an area path from the tree; emits the picked Path on the pipeline
+az-Find-AzDevOpsIteration                     # pick an iteration; grid shows StartDate / FinishDate columns; emits Path
+az-Find-AzDevOpsProject                       # pick from $global:AzDevOpsProjectMap (Active / Name / Project / Org)
+az-Find-AzDevOpsProject -Use                  # ... and switch to it (calls az-Use-AzDevOpsProject on the pick)
 ```
 
 If the cache is older than 6 hours, `az-Get-AzDevOpsAssigned`, `az-Get-AzDevOpsMentions`, `az-Show-AzDevOpsTree`, `az-Show-AzDevOpsBoard`, `az-Show-AzDevOpsAreas`, `az-Show-AzDevOpsIterations`, and `az-Find-AzDevOpsWorkItem` each print a one-line `WARNING stale (last sync: ...)` notice above their output and still render the cached data.
@@ -252,6 +260,23 @@ If the cache is older than 6 hours, `az-Get-AzDevOpsAssigned`, `az-Get-AzDevOpsM
 Every list and picker (`az-Get-AzDevOpsAssigned`, `az-Get-AzDevOpsMentions`, `az-Get-AzDevOpsSchema`, `az-Get-AzDevOpsCacheStatus`, `az-Show-AzDevOpsTree`, `az-Show-AzDevOpsBoard`, `az-Show-AzDevOpsAreas`, `az-Show-AzDevOpsIterations`, `az-Find-AzDevOpsWorkItem`, plus the parent-Feature / iteration / area pickers in `az-New-AzDevOpsUserStory`) renders through `Out-ConsoleGridView` — a sortable, filterable, click-to-select TUI grid that runs in your terminal on Windows, macOS, and Linux. Use the arrow keys to navigate, `Space` to select rows, `Enter` to confirm, `Esc` to cancel. Selected rows from the listing functions are emitted to the pipeline, so e.g. `az-Get-AzDevOpsAssigned | ForEach-Object { az-Open-AzDevOpsAssigned $_.Id }` opens every row you ticked. The grid ships in a separate module — install once with `Install-Module Microsoft.PowerShell.ConsoleGuiTools -Scope CurrentUser`. If the module isn't installed, every command falls back to the existing `Format-Table` / numbered-menu output — except `az-Find-AzDevOpsWorkItem`, which is grid-only by design and prints the install hint above instead of running.
 
 `az-Sync-AzDevOpsCache` populates two more cache files alongside the existing `assigned.json` / `mentions.json` / `hierarchy.json`: `iterations.json` and `areas.json`. The new-user-story command below uses these for instant iteration / area-path pickers; if you've upgraded but haven't re-synced yet, the picker fetches them live with a one-line "(run az-Sync-AzDevOpsCache to make this instant)" notice.
+
+#### Verb coverage at a glance
+
+Tab-tab on `az-Get-`, `az-Show-`, or `az-Find-` to discover commands. The matrix is also kept inline at the top of `powcuts_by_cli/azdevops_workitems.ps1`.
+
+| Noun                  | `az-Get-`             | `az-Show-`         | `az-Find-`  |
+|-----------------------|-----------------------|--------------------|-------------|
+| Project               | `Projects`            | `Project`          | `Project`   |
+| Work Item (hierarchy) | —                     | `Tree`, `Board`    | `WorkItem`  |
+| Work Item (assigned)  | `Assigned` (pickable) | —                  | —           |
+| Work Item (mentions)  | `Mentions` (pickable) | —                  | —           |
+| Area                  | `Areas`               | `Areas`            | `Area`      |
+| Iteration             | `Iterations`          | `Iterations`       | `Iteration` |
+| Cache                 | `CacheStatus`         | —                  | —           |
+| Schema                | `Schema`              | —                  | —           |
+
+`az-Get-*` returns pipeable rows (`[PSCustomObject]`); `az-Show-*` writes a human-readable view; `az-Find-*` is an interactive picker over `Out-ConsoleGridView` that emits the picked value on the pipeline. `Assigned` / `Mentions` already open a grid via `Show-AzDevOpsRows -PassThru` so they double as pickers; that's why there is no separate `Show-` or `Find-` for them.
 
 ### Creating a new User Story
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -42,7 +42,12 @@ flowchart LR
         Board["az-Show-AzDevOpsBoard"]
         ShowAreas["az-Show-AzDevOpsAreas"]
         ShowIters["az-Show-AzDevOpsIterations"]
+        GetAreas["az-Get-AzDevOpsAreas"]
+        GetIters["az-Get-AzDevOpsIterations"]
         Find["az-Find-AzDevOpsWorkItem"]
+        FindArea["az-Find-AzDevOpsArea"]
+        FindIter["az-Find-AzDevOpsIteration"]
+        FindProj["az-Find-AzDevOpsProject"]
         NewStory["az-New-AzDevOpsUserStory"]
         NewFeat["az-New-AzDevOpsFeature"]
         NewStoryBatch["az-New-AzDevOpsFeatureStories"]
@@ -95,6 +100,15 @@ flowchart LR
     ShowAreas -.live fallback.-> AzBoards
     ShowIters --> IterJson
     ShowIters -.live fallback.-> AzBoards
+    GetAreas --> AreasJson
+    GetAreas -.live fallback.-> AzBoards
+    GetIters --> IterJson
+    GetIters -.live fallback.-> AzBoards
+    FindArea --> AreasJson
+    FindArea -.live fallback.-> AzBoards
+    FindIter --> IterJson
+    FindIter -.live fallback.-> AzBoards
+    FindProj -.reads $global:AzDevOpsProjectMap.-> Public
 
     NewStory --> HierJson
     NewStory --> IterJson
@@ -542,6 +556,10 @@ graph LR
     Board(["az-Show-AzDevOpsBoard"]):::pub
     ShowAreas(["az-Show-AzDevOpsAreas"]):::pub
     ShowIters(["az-Show-AzDevOpsIterations"]):::pub
+    GetAreas(["az-Get-AzDevOpsAreas"]):::pub
+    GetIters(["az-Get-AzDevOpsIterations"]):::pub
+    FindArea(["az-Find-AzDevOpsArea"]):::pub
+    FindIter(["az-Find-AzDevOpsIteration"]):::pub
     NewS(["az-New-AzDevOpsUserStory"]):::pub
     NewF(["az-New-AzDevOpsFeature"]):::pub
     NewSB(["az-New-AzDevOpsFeatureStories"]):::pub
@@ -552,6 +570,7 @@ graph LR
     UseProj(["az-Use-AzDevOpsProject"]):::pub
     ShowProj(["az-Show-AzDevOpsProject"]):::pub
     GetProjs(["az-Get-AzDevOpsProjects"]):::pub
+    FindProj(["az-Find-AzDevOpsProject"]):::pub
 
     %% Step helpers
     C1[az-Confirm-AzDevOpsCli]:::priv
@@ -647,6 +666,7 @@ graph LR
 
     %% Grid presentation helpers (Out-ConsoleGridView)
     GridAvail[Test-AzDevOpsGridAvailable]:::priv
+    GridUnavail[Write-AzDevOpsGridUnavailable]:::priv
     ShowRows[Show-AzDevOpsRows]:::priv
     GridPick[Read-AzDevOpsGridPick]:::priv
     StatusRows[Get-AzDevOpsCacheStatusRows]:::priv
@@ -814,17 +834,44 @@ graph LR
     Board --> ShowRows
 
     %% Classification tree views (cache-first, live fallback)
-    ClsRows[Get-AzDevOpsClassificationRows]:::priv
+    ClsRows[ConvertFrom-AzDevOpsClassificationTree]:::priv
     ClsNode[Format-AzDevOpsClassificationNode]:::priv
     ShowCls[Show-AzDevOpsClassification]:::priv
+    ReadRows[Read-AzDevOpsClassificationRows]:::priv
+    DispRows[ConvertTo-AzDevOpsClassificationDisplayRows]:::priv
+    FmtDate[Format-AzDevOpsClassificationDate]:::priv
 
     ShowAreas --> ShowCls
     ShowIters --> ShowCls
-    ShowCls --> ReadCls
-    ShowCls -.cache miss.-> InvCls
-    ShowCls --> Stale
-    ShowCls --> ClsRows --> ShowRows
+    ShowCls --> ReadRows
+    ShowCls --> DispRows --> ShowRows
     ShowCls --> ClsNode --> Indent
+    ReadRows --> ReadCls
+    ReadRows -.cache miss.-> InvCls
+    ReadRows --> Stale
+    ReadRows --> ClsRows
+    DispRows --> FmtDate
+
+    %% Pipeable rows + interactive pickers for classification trees
+    GetAreas --> ReadRows
+    GetIters --> ReadRows
+    FindArea --> GridAvail
+    FindArea -.no grid.-> GridUnavail
+    FindArea --> ReadRows
+    FindArea --> PCls
+    FindIter --> GridAvail
+    FindIter -.no grid.-> GridUnavail
+    FindIter --> ReadRows
+    FindIter --> DispRows
+    FindIter --> GridPick
+
+    %% Interactive picker for projects (azdevops_projects.ps1)
+    FindProj --> GridAvail
+    FindProj -.no grid.-> GridUnavail
+    FindProj --> GetProjs
+    FindProj --> GridPick
+    FindProj -.opt-in -Use.-> UseProj
+    Find -.no grid.-> GridUnavail
 
     Find --> ReadH
     Find --> Stale

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -3,9 +3,9 @@
 #
 # Every `az boards ...` invocation in the bashcuts codebase routes through one
 # of the wrappers in this file so higher-level functions in azdevops_workitems
-# .ps1 / pow_az_cli.ps1 stay decoupled from `az` argument shapes, JSON
-# deserialization, and stderr handling. Future caching, retry, or alternative
-# transport changes are a one-file edit.
+# .ps1 stay decoupled from `az` argument shapes, JSON deserialization, and
+# stderr handling. Future caching, retry, or alternative transport changes are
+# a one-file edit.
 #
 # Conventions:
 #   - Every wrapper returns the canonical { Json, Error, ExitCode } envelope

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -274,7 +274,7 @@ function Add-AzDevOpsWorkItemRelation {
         [Parameter(Mandatory)] [string] $RelationType
     )
 
-    $result = Invoke-AzDevOpsAzJson -SkipProjectFlag $true -ArgList @(
+    $result = Invoke-AzDevOpsAzJson -SkipProjectFlag -ArgList @(
         'boards', 'work-item', 'relation', 'add',
         '--id',            "$Id",
         '--relation-type', $RelationType,

--- a/powcuts_by_cli/azdevops_projects.ps1
+++ b/powcuts_by_cli/azdevops_projects.ps1
@@ -55,6 +55,8 @@
 #   az-Show-AzDevOpsProject  - print the active project + resolved env vars
 #   az-Get-AzDevOpsProjects  - list every project name in the map, marking
 #                              the active one
+#   az-Find-AzDevOpsProject  - Out-ConsoleGridView picker over the map; emits
+#                              the picked name (-Use also switches projects)
 #
 # Type-key normalization: lookups uppercase the type and replace spaces with
 # underscores, so `'User Story'`, `'user story'`, and `'USER_STORY'` all hit
@@ -518,6 +520,49 @@ function az-Use-AzDevOpsProject {
         Write-Host "  AZ_AREA       = $env:AZ_AREA"
         Write-Host "  AZ_ITERATION  = $env:AZ_ITERATION"
     }
+}
+
+
+function az-Find-AzDevOpsProject {
+    # Out-ConsoleGridView picker over $global:AzDevOpsProjectMap. Grid columns
+    # match the az-Get-AzDevOpsProjects row shape (Active / Name / Project /
+    # Org) so users see the same surface in both views. Emits the picked
+    # project name on the pipeline; -Use also calls az-Use-AzDevOpsProject so
+    # one Find call switches and prints the active-project summary.
+    [CmdletBinding()]
+    param(
+        [switch] $Use
+    )
+
+    if (-not (Test-AzDevOpsProjectMapDefined)) {
+        Write-Host "(`$global:AzDevOpsProjectMap is not defined - see azdevops_projects.ps1 header for shape)" -ForegroundColor Yellow
+        return
+    }
+
+    if (-not (Test-AzDevOpsGridAvailable)) {
+        Write-AzDevOpsGridUnavailable -CommandName 'az-Find-AzDevOpsProject'
+        return
+    }
+
+    $rows = az-Get-AzDevOpsProjects
+    if ($null -eq $rows -or @($rows).Count -eq 0) {
+        Write-Host '(no projects defined in $global:AzDevOpsProjectMap)' -ForegroundColor Yellow
+        return
+    }
+
+    $picked = Read-AzDevOpsGridPick -Rows $rows -Title 'Pick Azure DevOps project'
+    if ($null -eq $picked) {
+        return $null
+    }
+
+    $pickedName = [string]$picked.Name
+
+    if ($Use) {
+        az-Use-AzDevOpsProject -Name $pickedName
+        return
+    }
+
+    return $pickedName
 }
 
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -50,6 +50,35 @@
 #
 # First-run:
 #   PS> az-Connect-AzDevOps
+#
+# ----------------------------------------------------------------------------
+# Verb coverage matrix (az-Get- / az-Show- / az-Find- across nouns)
+#
+# Verb contracts:
+#   az-Get-*   - returns [PSCustomObject] rows for the pipeline; may also open
+#                Show-AzDevOpsRows -PassThru so the same call doubles as an
+#                interactive grid (Assigned / Mentions).
+#   az-Show-*  - writes a human-readable view (tree / board / table); no
+#                pipeline data.
+#   az-Find-*  - interactive drill-down via Out-ConsoleGridView; emits the
+#                picked value(s) on the pipeline. Prints an install hint and
+#                returns when Microsoft.PowerShell.ConsoleGuiTools is missing.
+#
+# Coverage:
+#                          Get-                  Show-                Find-
+#   Project                Projects              Project              Project
+#   Work Item (hierarchy)  --                    Tree, Board          WorkItem
+#   Work Item (assigned)   Assigned [pickable]   --                   --
+#   Work Item (mentions)   Mentions [pickable]   --                   --
+#   Area                   Areas                 Areas                Area
+#   Iteration              Iterations            Iterations           Iteration
+#   Cache                  CacheStatus           --                   --
+#   Schema                 Schema                --                   --
+#
+# Deliberately-empty cells:
+#   Assigned / Mentions Show-: az-Get-* already grid-renders; Show- would dupe.
+#   Cache / Schema Show- / Find-: no tree to drill, no pick semantics.
+#   Hierarchy Get-: Tree and Board cover the listing surface; Find- emits IDs.
 # ============================================================================
 
 
@@ -2433,20 +2462,27 @@ function Get-AzDevOpsClassificationPaths {
 # available, falls back to an indented text tree otherwise.
 # ---------------------------------------------------------------------------
 
-function Get-AzDevOpsClassificationRows {
+function ConvertFrom-AzDevOpsClassificationTree {
     # Walks the classification tree (depth-first, children in declaration
     # order) and emits one PSCustomObject per node. Skips the synthetic root
     # node (whose path is the bare '\<Project>\<Kind>' shell with no work-
-    # item-path equivalent) so the grid only shows pickable entries. For
-    # iterations, surfaces the startDate / finishDate attributes as ISO
-    # yyyy-MM-dd strings; areas omit those columns.
+    # item-path equivalent) so consumers only see pickable entries.
+    #
+    # Row shape:
+    #   Areas:      Depth, Name, Path, HasChildren
+    #   Iterations: Depth, Name, Path, HasChildren, StartDate, FinishDate
+    #
+    # StartDate / FinishDate are [datetime]? so pipeline callers can use
+    # `Where-Object { $_.StartDate -ge (Get-Date) }`. Display callers
+    # (az-Show-AzDevOps*) format them to ISO yyyy-MM-dd strings just before
+    # rendering.
     param(
-        [Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind,
-        [Parameter(Mandatory)] $Root
+        [Parameter(Mandatory)] $Tree,
+        [Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind
     )
 
     $rows = New-Object System.Collections.Generic.List[PSCustomObject]
-    if ($null -eq $Root) {
+    if ($null -eq $Tree) {
         $empty = , @($rows)
         return $empty
     }
@@ -2458,40 +2494,50 @@ function Get-AzDevOpsClassificationRows {
 
         # Only emit the synthetic root's children onward - the root itself
         # is the bare project/kind shell that ConvertTo-AzDevOpsWorkItemPath
-        # also filters out (returns $null for it).
+        # filters out (returns $null for it). Emit Path in work-item-path
+        # form ('MyProject\TeamA\Backend') so pipeline callers can drop it
+        # straight into WIQL or `az boards work-item create`.
         if ($Depth -gt 0) {
-            $row = if ($Kind -eq 'Iteration') {
-                $startIso = if ($Node.attributes -and $Node.attributes.startDate) {
-                    ($Node.attributes.startDate -as [datetime]).ToString('yyyy-MM-dd')
+            $workItemPath = ConvertTo-AzDevOpsWorkItemPath -ApiPath $Node.path -Kind $Kind
+
+            if ($workItemPath) {
+                $hasChildren = [bool]($Node.children -and @($Node.children).Count -gt 0)
+
+                $row = if ($Kind -eq 'Iteration') {
+                    $startDate = if ($Node.attributes -and $Node.attributes.startDate) {
+                        $Node.attributes.startDate -as [datetime]
+                    }
+                    else {
+                        $null
+                    }
+
+                    $finishDate = if ($Node.attributes -and $Node.attributes.finishDate) {
+                        $Node.attributes.finishDate -as [datetime]
+                    }
+                    else {
+                        $null
+                    }
+
+                    [PSCustomObject]@{
+                        Depth       = $Depth
+                        Name        = $Node.name
+                        Path        = $workItemPath
+                        HasChildren = $hasChildren
+                        StartDate   = $startDate
+                        FinishDate  = $finishDate
+                    }
                 }
                 else {
-                    ''
+                    [PSCustomObject]@{
+                        Depth       = $Depth
+                        Name        = $Node.name
+                        Path        = $workItemPath
+                        HasChildren = $hasChildren
+                    }
                 }
 
-                $finishIso = if ($Node.attributes -and $Node.attributes.finishDate) {
-                    ($Node.attributes.finishDate -as [datetime]).ToString('yyyy-MM-dd')
-                }
-                else {
-                    ''
-                }
-
-                [PSCustomObject]@{
-                    Depth      = $Depth
-                    Name       = $Node.name
-                    Path       = $Node.path
-                    StartDate  = $startIso
-                    FinishDate = $finishIso
-                }
+                $rows.Add($row)
             }
-            else {
-                [PSCustomObject]@{
-                    Depth = $Depth
-                    Name  = $Node.name
-                    Path  = $Node.path
-                }
-            }
-
-            $rows.Add($row)
         }
 
         if ($Node.children) {
@@ -2501,9 +2547,62 @@ function Get-AzDevOpsClassificationRows {
         }
     }
 
-    & $walk $Root 0
+    & $walk $Tree 0
 
     $result = , @($rows)
+    return $result
+}
+
+
+function Format-AzDevOpsClassificationDate {
+    # Renders a [datetime]? as ISO yyyy-MM-dd, or '' when $null. Single
+    # source of truth for the date formatting used by the Show- display
+    # projection and Format-AzDevOpsClassificationNode's text fallback.
+    param([datetime] $Date)
+
+    if ($null -eq $Date) {
+        return ''
+    }
+
+    $iso = $Date.ToString('yyyy-MM-dd')
+    return $iso
+}
+
+
+function ConvertTo-AzDevOpsClassificationDisplayRows {
+    # Projects the typed rows from ConvertFrom-AzDevOpsClassificationTree
+    # into the display-shaped rows az-Show-AzDevOpsAreas /
+    # az-Show-AzDevOpsIterations render in the grid: dates become ISO
+    # strings, HasChildren is dropped (display noise).
+    param(
+        [Parameter(Mandatory)] $Rows,
+        [Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind
+    )
+
+    if ($null -eq $Rows -or @($Rows).Count -eq 0) {
+        $empty = , @()
+        return $empty
+    }
+
+    $displayRows = if ($Kind -eq 'Iteration') {
+        @($Rows | ForEach-Object {
+            $startIso  = Format-AzDevOpsClassificationDate -Date $_.StartDate
+            $finishIso = Format-AzDevOpsClassificationDate -Date $_.FinishDate
+
+            [PSCustomObject]@{
+                Depth      = $_.Depth
+                Name       = $_.Name
+                Path       = $_.Path
+                StartDate  = $startIso
+                FinishDate = $finishIso
+            }
+        })
+    }
+    else {
+        @($Rows | Select-Object Depth, Name, Path)
+    }
+
+    $result = , $displayRows
     return $result
 }
 
@@ -2511,8 +2610,9 @@ function Get-AzDevOpsClassificationRows {
 function Format-AzDevOpsClassificationNode {
     # Text-fallback per-node line. '<indent><name>' for areas; for iterations
     # appends '<tab><start> -> <finish>' when both dates are present (omits
-    # the date suffix when either is blank, matching the Get- helper). The
-    # tab separator keeps the dates copy-paste-able into a spreadsheet.
+    # the date suffix when either is blank). The tab separator keeps the
+    # dates copy-paste-able into a spreadsheet. Accepts the typed rows from
+    # ConvertFrom-AzDevOpsClassificationTree (dates as [datetime]?).
     param(
         [Parameter(Mandatory)] [PSCustomObject] $Row,
         [Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind
@@ -2523,32 +2623,36 @@ function Format-AzDevOpsClassificationNode {
     $line = "$indent$($Row.Name)"
 
     if ($Kind -eq 'Iteration' -and $Row.StartDate -and $Row.FinishDate) {
-        $line = "$line`t$($Row.StartDate) $arrowGlyph $($Row.FinishDate)"
+        $startIso  = Format-AzDevOpsClassificationDate -Date $Row.StartDate
+        $finishIso = Format-AzDevOpsClassificationDate -Date $Row.FinishDate
+        $line = "$line`t$startIso $arrowGlyph $finishIso"
     }
 
     return $line
 }
 
 
-function Show-AzDevOpsClassification {
-    # Orchestrator for az-Show-AzDevOpsAreas / az-Show-AzDevOpsIterations.
-    # Cache-first with live fallback (gated by Assert-AzDevOpsAuthOrAbort so
-    # the live `az` call doesn't fire on a stale env). Emits to
-    # Out-ConsoleGridView when available, falls back to an indented text tree
-    # via Format-AzDevOpsClassificationNode + Write-Output. Mirrors the
-    # az-Show-AzDevOpsTree post-#36 shape so the Show- family stays uniform.
-    param([Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind)
+function Read-AzDevOpsClassificationRows {
+    # Cache-first + live-fallback read + flatten. Emits the stale banner and
+    # the live-fetch notice as Write-Host side effects (metadata, not data).
+    # Returns the typed rows from ConvertFrom-AzDevOpsClassificationTree, or
+    # $null when neither the cache nor a live fetch yields a tree (e.g. the
+    # user cancels the auth gate). Shared by az-Show-AzDevOps* /
+    # az-Get-AzDevOps* / az-Find-AzDevOps* for the classification trees.
+    param(
+        [Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind,
+        [Parameter(Mandatory)] [string] $CommandName
+    )
 
     $azKind = $Kind.ToLower()
-    $publicCommand = "az-Show-AzDevOps$($Kind)s"
     $kindLabelLow = "${azKind}s"
 
     $tree = Read-AzDevOpsClassificationCache -Kind $Kind
     $cameFromCache = $true
 
     if ($null -eq $tree) {
-        if (-not (Assert-AzDevOpsAuthOrAbort -CommandName $publicCommand)) {
-            return
+        if (-not (Assert-AzDevOpsAuthOrAbort -CommandName $CommandName)) {
+            return $null
         }
 
         Write-Host "(fetching $kindLabelLow live - run az-Sync-AzDevOpsCache to make this instant)" -ForegroundColor Yellow
@@ -2557,22 +2661,45 @@ function Show-AzDevOpsClassification {
     }
 
     if ($null -eq $tree) {
-        return
+        return $null
     }
 
     if ($cameFromCache) {
         Write-AzDevOpsStaleBanner
     }
 
-    $rows = Get-AzDevOpsClassificationRows -Kind $Kind -Root $tree
+    $rows = ConvertFrom-AzDevOpsClassificationTree -Tree $tree -Kind $Kind
+    return $rows
+}
+
+
+function Show-AzDevOpsClassification {
+    # Orchestrator for az-Show-AzDevOpsAreas / az-Show-AzDevOpsIterations.
+    # Reads + flattens via Read-AzDevOpsClassificationRows, projects typed
+    # rows to display rows, then renders to Out-ConsoleGridView when
+    # available or to an indented text tree via Format-AzDevOpsClassificationNode
+    # otherwise. Mirrors the az-Show-AzDevOpsTree post-#36 shape so the Show-
+    # family stays uniform.
+    param([Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind)
+
+    $azKind = $Kind.ToLower()
+    $kindLabelLow = "${azKind}s"
+    $publicCommand = "az-Show-AzDevOps$($Kind)s"
+
+    $rows = Read-AzDevOpsClassificationRows -Kind $Kind -CommandName $publicCommand
+    if ($null -eq $rows) {
+        return
+    }
+
     if (@($rows).Count -eq 0) {
         Write-Host "(no $kindLabelLow defined)" -ForegroundColor Yellow
         return
     }
 
     if (Test-AzDevOpsGridAvailable) {
+        $displayRows = ConvertTo-AzDevOpsClassificationDisplayRows -Rows $rows -Kind $Kind
         $title = "Azure DevOps $kindLabelLow - $(@($rows).Count) nodes"
-        Show-AzDevOpsRows -Rows $rows -Title $title
+        Show-AzDevOpsRows -Rows $displayRows -Title $title
         return
     }
 
@@ -2595,6 +2722,122 @@ function az-Show-AzDevOpsIterations {
     param()
 
     Show-AzDevOpsClassification -Kind 'Iteration'
+}
+
+
+# ---------------------------------------------------------------------------
+# Classification rows for pipeline consumers
+#
+# Public functions:
+#   az-Get-AzDevOpsAreas       - pipeable rows for the area-path tree
+#                                (Depth / Name / Path / HasChildren)
+#   az-Get-AzDevOpsIterations  - pipeable rows for the iteration tree
+#                                (adds StartDate / FinishDate as [datetime]?)
+#
+# Both wrap Read-AzDevOpsClassificationRows so the cache-first / live-fallback
+# behavior matches az-Show-AzDevOps*. Path is the work-item-path form
+# ('MyProject\TeamA\Backend') so callers can pipe straight into WIQL or
+# `az boards work-item create --area-path ...`.
+# ---------------------------------------------------------------------------
+
+function az-Get-AzDevOpsAreas {
+    [CmdletBinding()]
+    param()
+
+    $rows = Read-AzDevOpsClassificationRows -Kind 'Area' -CommandName 'az-Get-AzDevOpsAreas'
+    return $rows
+}
+
+
+function az-Get-AzDevOpsIterations {
+    [CmdletBinding()]
+    param()
+
+    $rows = Read-AzDevOpsClassificationRows -Kind 'Iteration' -CommandName 'az-Get-AzDevOpsIterations'
+    return $rows
+}
+
+
+# ---------------------------------------------------------------------------
+# Classification pickers (interactive drill-down for the classification trees)
+#
+# Public functions:
+#   az-Find-AzDevOpsArea       - Out-ConsoleGridView picker over the area tree;
+#                                emits the picked Path (work-item-path form)
+#                                or $null when the user cancels.
+#   az-Find-AzDevOpsIteration  - same shape, plus StartDate / FinishDate grid
+#                                columns so the user can pick by sprint dates.
+#
+# Both require Microsoft.PowerShell.ConsoleGuiTools - they print the install
+# hint and return when the cmdlet is missing. Neither function has side
+# effects (does not set $env:AZ_AREA / $env:AZ_ITERATION); callers that want
+# that behavior can pipe the result into Set-Item env:AZ_AREA.
+# ---------------------------------------------------------------------------
+
+$script:AzDevOpsConsoleGuiToolsInstallHint = 'Install with: Install-Module Microsoft.PowerShell.ConsoleGuiTools -Scope CurrentUser'
+
+
+function Write-AzDevOpsGridUnavailable {
+    # Single source of truth for the "Out-ConsoleGridView is required for X"
+    # message shape so every az-Find-AzDevOps* uses the same wording.
+    param([Parameter(Mandatory)] [string] $CommandName)
+
+    Write-Host "Out-ConsoleGridView is required for $CommandName." -ForegroundColor Yellow
+    Write-Host "  $script:AzDevOpsConsoleGuiToolsInstallHint" -ForegroundColor Yellow
+}
+
+
+function az-Find-AzDevOpsArea {
+    [CmdletBinding()]
+    param()
+
+    if (-not (Test-AzDevOpsGridAvailable)) {
+        Write-AzDevOpsGridUnavailable -CommandName 'az-Find-AzDevOpsArea'
+        return
+    }
+
+    $rows = Read-AzDevOpsClassificationRows -Kind 'Area' -CommandName 'az-Find-AzDevOpsArea'
+    if ($null -eq $rows -or @($rows).Count -eq 0) {
+        Write-Host '(no areas available)' -ForegroundColor Yellow
+        return
+    }
+
+    $paths = @($rows | ForEach-Object { $_.Path } | Where-Object { $_ })
+    if ($paths.Count -eq 0) {
+        Write-Host '(no pickable area paths)' -ForegroundColor Yellow
+        return
+    }
+
+    $picked = Read-AzDevOpsClassificationPick -Kind 'Area' -Paths $paths
+    return $picked
+}
+
+
+function az-Find-AzDevOpsIteration {
+    [CmdletBinding()]
+    param()
+
+    if (-not (Test-AzDevOpsGridAvailable)) {
+        Write-AzDevOpsGridUnavailable -CommandName 'az-Find-AzDevOpsIteration'
+        return
+    }
+
+    $rows = Read-AzDevOpsClassificationRows -Kind 'Iteration' -CommandName 'az-Find-AzDevOpsIteration'
+    if ($null -eq $rows -or @($rows).Count -eq 0) {
+        Write-Host '(no iterations available)' -ForegroundColor Yellow
+        return
+    }
+
+    $displayRows = ConvertTo-AzDevOpsClassificationDisplayRows -Rows $rows -Kind 'Iteration'
+    $pickRows = @($displayRows | Select-Object Path, StartDate, FinishDate)
+
+    $picked = Read-AzDevOpsGridPick -Rows $pickRows -Title 'Pick iteration'
+    if ($null -eq $picked) {
+        return $null
+    }
+
+    $pickedPath = [string]$picked.Path
+    return $pickedPath
 }
 
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -2311,8 +2311,7 @@ function az-Find-AzDevOpsWorkItem {
 #                              story in the browser.
 #
 # All prompts are skippable via parameters so the function works
-# non-interactively in scripts. The existing `az-create-userstory` in
-# pow_az_cli.ps1 is left untouched (parallel coexistence).
+# non-interactively in scripts.
 # ---------------------------------------------------------------------------
 
 function Read-AzDevOpsClassificationCache {

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -2163,8 +2163,7 @@ function az-Find-AzDevOpsWorkItem {
     )
 
     if (-not (Test-AzDevOpsGridAvailable)) {
-        Write-Host "Out-ConsoleGridView is required for az-Find-AzDevOpsWorkItem." -ForegroundColor Yellow
-        Write-Host "  Install with: Install-Module Microsoft.PowerShell.ConsoleGuiTools -Scope CurrentUser" -ForegroundColor Yellow
+        Write-AzDevOpsGridUnavailable -CommandName 'az-Find-AzDevOpsWorkItem'
         return
     }
 
@@ -2808,7 +2807,15 @@ function az-Find-AzDevOpsArea {
         return
     }
 
+    # Read-AzDevOpsClassificationPick returns its $Default param on cancel,
+    # which falls back to '' (empty string) when no default is supplied here.
+    # Normalize that to $null so this function and az-Find-AzDevOpsIteration
+    # share the same "cancelled" signal on the pipeline.
     $picked = Read-AzDevOpsClassificationPick -Kind 'Area' -Paths $paths
+    if (-not $picked) {
+        return $null
+    }
+
     return $picked
 }
 

--- a/powcuts_by_cli/pow_open.ps1
+++ b/powcuts_by_cli/pow_open.ps1
@@ -17,10 +17,6 @@ function o-pow-common {
 	Start-Process "$path_to_bashcuts\powcuts_by_cli\pow_common.ps1"
 }
 
-function o-pow-az-cli {
-	Start-Process "$path_to_bashcuts\powcuts_by_cli\pow_az_cli.ps1"
-}
-
 function o-pester {
 	Start-Process "$path_to_bashcuts\powcuts_by_cli\pester.ps1"
 }


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #76 |
| [Changes](#changes) | ✅ 7 files |
| [Checklist](#checklist) | 8/9 |
| [Test Plan](#test-plan) | ✅ 7 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4436637415) |
| 💠 PowerShell Engineer Review | ❌ REQUEST CHANGES → fixed in `d5ba7dc` — [View](#issuecomment-4436663816) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4436659210) |
| 🧼 Clean-Code Engineer Review | ❌ REQUEST CHANGES → fixed in `d5ba7dc` — [View](#issuecomment-4436655895) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4444551561) |
| 📐 AzDO Diagrams Check | ✅ SYNCED — [View](#issuecomment-4444698284) |
<!-- toc:end -->
<!-- pr-diagram:start -->
## How it works

Five new public entry points sit on top of one shared orchestrator: `Read-AzDevOpsClassificationRows` resolves cache-first / live-fallback once, then fans out to the typed-row flattener for `Get-` consumers and the display-row projection for `Find-` pickers. The project picker reuses the existing `az-Get-AzDevOpsProjects` row shape and only invokes `az-Use-AzDevOpsProject` when `-Use` is passed.

```mermaid
flowchart TD
    GetAreas([az-Get-AzDevOpsAreas]):::pub
    GetIters([az-Get-AzDevOpsIterations]):::pub
    FindArea([az-Find-AzDevOpsArea]):::pub
    FindIter([az-Find-AzDevOpsIteration]):::pub
    FindProj([az-Find-AzDevOpsProject]):::pub

    ReadRows[Read-AzDevOpsClassificationRows<br/>cache-first + live fallback]:::priv
    ClsFlatten[ConvertFrom-AzDevOpsClassificationTree<br/>typed dates / HasChildren / WI-path]:::priv
    DispRows[ConvertTo-AzDevOpsClassificationDisplayRows]:::priv
    FmtDate[Format-AzDevOpsClassificationDate]:::priv
    GridUnavail[Write-AzDevOpsGridUnavailable<br/>shared install hint]:::priv

    GridAvail{Test-AzDevOpsGridAvailable}
    GridPick[Read-AzDevOpsGridPick]
    PCls[Read-AzDevOpsClassificationPick]
    GetProjs[az-Get-AzDevOpsProjects]
    UseProj([az-Use-AzDevOpsProject]):::pub

    AzBoards["az boards (live fallback)"]:::io
    ProjMap[("$global:AzDevOpsProjectMap")]:::io

    GetAreas --> ReadRows
    GetIters --> ReadRows
    ReadRows -.cache miss.-> AzBoards
    ReadRows --> ClsFlatten --> FmtDate

    FindArea --> GridAvail
    FindIter --> GridAvail
    GridAvail -- no --> GridUnavail
    FindArea -- ok --> ReadRows
    FindArea -- ok --> PCls
    FindIter -- ok --> ReadRows
    FindIter -- ok --> DispRows --> GridPick
    DispRows --> FmtDate

    FindProj --> GridAvail
    FindProj -- ok --> GetProjs
    GetProjs --> ProjMap
    FindProj --> GridPick
    FindProj -.opt-in -Use.-> UseProj

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Adds `az-Get-AzDevOpsAreas`, `az-Get-AzDevOpsIterations`, `az-Find-AzDevOpsArea`, `az-Find-AzDevOpsIteration`, `az-Find-AzDevOpsProject` so every classification tree has pipeable rows + an interactive picker alongside the existing `Show-` viewer. Renames `Get-AzDevOpsClassificationRows` → `ConvertFrom-AzDevOpsClassificationTree` with typed dates (`[datetime]?`), `HasChildren`, and work-item-path `Path` so `Get-` consumers can pipe straight into WIQL / `az boards`. Extracts `Read-AzDevOpsClassificationRows` as the shared cache-first + live-fallback orchestrator so `Show-` / `Get-` / `Find-` all read through one path. Documents the full verb matrix in the file header and the README.

## Issue

Closes #76

## Changes

| File | Δ | Purpose |
|---|---:|---|
| `powcuts_by_cli/azdevops_workitems.ps1` | +361 | Core feature: 5 new public functions, 4 new private helpers, 1 rename, refactored classification cluster |
| `powcuts_by_cli/azdevops_projects.ps1` | +45 | New `az-Find-AzDevOpsProject` picker over `$global:AzDevOpsProjectMap` with `-Use` switch |
| `docs/azure-devops-diagrams.md` | +57 | Sync Diagram 1 + Diagram 9 with new public/private nodes and edges |
| `README.md` | +27 | Add verb-coverage matrix to the Azure DevOps section |
| `powcuts_by_cli/azdevops_db.ps1` | ±8 | Refresh file-header comment (drop deleted `pow_az_cli.ps1` mention) |
| `CLAUDE.md` | ±5 | Refresh project tree |
| `powcuts_by_cli/pow_open.ps1` | -4 | Drop `o-pow-az-cli` opener for the deleted file |

## Checklist

- [x] Bash files parse cleanly (`bash -n bashcuts_by_cli/.sfdxcli_bashcuts`)
- [x] PowerShell files parse cleanly (visual review + bracket-balance smoke check; `pwsh` not on PATH in this env)
- [x] Sourcing wire-up unchanged (no new files added; all changes to existing `azdevops_*.ps1`)
- [x] README updated with verb-coverage matrix
- [x] CLAUDE.md project tree refreshed
- [x] AzDO diagrams in sync with new functions
- [x] Quad code review run; HIGH/MEDIUM findings addressed in `d5ba7dc`
- [x] Criteria check passed (11 ✅ / 2 ⚠️ partial / 5 🔍 manual)
- [ ] Manual terminal verification (see Test Plan)

## Test Plan

In a fresh PowerShell terminal after re-sourcing `$profile`:

- [ ] `az-Get-AzDevOps` + tab-tab → lists `Areas`, `Iterations` alongside existing entries
- [ ] `az-Find-AzDevOps` + tab-tab → lists `Area`, `Iteration`, `Project`, `WorkItem`
- [ ] `az-Get-AzDevOpsAreas | Where-Object { $_.Depth -eq 2 } | Select-Object Path` returns 2nd-tier nodes
- [ ] `az-Get-AzDevOpsIterations | Where-Object { $_.StartDate -le (Get-Date) -and $_.FinishDate -ge (Get-Date) }` returns current iteration
- [ ] `$picked = az-Find-AzDevOpsArea; $picked.GetType()` reports `string`
- [ ] `az-Find-AzDevOpsProject -Use` opens grid → pick → `az-Show-AzDevOpsProject` summary prints
- [ ] Without `Microsoft.PowerShell.ConsoleGuiTools` installed: each `az-Find-*` shows the same install hint as `az-Find-AzDevOpsWorkItem`

https://claude.ai/code/session_01PRK8JJADVzXQMGGuGj1o5Z