### PR TITLE
Add az-Open-AzDevOps* shortcuts for ~/.bashcuts-az-devops-app/ config + cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,45 @@ It seeds any missing defaults (so it works on a fresh machine even before `az-Co
 
 If you delete a file, the next sync writes that default back. The placeholder `{{AZ_AREA}}` is the only one currently supported; everything else in each file is passed through to `az boards query --wiql` verbatim.
 
+### Opening cache / config / schema files
+
+Every folder and file under `~/.bashcuts-az-devops-app/` has a dedicated `az-Open-AzDevOps*` shortcut. Tab-tab on `az-Open-AzDevOps` to see the full list. Each opener launches the path in your OS default handler (`Start-Process`); if the target doesn't exist yet it prints a one-line yellow hint pointing at the function that produces it (e.g. `az-Sync-AzDevOpsCache`) and returns without spawning anything.
+
+Folders:
+
+```powershell
+az-Open-AzDevOpsAppRoot       # ~/.bashcuts-az-devops-app/
+az-Open-AzDevOpsCacheDir      # cache/  (or cache/<project-slug>/ when az-Use-AzDevOpsProject is active)
+az-Open-AzDevOpsConfigDir     # config/queries/
+az-Open-AzDevOpsSchemaDir     # schema/
+```
+
+Cache files (all resolved through the active project slice):
+
+```powershell
+az-Open-AzDevOpsAssignedCache    # assigned.json
+az-Open-AzDevOpsMentionsCache    # mentions.json
+az-Open-AzDevOpsHierarchyCache   # hierarchy.json
+az-Open-AzDevOpsIterationsCache  # iterations.json
+az-Open-AzDevOpsAreasCache       # areas.json
+az-Open-AzDevOpsLastSync         # last-sync.json
+az-Open-AzDevOpsSyncLog          # sync.log
+```
+
+Config WIQL files (per file; `az-Open-AzDevOpsHierarchyWiqls` above remains the "open all three" convenience):
+
+```powershell
+az-Open-AzDevOpsEpicsWiql        # config/queries/epics.wiql
+az-Open-AzDevOpsFeaturesWiql     # config/queries/features.wiql
+az-Open-AzDevOpsUserStoriesWiql  # config/queries/user-stories.wiql
+```
+
+Schema file (per-org `schema-<slug>.json`, falling back to `schema.json` when `$env:AZ_DEVOPS_ORG` is unset):
+
+```powershell
+az-Open-AzDevOpsSchema
+```
+
 ### Day-to-day work-item shortcuts
 
 These read the local cache populated by `az-Sync-AzDevOpsCache` (and the recurring `az-Register-AzDevOpsSyncSchedule` job). They never call `az` directly, so they return instantly.

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -48,6 +48,13 @@ flowchart LR
         NewStoryBatch["az-New-AzDevOpsFeatureStories"]
     end
 
+    subgraph PathOpeners["Path inspectors (az-Open-AzDevOps*)"]
+        OpensFolders["Folder openers:<br/>AppRoot, CacheDir, ConfigDir, SchemaDir"]
+        OpensCache["Cache file openers:<br/>AssignedCache, MentionsCache, HierarchyCache,<br/>IterationsCache, AreasCache, LastSync, SyncLog"]
+        OpensWiql["WIQL openers:<br/>EpicsWiql, FeaturesWiql, UserStoriesWiql"]
+        OpensSchema["az-Open-AzDevOpsSchema"]
+    end
+
     subgraph Cache["$HOME/.bashcuts-az-devops-app/cache/"]
         AssignedJson["assigned.json"]
         MentionsJson["mentions.json"]
@@ -56,6 +63,16 @@ flowchart LR
         AreasJson["areas.json"]
         LastSync["last-sync.json"]
         SyncLog["sync.log (rotates at ~1MB)"]
+    end
+
+    subgraph Config["$HOME/.bashcuts-az-devops-app/config/queries/"]
+        EpicsWiql["epics.wiql"]
+        FeatsWiql["features.wiql"]
+        StoriesWiql["user-stories.wiql"]
+    end
+
+    subgraph Schema["$HOME/.bashcuts-az-devops-app/schema/"]
+        SchemaJson["schema-&lt;org&gt;.json"]
     end
 
     subgraph AzCLI["Azure CLI"]
@@ -103,6 +120,25 @@ flowchart LR
 
     Reg -.task scheduler / cron.-> Sync
     Unreg -.removes schedule.-> Reg
+
+    OpensFolders -.opens dir.-> Cache
+    OpensFolders -.opens dir.-> Config
+    OpensFolders -.opens dir.-> Schema
+    OpensCache -.opens file.-> AssignedJson
+    OpensCache -.opens file.-> MentionsJson
+    OpensCache -.opens file.-> HierJson
+    OpensCache -.opens file.-> IterJson
+    OpensCache -.opens file.-> AreasJson
+    OpensCache -.opens file.-> LastSync
+    OpensCache -.opens file.-> SyncLog
+    OpensWiql -.opens file.-> EpicsWiql
+    OpensWiql -.opens file.-> FeatsWiql
+    OpensWiql -.opens file.-> StoriesWiql
+    OpensSchema -.opens file.-> SchemaJson
+
+    Sync --> EpicsWiql
+    Sync --> FeatsWiql
+    Sync --> StoriesWiql
 ```
 
 ---
@@ -944,6 +980,58 @@ graph LR
     PFeat --> ScopePaths --> RScope
     PEpic --> ScopePaths
     PParent --> AreaMatch
+
+    %% Path-inspector openers (azdevops_workitems.ps1) — every public below is a
+    %% thin wrapper that resolves a path via one of the Get-AzDevOps*Paths
+    %% helpers and delegates to Open-AzDevOpsPathIfExists, which Test-Paths the
+    %% target and calls Start-Process when it exists.
+    OpenAppRoot(["az-Open-AzDevOpsAppRoot"]):::pub
+    OpenCacheDir(["az-Open-AzDevOpsCacheDir"]):::pub
+    OpenConfigDir(["az-Open-AzDevOpsConfigDir"]):::pub
+    OpenSchemaDir(["az-Open-AzDevOpsSchemaDir"]):::pub
+    OpenAsg(["az-Open-AzDevOpsAssignedCache"]):::pub
+    OpenMen(["az-Open-AzDevOpsMentionsCache"]):::pub
+    OpenHier(["az-Open-AzDevOpsHierarchyCache"]):::pub
+    OpenIter(["az-Open-AzDevOpsIterationsCache"]):::pub
+    OpenAreas(["az-Open-AzDevOpsAreasCache"]):::pub
+    OpenLast(["az-Open-AzDevOpsLastSync"]):::pub
+    OpenLog(["az-Open-AzDevOpsSyncLog"]):::pub
+    OpenEpics(["az-Open-AzDevOpsEpicsWiql"]):::pub
+    OpenFeats(["az-Open-AzDevOpsFeaturesWiql"]):::pub
+    OpenStories(["az-Open-AzDevOpsUserStoriesWiql"]):::pub
+    OpenSchema(["az-Open-AzDevOpsSchema"]):::pub
+
+    %% Path-inspector helper + path-discovery helpers used by the openers above
+    OpenPath[Open-AzDevOpsPathIfExists]:::priv
+    AppRoot[Get-AzDevOpsAppRoot]:::priv
+    SPaths[Get-AzDevOpsSchemaPaths]:::priv
+
+    %% OS handler I/O sink for Start-Process
+    OSHandler[(OS default handler)]:::io
+
+    %% Each opener resolves its path through the matching Get-AzDevOps*Paths
+    %% helper, then delegates to Open-AzDevOpsPathIfExists which calls
+    %% Start-Process on the resolved path.
+    OpenAppRoot --> AppRoot
+    OpenCacheDir --> Paths
+    OpenConfigDir --> QPaths
+    OpenSchemaDir --> SPaths
+    OpenAsg --> Paths
+    OpenMen --> Paths
+    OpenHier --> Paths
+    OpenIter --> Paths
+    OpenAreas --> Paths
+    OpenLast --> Paths
+    OpenLog --> Paths
+    OpenEpics --> QPaths
+    OpenFeats --> QPaths
+    OpenStories --> QPaths
+    OpenSchema --> SPaths
+
+    OpenAppRoot & OpenCacheDir & OpenConfigDir & OpenSchemaDir --> OpenPath
+    OpenAsg & OpenMen & OpenHier & OpenIter & OpenAreas & OpenLast & OpenLog --> OpenPath
+    OpenEpics & OpenFeats & OpenStories & OpenSchema --> OpenPath
+    OpenPath --> OSHandler
 ```
 
 ---

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -4318,3 +4318,148 @@ function az-Test-AzDevOpsSchema {
         }
     }
 }
+
+
+# ---------------------------------------------------------------------------
+# az-Open-AzDevOps* family - direct openers for every folder and file under
+# $HOME/.bashcuts-az-devops-app/. Every public function below resolves its
+# path through the existing Get-AzDevOps* helpers so cache openers auto-follow
+# the active project slice set by az-Use-AzDevOpsProject, and the schema
+# opener auto-follows the per-org $env:AZ_DEVOPS_ORG slug.
+#
+# Discovery: tab-tab on `az-Open-AzDevOps` in any pwsh session.
+# ---------------------------------------------------------------------------
+
+function Open-AzDevOpsPathIfExists {
+    # Private helper used by every public az-Open-AzDevOps* function in this
+    # section. Centralizes the "exists? -> Start-Process, missing? -> yellow
+    # hint + return" branch so the 15 public openers stay one-liners. Uses an
+    # unapproved verb on purpose - it isn't user-facing, so it doesn't need to
+    # pass Get-Verb.
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [string] $HintMessage
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        Write-Host "Not found: $Path" -ForegroundColor Yellow
+        Write-Host "  $HintMessage" -ForegroundColor Yellow
+        return
+    }
+
+    Write-Host "Opening $Path" -ForegroundColor DarkGray
+    Start-Process $Path
+}
+
+
+# --- Folder openers (4) ----------------------------------------------------
+
+function az-Open-AzDevOpsAppRoot {
+    $root = Get-AzDevOpsAppRoot
+    Open-AzDevOpsPathIfExists -Path $root `
+        -HintMessage "Run az-Connect-AzDevOps to scaffold the app root."
+}
+
+
+function az-Open-AzDevOpsCacheDir {
+    $paths = Get-AzDevOpsCachePaths
+    Open-AzDevOpsPathIfExists -Path $paths.Dir `
+        -HintMessage "Run az-Sync-AzDevOpsCache to populate the active project's cache slice."
+}
+
+
+function az-Open-AzDevOpsConfigDir {
+    $paths = Get-AzDevOpsConfigPaths
+    Open-AzDevOpsPathIfExists -Path $paths.QueriesDir `
+        -HintMessage "Run az-Connect-AzDevOps (or az-Open-AzDevOpsHierarchyWiqls) to seed the default WIQL files."
+}
+
+
+function az-Open-AzDevOpsSchemaDir {
+    $paths = Get-AzDevOpsSchemaPaths
+    Open-AzDevOpsPathIfExists -Path $paths.Dir `
+        -HintMessage "Run az-Initialize-AzDevOpsSchema (or az-Edit-AzDevOpsSchema) to create the schema directory."
+}
+
+
+# --- Cache file openers (7) ------------------------------------------------
+
+function az-Open-AzDevOpsAssignedCache {
+    $paths = Get-AzDevOpsCachePaths
+    Open-AzDevOpsPathIfExists -Path $paths.Assigned `
+        -HintMessage "Run az-Sync-AzDevOpsCache to populate assigned.json."
+}
+
+
+function az-Open-AzDevOpsMentionsCache {
+    $paths = Get-AzDevOpsCachePaths
+    Open-AzDevOpsPathIfExists -Path $paths.Mentions `
+        -HintMessage "Run az-Sync-AzDevOpsCache to populate mentions.json."
+}
+
+
+function az-Open-AzDevOpsHierarchyCache {
+    $paths = Get-AzDevOpsCachePaths
+    Open-AzDevOpsPathIfExists -Path $paths.Hierarchy `
+        -HintMessage "Run az-Sync-AzDevOpsCache to populate hierarchy.json."
+}
+
+
+function az-Open-AzDevOpsIterationsCache {
+    $paths = Get-AzDevOpsCachePaths
+    Open-AzDevOpsPathIfExists -Path $paths.Iterations `
+        -HintMessage "Run az-Sync-AzDevOpsCache to populate iterations.json."
+}
+
+
+function az-Open-AzDevOpsAreasCache {
+    $paths = Get-AzDevOpsCachePaths
+    Open-AzDevOpsPathIfExists -Path $paths.Areas `
+        -HintMessage "Run az-Sync-AzDevOpsCache to populate areas.json."
+}
+
+
+function az-Open-AzDevOpsLastSync {
+    $paths = Get-AzDevOpsCachePaths
+    Open-AzDevOpsPathIfExists -Path $paths.LastSync `
+        -HintMessage "Run az-Sync-AzDevOpsCache to write the first last-sync.json."
+}
+
+
+function az-Open-AzDevOpsSyncLog {
+    $paths = Get-AzDevOpsCachePaths
+    Open-AzDevOpsPathIfExists -Path $paths.Log `
+        -HintMessage "Run az-Sync-AzDevOpsCache - the log is appended only when a sync runs."
+}
+
+
+# --- Config file openers (3) -----------------------------------------------
+
+function az-Open-AzDevOpsEpicsWiql {
+    $paths = Get-AzDevOpsConfigPaths
+    Open-AzDevOpsPathIfExists -Path $paths.EpicsQuery `
+        -HintMessage "Run az-Open-AzDevOpsHierarchyWiqls (or az-Connect-AzDevOps) to seed epics.wiql with the default."
+}
+
+
+function az-Open-AzDevOpsFeaturesWiql {
+    $paths = Get-AzDevOpsConfigPaths
+    Open-AzDevOpsPathIfExists -Path $paths.FeaturesQuery `
+        -HintMessage "Run az-Open-AzDevOpsHierarchyWiqls (or az-Connect-AzDevOps) to seed features.wiql with the default."
+}
+
+
+function az-Open-AzDevOpsUserStoriesWiql {
+    $paths = Get-AzDevOpsConfigPaths
+    Open-AzDevOpsPathIfExists -Path $paths.UserStoriesQuery `
+        -HintMessage "Run az-Open-AzDevOpsHierarchyWiqls (or az-Connect-AzDevOps) to seed user-stories.wiql with the default."
+}
+
+
+# --- Schema file opener (1) ------------------------------------------------
+
+function az-Open-AzDevOpsSchema {
+    $paths = Get-AzDevOpsSchemaPaths
+    Open-AzDevOpsPathIfExists -Path $paths.File `
+        -HintMessage "Run az-Initialize-AzDevOpsSchema to introspect your org, or az-Edit-AzDevOpsSchema to scaffold a stub."
+}


### PR DESCRIPTION
<!-- toc:start -->
## Navigation

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #79 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | 0/6 manual checks |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/80#issuecomment-4444699287) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/80#issuecomment-4444705213) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/80#issuecomment-4444708871) |
| 🛡️ Security Audit | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/80#issuecomment-4444709065) |
| ✅ Criteria Check (#79) | ✅ PASS (21/24 automated; 3 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/80#issuecomment-4444721468) |
| 🗺️ AzDO Diagrams Check | ✅ CURRENT (stale drift fixed in `39ff504`) — [View](https://github.com/jdschleicher/bashcuts/pull/80#issuecomment-4444804418) |
| 📚 Docs Check | ✅ CURRENT — ran inline during `/pr-flow`; no comment posted |
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

Each new opener resolves its target path through the matching `Get-AzDevOps*Paths` helper, then delegates to the shared `Open-AzDevOpsPathIfExists` helper. The helper guards on `Test-Path -LiteralPath`: existing paths launch via `Start-Process`, missing paths print a yellow remediation hint and return.

```mermaid
flowchart TD
    EntryF([Folder openers<br/>az-Open-AzDevOps&#123;AppRoot,CacheDir,ConfigDir,SchemaDir&#125;]):::pub
    EntryC([Cache file openers<br/>az-Open-AzDevOps&#123;Assigned,Mentions,Hierarchy,Iterations,Areas&#125;Cache<br/>+ LastSync + SyncLog]):::pub
    EntryW([WIQL openers<br/>az-Open-AzDevOps&#123;Epics,Features,UserStories&#125;Wiql]):::pub
    EntryS([az-Open-AzDevOpsSchema]):::pub

    AppRoot[Get-AzDevOpsAppRoot]:::priv
    CachePaths[Get-AzDevOpsCachePaths<br/>auto-follows active project slice]:::priv
    ConfigPaths[Get-AzDevOpsConfigPaths]:::priv
    SchemaPaths[Get-AzDevOpsSchemaPaths<br/>auto-follows $env:AZ_DEVOPS_ORG]:::priv

    Helper[Open-AzDevOpsPathIfExists<br/>shared by all 15 publics]:::priv
    Gate{Test-Path<br/>-LiteralPath?}
    Hint(["yellow 'Not found' hint<br/>+ remediation tip<br/>+ return"])

    OS[(OS default handler<br/>via Start-Process)]:::io

    EntryF --> AppRoot
    EntryF --> CachePaths
    EntryF --> ConfigPaths
    EntryF --> SchemaPaths
    EntryC --> CachePaths
    EntryW --> ConfigPaths
    EntryS --> SchemaPaths

    AppRoot --> Helper
    CachePaths --> Helper
    ConfigPaths --> Helper
    SchemaPaths --> Helper

    Helper --> Gate
    Gate -- exists --> OS
    Gate -- missing --> Hint

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
Adds 15 PowerShell openers + 1 private helper so every folder and file under `~/.bashcuts-az-devops-app/` is tab-tab discoverable from the `az-Open-AzDevOps` prefix. Closes the gap left by today's lone `az-Open-AzDevOpsHierarchyWiqls`: cache JSONs, the sync log, the schema file, individual WIQLs, and the three top-level state folders now each have a dedicated opener.

## Issue
Closes #79

## Changes
- `powcuts_by_cli/azdevops_workitems.ps1` — appended `Open-AzDevOpsPathIfExists` private helper + 15 public functions:
  - **Folders:** `az-Open-AzDevOpsAppRoot`, `az-Open-AzDevOpsCacheDir`, `az-Open-AzDevOpsConfigDir`, `az-Open-AzDevOpsSchemaDir`
  - **Cache files:** `az-Open-AzDevOpsAssignedCache`, `az-Open-AzDevOpsMentionsCache`, `az-Open-AzDevOpsHierarchyCache`, `az-Open-AzDevOpsIterationsCache`, `az-Open-AzDevOpsAreasCache`, `az-Open-AzDevOpsLastSync`, `az-Open-AzDevOpsSyncLog`
  - **Config WIQLs:** `az-Open-AzDevOpsEpicsWiql`, `az-Open-AzDevOpsFeaturesWiql`, `az-Open-AzDevOpsUserStoriesWiql`
  - **Schema:** `az-Open-AzDevOpsSchema`
- `README.md` — new "Opening cache / config / schema files" subsection under Azure DevOps work-item shortcuts
- `docs/azure-devops-diagrams.md` — mermaid Diagrams 1 + 11 updated to cover the new functions, helper, and OS-handler sink (commit `39ff504`)

All public openers route through the helper, so the missing-target behaviour (yellow hint + `return`, no `Start-Process` on a non-existent path) is implemented once. Cache openers auto-follow the active project slice via `Get-AzDevOpsCachePaths`; the schema opener auto-follows `$env:AZ_DEVOPS_ORG` via `Get-AzDevOpsSchemaPaths`.

## Test Plan
- [ ] `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/azdevops_workitems.ps1', [ref]$null, [ref]$null)"` reports zero errors
- [ ] Fresh PowerShell terminal: tab-tab on `az-Open-AzDevOps` lists the 15 new functions alongside the existing ones
- [ ] With a populated `~/.bashcuts-az-devops-app/`: each opener launches the target in the OS default handler
- [ ] With an empty / missing `~/.bashcuts-az-devops-app/`: each opener prints the yellow hint and returns (no `Start-Process` on a non-existent path)
- [ ] `az-Open-AzDevOpsCacheDir` follows the active project after `az-Use-AzDevOpsProject <Name>` switches slices
- [ ] `az-Open-AzDevOpsSchema` follows the per-org file when `$env:AZ_DEVOPS_ORG` is set, falls back to `schema.json` when unset


---
_Generated by [Claude Code](https://claude.ai/code/session_01YcAB4u1Xze8NAUY14ws8rc)_