### PR TITLE
refactor(azdevops): rely on az devops configure --defaults; move inline WIQLs to user-editable files

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,16 +167,24 @@ PowerShell shortcuts in `powcuts_by_cli/azdevops_workitems.ps1` provide guided s
 - `azure-devops` CLI extension: `az extension add --name azure-devops` (`az-Connect-AzDevOps` will offer to install this for you on first run)
 - An active `az login` session (`az-Connect-AzDevOps` will offer to start one for you on first run)
 
-### Profile environment variables
+### Configure org and project defaults
 
-Add this block to your PowerShell `$profile` and reload (open a new terminal). Replace each value with what's appropriate for your organization:
+Org and project are stored in your Microsoft profile via the Azure CLI — not in PowerShell env vars. Run once per machine (or after switching orgs):
 
 ```powershell
-$env:AZ_DEVOPS_ORG = 'https://dev.azure.com/myorg'
-$env:AZ_PROJECT    = 'My Project'
-$env:AZ_USER_EMAIL = 'user@example.com'
-$env:AZ_AREA       = 'My Project\My Team'
-$env:AZ_ITERATION  = 'My Project\Sprint 42'
+az devops configure --defaults organization='https://dev.azure.com/myorg' project='My Project'
+```
+
+(`az-Connect-AzDevOps` will guide you through this interactively on first run.)
+
+### Optional profile environment variables
+
+Add any of these to your PowerShell `$profile` to enable additional features:
+
+```powershell
+$env:AZ_USER_EMAIL = 'user@example.com'   # enables accurate mentions WIQL
+$env:AZ_AREA       = 'My Project\My Team' # default area path for hierarchy queries
+$env:AZ_ITERATION  = 'My Project\Sprint 42' # default iteration for work item creation
 ```
 
 ### First run

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -53,6 +53,13 @@ flowchart LR
         NewStoryBatch["az-New-AzDevOpsFeatureStories"]
     end
 
+    subgraph PathOpeners["Path inspectors (az-Open-AzDevOps*)"]
+        OpensFolders["Folder openers:<br/>AppRoot, CacheDir, ConfigDir, SchemaDir"]
+        OpensCache["Cache file openers:<br/>AssignedCache, MentionsCache, HierarchyCache,<br/>IterationsCache, AreasCache, LastSync, SyncLog"]
+        OpensWiql["WIQL openers:<br/>EpicsWiql, FeaturesWiql, UserStoriesWiql"]
+        OpensSchema["az-Open-AzDevOpsSchema"]
+    end
+
     subgraph Cache["$HOME/.bashcuts-az-devops-app/cache/"]
         AssignedJson["assigned.json"]
         MentionsJson["mentions.json"]
@@ -61,6 +68,16 @@ flowchart LR
         AreasJson["areas.json"]
         LastSync["last-sync.json"]
         SyncLog["sync.log (rotates at ~1MB)"]
+    end
+
+    subgraph Config["$HOME/.bashcuts-az-devops-app/config/queries/"]
+        EpicsWiql["epics.wiql"]
+        FeatsWiql["features.wiql"]
+        StoriesWiql["user-stories.wiql"]
+    end
+
+    subgraph Schema["$HOME/.bashcuts-az-devops-app/schema/"]
+        SchemaJson["schema-&lt;org&gt;.json"]
     end
 
     subgraph AzCLI["Azure CLI"]
@@ -117,6 +134,25 @@ flowchart LR
 
     Reg -.task scheduler / cron.-> Sync
     Unreg -.removes schedule.-> Reg
+
+    OpensFolders -.opens dir.-> Cache
+    OpensFolders -.opens dir.-> Config
+    OpensFolders -.opens dir.-> Schema
+    OpensCache -.opens file.-> AssignedJson
+    OpensCache -.opens file.-> MentionsJson
+    OpensCache -.opens file.-> HierJson
+    OpensCache -.opens file.-> IterJson
+    OpensCache -.opens file.-> AreasJson
+    OpensCache -.opens file.-> LastSync
+    OpensCache -.opens file.-> SyncLog
+    OpensWiql -.opens file.-> EpicsWiql
+    OpensWiql -.opens file.-> FeatsWiql
+    OpensWiql -.opens file.-> StoriesWiql
+    OpensSchema -.opens file.-> SchemaJson
+
+    Sync --> EpicsWiql
+    Sync --> FeatsWiql
+    Sync --> StoriesWiql
 ```
 
 ---
@@ -622,6 +658,7 @@ graph LR
     NewWI[New-AzDevOpsWorkItem]:::priv
     AddRel[Add-AzDevOpsWorkItemRelation]:::priv
     AddDisc[Add-AzDevOpsDiscussionComment]:::priv
+    WITypeDef[Get-AzDevOpsWorkItemTypeDefinition]:::priv
 
     %% Query echo helpers (azdevops_db.ps1)
     CmdDisp[Format-AzDevOpsCommandDisplay]:::priv
@@ -694,6 +731,9 @@ graph LR
     BatchCont[Read-AzDevOpsBatchContinue]:::priv
     ParentTest[Test-AzDevOpsParentIsFeature]:::priv
 
+    %% Auth abort prologue
+    AuthAbort[Assert-AzDevOpsAuthOrAbort]:::priv
+
     %% Shared creator scaffolding (consumed by all three az-New-AzDevOps* creators)
     CGate[Test-AzDevOpsCreateGate]:::priv
     ResIA[Resolve-AzDevOpsIterationArea]:::priv
@@ -723,6 +763,25 @@ graph LR
     ScopePaths[Get-AzDevOpsParentScopeAreaPaths]:::priv
     AreaMatch[Test-AzDevOpsAreaPathMatch]:::priv
 
+    %% Schema management (azdevops_workitems.ps1)
+    GetSchema(["az-Get-AzDevOpsSchema"]):::pub
+    InitSchema(["az-Initialize-AzDevOpsSchema"]):::pub
+    EditSchema(["az-Edit-AzDevOpsSchema"]):::pub
+    TestSchema(["az-Test-AzDevOpsSchema"]):::pub
+    SchemaSlug[Get-AzDevOpsSchemaOrgSlug]:::priv
+    SchemaValidTypes[Get-AzDevOpsSchemaValidTypes]:::priv
+    SchemaWITypes[Get-AzDevOpsSchemaWorkItemTypes]:::priv
+    SchemaSysRefs[Get-AzDevOpsSchemaSystemRefs]:::priv
+    SchemaForType[Get-AzDevOpsSchemaForType]:::priv
+    SchemaStub[New-AzDevOpsSchemaStub]:::priv
+    SchemaEditor[Resolve-AzDevOpsEditor]:::priv
+    WITypeShow[Invoke-AzDevOpsWorkItemTypeShow]:::priv
+    SchemaFieldEntry[ConvertTo-AzDevOpsSchemaFieldEntry]:::priv
+    SchemaToRows[ConvertFrom-AzDevOpsSchemaToRows]:::priv
+    SchemaRead[Read-AzDevOpsSchemaFile]:::priv
+    SchemaWrite[Write-AzDevOpsSchemaFile]:::priv
+    SchemaInitDir[Initialize-AzDevOpsSchemaDir]:::priv
+
     %% I/O sinks
     Az[(az CLI)]:::io
     FS[(cache files)]:::io
@@ -747,7 +806,8 @@ graph LR
     TestAuth --> TSmoke
     TSmoke --> Az
 
-    Sync --> TestAuth
+    AuthAbort --> TestAuth
+    Sync --> AuthAbort
     Sync --> InitDir --> Paths
     InitDir --> MkDir
     Sync --> LogFn --> Paths
@@ -766,6 +826,7 @@ graph LR
     Boards --> AzJson
     ClassList --> AzJson
     AddDisc --> AzJson
+    WITypeDef --> AzJson
     Boards --> EchoLn
     AzJson --> CmdDisp
     AzJson --> CmdHead
@@ -991,6 +1052,94 @@ graph LR
     PFeat --> ScopePaths --> RScope
     PEpic --> ScopePaths
     PParent --> AreaMatch
+
+    %% Path-inspector openers (azdevops_workitems.ps1) — every public below is a
+    %% thin wrapper that resolves a path via one of the Get-AzDevOps*Paths
+    %% helpers and delegates to Open-AzDevOpsPathIfExists, which Test-Paths the
+    %% target and calls Start-Process when it exists.
+    OpenAppRoot(["az-Open-AzDevOpsAppRoot"]):::pub
+    OpenCacheDir(["az-Open-AzDevOpsCacheDir"]):::pub
+    OpenConfigDir(["az-Open-AzDevOpsConfigDir"]):::pub
+    OpenSchemaDir(["az-Open-AzDevOpsSchemaDir"]):::pub
+    OpenAsg(["az-Open-AzDevOpsAssignedCache"]):::pub
+    OpenMen(["az-Open-AzDevOpsMentionsCache"]):::pub
+    OpenHier(["az-Open-AzDevOpsHierarchyCache"]):::pub
+    OpenIter(["az-Open-AzDevOpsIterationsCache"]):::pub
+    OpenAreas(["az-Open-AzDevOpsAreasCache"]):::pub
+    OpenLast(["az-Open-AzDevOpsLastSync"]):::pub
+    OpenLog(["az-Open-AzDevOpsSyncLog"]):::pub
+    OpenEpics(["az-Open-AzDevOpsEpicsWiql"]):::pub
+    OpenFeats(["az-Open-AzDevOpsFeaturesWiql"]):::pub
+    OpenStories(["az-Open-AzDevOpsUserStoriesWiql"]):::pub
+    OpenSchema(["az-Open-AzDevOpsSchema"]):::pub
+
+    %% Path-inspector helper + path-discovery helpers used by the openers above
+    OpenPath[Open-AzDevOpsPathIfExists]:::priv
+    AppRoot[Get-AzDevOpsAppRoot]:::priv
+    SPaths[Get-AzDevOpsSchemaPaths]:::priv
+
+    %% OS handler I/O sink for Start-Process
+    OSHandler[(OS default handler)]:::io
+
+    %% Each opener resolves its path through the matching Get-AzDevOps*Paths
+    %% helper, then delegates to Open-AzDevOpsPathIfExists which calls
+    %% Start-Process on the resolved path.
+    OpenAppRoot --> AppRoot
+    OpenCacheDir --> Paths
+    OpenConfigDir --> QPaths
+    OpenSchemaDir --> SPaths
+    OpenAsg --> Paths
+    OpenMen --> Paths
+    OpenHier --> Paths
+    OpenIter --> Paths
+    OpenAreas --> Paths
+    OpenLast --> Paths
+    OpenLog --> Paths
+    OpenEpics --> QPaths
+    OpenFeats --> QPaths
+    OpenStories --> QPaths
+    OpenSchema --> SPaths
+
+    OpenAppRoot & OpenCacheDir & OpenConfigDir & OpenSchemaDir --> OpenPath
+    OpenAsg & OpenMen & OpenHier & OpenIter & OpenAreas & OpenLast & OpenLog --> OpenPath
+    OpenEpics & OpenFeats & OpenStories & OpenSchema --> OpenPath
+    OpenPath --> OSHandler
+
+    %% Schema management wiring
+    GetSchema --> SchemaRead
+    GetSchema --> SPaths
+    GetSchema --> SchemaToRows
+    GetSchema --> ShowRows
+
+    EditSchema --> SchemaInitDir
+    EditSchema --> SchemaRead
+    EditSchema --> SchemaStub
+    EditSchema --> SchemaWrite
+    EditSchema --> SchemaEditor
+
+    InitSchema --> AuthAbort
+    InitSchema --> SchemaInitDir
+    InitSchema --> SchemaSysRefs
+    InitSchema --> SchemaWITypes
+    InitSchema --> WITypeShow
+    InitSchema --> SchemaFieldEntry
+    InitSchema --> SchemaWrite
+
+    TestSchema --> AuthAbort
+    TestSchema --> SPaths
+    TestSchema --> SchemaRead
+    TestSchema --> SchemaValidTypes
+    TestSchema --> SchemaWITypes
+    TestSchema --> WITypeShow
+
+    WITypeShow --> WITypeDef
+    SchemaRead --> SPaths
+    SchemaWrite --> SPaths
+    SchemaInitDir --> SPaths
+    SchemaInitDir --> Plat
+    SPaths --> SchemaSlug
+    SchemaSlug --> AppRoot
+    SchemaForType --> SchemaRead
 ```
 
 ---

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -93,6 +93,38 @@ function Get-AzDevOpsCommandHeadline {
 }
 
 
+function Get-AzDevOpsConfiguredDefaults {
+    # Reads the current `az devops configure --defaults` values (org URL and
+    # project name). Returns [PSCustomObject]@{ Org = '...'; Project = '...' }
+    # with empty strings when not configured. Results are cached per-session so
+    # the az invocation runs at most once per PowerShell session.
+    if ($null -ne $global:AzDevOpsCachedConfiguredDefaults) {
+        return $global:AzDevOpsCachedConfiguredDefaults
+    }
+
+    $lines = az devops configure --list 2>$null
+    $org     = ''
+    $project = ''
+
+    if ($LASTEXITCODE -eq 0 -and $lines) {
+        $orgLine     = @($lines) | Where-Object { $_ -match '^\s*organization\s*=' } | Select-Object -First 1
+        $projectLine = @($lines) | Where-Object { $_ -match '^\s*project\s*='      } | Select-Object -First 1
+
+        if ($orgLine) {
+            $org = ($orgLine -split '=', 2)[1].Trim()
+        }
+
+        if ($projectLine) {
+            $project = ($projectLine -split '=', 2)[1].Trim()
+        }
+    }
+
+    $result = [PSCustomObject]@{ Org = $org; Project = $project }
+    $global:AzDevOpsCachedConfiguredDefaults = $result
+    return $result
+}
+
+
 function Invoke-AzDevOpsAzJson {
     # Generic wrapper around `az ... --output json` that captures stdout JSON
     # and stderr text separately. The canonical JSON+error path used by every
@@ -100,43 +132,21 @@ function Invoke-AzDevOpsAzJson {
     # echoes so every query is visible in the terminal alongside its elapsed
     # time and exit code.
     #
-    # When $env:AZ_DEVOPS_ORG / $env:AZ_PROJECT are set and the caller has not
-    # already supplied --organization / --project, we inject them so every
-    # wrapper auto-scopes to the bashcuts env-var contract instead of relying
-    # on `az devops configure --defaults`. Explicit caller flags always win
-    # (e.g. New-AzDevOpsWorkItem passes its own --project). The echo prints
-    # the post-injection command so the user sees the actual flags being
-    # sent to az, not the pre-scoped ArgList from the caller.
-    #
-    # -SkipProjectFlag opts out of the --project auto-injection for callers
-    # whose subcommand rejects --project as a top-level flag (e.g.
-    # `az devops invoke`, which carries the project in --route-parameters
-    # instead). --organization auto-injection still applies since
-    # `az devops invoke` accepts it.
+    # Org and project scoping rely on `az devops configure --defaults` set in
+    # the user's Microsoft profile (via az-Connect-AzDevOps or manually). No
+    # flags are auto-injected here; callers that need explicit scoping pass
+    # --organization / --project themselves.
     param(
-        [Parameter(Mandatory)] [string[]] $ArgList,
-        [switch] $SkipProjectFlag
+        [Parameter(Mandatory)] [string[]] $ArgList
     )
 
-    $scopedArgs = @($ArgList)
-
-    if ($env:AZ_DEVOPS_ORG -and ($scopedArgs -notcontains '--organization')) {
-        $scopedArgs += @('--organization', $env:AZ_DEVOPS_ORG)
-    }
-
-    if (-not $SkipProjectFlag `
-            -and $env:AZ_PROJECT `
-            -and ($scopedArgs -notcontains '--project') ) {
-        $scopedArgs += @('--project', $env:AZ_PROJECT)
-    }
-
-    $commandDisplay = Format-AzDevOpsCommandDisplay -ArgList $scopedArgs
+    $commandDisplay = Format-AzDevOpsCommandDisplay -ArgList $ArgList
     Write-AzDevOpsQueryEcho -Message $commandDisplay -Color 'DarkCyan'
 
     $stderrFile = [System.IO.Path]::GetTempFileName()
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     try {
-        $json = & az @scopedArgs --output json 2>$stderrFile
+        $json = & az @ArgList --output json 2>$stderrFile
         $exit = $LASTEXITCODE
         $stderr = if (Test-Path -LiteralPath $stderrFile) {
             (Get-Content -LiteralPath $stderrFile -Raw)
@@ -149,7 +159,7 @@ function Invoke-AzDevOpsAzJson {
     $sw.Stop()
 
     $elapsed  = '{0:N1}s' -f $sw.Elapsed.TotalSeconds
-    $headline = Get-AzDevOpsCommandHeadline -ArgList $scopedArgs
+    $headline = Get-AzDevOpsCommandHeadline -ArgList $ArgList
 
     $summary      = "$headline ($elapsed, exit=$exit)"
     $summaryColor = if ($exit -eq 0) {
@@ -274,7 +284,7 @@ function Add-AzDevOpsWorkItemRelation {
         [Parameter(Mandatory)] [string] $RelationType
     )
 
-    $result = Invoke-AzDevOpsAzJson -SkipProjectFlag -ArgList @(
+    $result = Invoke-AzDevOpsAzJson -ArgList @(
         'boards', 'work-item', 'relation', 'add',
         '--id',            "$Id",
         '--relation-type', $RelationType,
@@ -313,17 +323,18 @@ function Get-AzDevOpsWorkItemTypeDefinition {
     # The azure-devops extension does NOT expose a `boards work-item-type`
     # subgroup, so we go through `az devops invoke` (REST passthrough) against
     # the WIT workitemtypes endpoint. Project scope rides in --route-parameters
-    # rather than --project, so we pass -SkipProjectFlag to bypass the
-    # Invoke-AzDevOpsAzJson auto-injection that `az devops invoke` would reject.
+    # (the az devops invoke REST path) rather than the top-level --project flag.
     param([Parameter(Mandatory)] [string] $Type)
 
     $apiVersion = '7.1'
+    $defaults   = Get-AzDevOpsConfiguredDefaults
+    $project    = $defaults.Project
 
-    $result = Invoke-AzDevOpsAzJson -SkipProjectFlag -ArgList @(
+    $result = Invoke-AzDevOpsAzJson -ArgList @(
         'devops', 'invoke',
         '--area',             'wit',
         '--resource',         'workitemtypes',
-        '--route-parameters', "project=$env:AZ_PROJECT", "type=$Type",
+        '--route-parameters', "project=$project", "type=$Type",
         '--api-version',      $apiVersion
     )
     return $result

--- a/powcuts_by_cli/azdevops_projects.ps1
+++ b/powcuts_by_cli/azdevops_projects.ps1
@@ -502,13 +502,17 @@ function az-Use-AzDevOpsProject {
 
     if (-not $SkipConfigure) {
         if (Get-Command az -ErrorAction SilentlyContinue) {
-            $configureOutput = az devops configure --defaults "organization=$env:AZ_DEVOPS_ORG" "project=$env:AZ_PROJECT" 2>&1
+            $org     = [string]$config['Org']
+            $project = [string]$config['Project']
+            $configureOutput = az devops configure --defaults "organization=$org" "project=$project" 2>&1
             if ($LASTEXITCODE -ne 0 -and -not $Quiet) {
                 Write-Host "  !  az devops configure failed (env vars still set):" -ForegroundColor Yellow
                 Write-Host "     $configureOutput" -ForegroundColor Yellow
+            } else {
+                $global:AzDevOpsCachedConfiguredDefaults = $null
             }
         } elseif (-not $Quiet) {
-            Write-Host "  !  az CLI not on PATH - env vars set but `az devops configure` skipped." -ForegroundColor Yellow
+            Write-Host "  !  az CLI not on PATH - `az devops configure` skipped." -ForegroundColor Yellow
         }
     }
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -690,7 +690,14 @@ function Get-AzDevOpsWiql {
     }
 
     if ($wiql -match [regex]::Escape($script:AzDevOpsUserEmailToken)) {
-        $emailValue = if ($env:AZ_USER_EMAIL) { "@$env:AZ_USER_EMAIL" } else { '@' }
+        $emailRaw   = if ($env:AZ_USER_EMAIL) {
+            "@$env:AZ_USER_EMAIL"
+        } else {
+            '@'
+        }
+        # Escape single quotes for WIQL string-literal safety — same rationale
+        # as $areaEscaped above.
+        $emailValue = $emailRaw.Replace("'", "''")
         $wiql       = $wiql.Replace($script:AzDevOpsUserEmailToken, $emailValue)
     }
 

--- a/powcuts_by_cli/azdevops_workitems.ps1
+++ b/powcuts_by_cli/azdevops_workitems.ps1
@@ -36,13 +36,15 @@
 #   Invoke-AzDevOpsSmokeQuery        - runs WIQL "items assigned to me",
 #                                       returns count or $null on failure
 #
-# Expected $profile environment variables (set these once in your $profile):
+# Required setup (run once):
+#   az devops configure --defaults organization=https://dev.azure.com/myorg project="My Project"
+#   (or run az-Connect-AzDevOps which walks you through this interactively)
 #
-#   $env:AZ_DEVOPS_ORG = 'https://dev.azure.com/myorg'   # full org URL
-#   $env:AZ_PROJECT    = 'My Project'                    # project name
-#   $env:AZ_USER_EMAIL = 'user@example.com'              # your AAD email
-#   $env:AZ_AREA       = 'My Project\My Team'            # default area path
-#   $env:AZ_ITERATION  = 'My Project\Sprint 42'          # default iteration
+# Optional $profile environment variables:
+#
+#   $env:AZ_USER_EMAIL = 'user@example.com'              # your AAD email (mentions WIQL)
+#   $env:AZ_AREA       = 'My Project\My Team'            # default area path (hierarchy WIQL)
+#   $env:AZ_ITERATION  = 'My Project\Sprint 42'          # default iteration (work item creation)
 #
 # Prereqs:
 #   - Azure CLI        : https://aka.ms/installazurecli
@@ -97,18 +99,6 @@ function Test-AzDevOpsExtensionInstalled {
 }
 
 
-function Get-AzDevOpsMissingEnvVars {
-    $missing = @()
-    if (-not $env:AZ_DEVOPS_ORG) { 
-        $missing += 'AZ_DEVOPS_ORG'
-    }
-    if (-not $env:AZ_PROJECT) { 
-        $missing += 'AZ_PROJECT'
-    }
-    return , $missing
-}
-
-
 function Test-AzDevOpsLoggedIn {
     $null = az account show 2>$null
     return ($LASTEXITCODE -eq 0)
@@ -134,13 +124,10 @@ function Invoke-AzDevOpsSmokeQuery {
 
 function az-Test-AzDevOpsAuth {
     if (-not (Test-AzDevOpsCliPresent)) {
-        return $false 
-    }
-    if ((Get-AzDevOpsMissingEnvVars).Count -gt 0) {
-        return $false 
+        return $false
     }
     if ($null -eq (Invoke-AzDevOpsSmokeQuery)) {
-        return $false 
+        return $false
     }
 
     return $true
@@ -230,23 +217,23 @@ function az-Confirm-AzDevOpsExtension {
 
 
 function az-Confirm-AzDevOpsEnvVars {
-    $missing = Get-AzDevOpsMissingEnvVars
-    if ($missing.Count -gt 0) {
-        Write-Host "  X Missing env vars: $($missing -join ', ')" -ForegroundColor Red
-        Write-Host ""
-        Write-Host "    Add this block to your `$profile and reload (open a new terminal):" -ForegroundColor Yellow
-        Write-Host "    ---------------------------------------------------------------"
-        Write-Host "    `$env:AZ_DEVOPS_ORG = 'https://dev.azure.com/myorg'"
-        Write-Host "    `$env:AZ_PROJECT    = 'My Project'"
-        Write-Host "    `$env:AZ_USER_EMAIL = 'user@example.com'"
-        Write-Host "    `$env:AZ_AREA       = 'My Project\My Team'"
-        Write-Host "    `$env:AZ_ITERATION  = 'My Project\Sprint 42'"
-        Write-Host "    ---------------------------------------------------------------"
-        Write-Host "    See README section 'Azure DevOps work-item shortcuts' for details."
-        return New-AzDevOpsStepResult -Ok $false -FailMessage 'env vars missing'
+    # Org and project come from `az devops configure --defaults` (the user's
+    # Microsoft profile). AZ_USER_EMAIL and AZ_AREA are optional but improve
+    # the mentions WIQL and hierarchy query respectively.
+    if ($env:AZ_USER_EMAIL) {
+        Write-Host "  OK  AZ_USER_EMAIL = $env:AZ_USER_EMAIL" -ForegroundColor Green
+    } else {
+        Write-Host "  --  AZ_USER_EMAIL not set (mentions WIQL will use '@' fallback)" -ForegroundColor DarkYellow
+        Write-Host "      Add to `$profile: `$env:AZ_USER_EMAIL = 'you@example.com'"
     }
-    Write-Host "  OK  AZ_DEVOPS_ORG = $env:AZ_DEVOPS_ORG" -ForegroundColor Green
-    Write-Host "  OK  AZ_PROJECT    = $env:AZ_PROJECT" -ForegroundColor Green
+
+    if ($env:AZ_AREA) {
+        Write-Host "  OK  AZ_AREA = $env:AZ_AREA" -ForegroundColor Green
+    } else {
+        Write-Host "  --  AZ_AREA not set (hierarchy WIQL token {{AZ_AREA}} will need manual edit)" -ForegroundColor DarkYellow
+        Write-Host "      Add to `$profile: `$env:AZ_AREA = 'My Project\My Team'"
+    }
+
     return New-AzDevOpsStepResult -Ok $true
 }
 
@@ -327,13 +314,26 @@ function az-Confirm-AzDevOpsLogin {
 
 
 function az-Set-AzDevOpsDefaults {
-    $configOutput = az devops configure --defaults "organization=$env:AZ_DEVOPS_ORG" "project=$env:AZ_PROJECT" 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "  X az devops configure failed" -ForegroundColor Red
-        Write-Host "    $configOutput"
-        return New-AzDevOpsStepResult -Ok $false -FailMessage 'configure failed'
+    # Shows the currently-configured az devops defaults (stored in the user's
+    # Microsoft profile via `az devops configure --defaults`). Guides the user
+    # to set them if either is missing; the smoke query in the next step will
+    # surface auth/scope failures if defaults aren't pointing at a valid org.
+    $defaults = Get-AzDevOpsConfiguredDefaults
+
+    if ($defaults.Org) {
+        Write-Host "  OK  organization = $($defaults.Org)" -ForegroundColor Green
+    } else {
+        Write-Host "  !   organization not configured" -ForegroundColor Yellow
+        Write-Host "      Run: az devops configure --defaults organization=https://dev.azure.com/myorg"
     }
-    Write-Host "  OK  Defaults set: org=$env:AZ_DEVOPS_ORG project=$env:AZ_PROJECT" -ForegroundColor Green
+
+    if ($defaults.Project) {
+        Write-Host "  OK  project = $($defaults.Project)" -ForegroundColor Green
+    } else {
+        Write-Host "  !   project not configured" -ForegroundColor Yellow
+        Write-Host "      Run: az devops configure --defaults project=`"My Project`""
+    }
+
     return New-AzDevOpsStepResult -Ok $true
 }
 
@@ -347,7 +347,7 @@ function az-Confirm-AzDevOpsQueryFiles {
         foreach ($entry in $newlySeeded) {
             Write-Host "  OK  Wrote default $($entry.Name).wiql to $($entry.Path)" -ForegroundColor Green
         }
-        Write-Host "      Edit these files to customize what az-Sync-AzDevOpsCache pulls into hierarchy.json." -ForegroundColor DarkGray
+        Write-Host "      Edit these files to customize what az-Sync-AzDevOpsCache fetches." -ForegroundColor DarkGray
     } else {
         Write-Host "  OK  Query files at $($init.Paths.QueriesDir)" -ForegroundColor Green
     }
@@ -358,11 +358,11 @@ function az-Confirm-AzDevOpsQueryFiles {
 
 
 function az-Open-AzDevOpsHierarchyWiqls {
-    # Opens each of the user-machine hierarchy WIQL files (epics, features,
-    # user-stories) in the OS default editor. Defensively seeds the defaults
-    # via Initialize-AzDevOpsQueryFiles so a fresh machine that skipped
-    # az-Connect-AzDevOps can still discover and customize the queries in one
-    # step (no "file not found" detour).
+    # Opens all user-machine WIQL files (epics, features, user-stories,
+    # assigned, mentions) in the OS default editor. Defensively seeds the
+    # defaults via Initialize-AzDevOpsQueryFiles so a fresh machine that
+    # skipped az-Connect-AzDevOps can still discover and customize the
+    # queries in one step (no "file not found" detour).
     $init = Initialize-AzDevOpsQueryFiles
 
     foreach ($entry in $init.Seeded) {
@@ -406,7 +406,7 @@ function az-Connect-AzDevOps {
     $steps = @(
         @{ Num = 1; Name = 'Azure CLI'; Action = { az-Confirm-AzDevOpsCli } },
         @{ Num = 2; Name = 'azure-devops extension'; Action = { az-Confirm-AzDevOpsExtension } },
-        @{ Num = 3; Name = 'Profile environment variables'; Action = { az-Confirm-AzDevOpsEnvVars } },
+        @{ Num = 3; Name = 'Optional profile env vars (AZ_USER_EMAIL, AZ_AREA)'; Action = { az-Confirm-AzDevOpsEnvVars } },
         @{ Num = 4; Name = 'Project map (multi-project)'; Action = { az-Confirm-AzDevOpsProjectMap } },
         @{ Num = 5; Name = 'Azure login session'; Action = { az-Confirm-AzDevOpsLogin } },
         @{ Num = 6; Name = 'Configure az devops defaults'; Action = { az-Set-AzDevOpsDefaults } },
@@ -426,7 +426,8 @@ function az-Connect-AzDevOps {
     }
 
     Write-Host ""
-    Write-Host "READY - Azure DevOps connection verified for project=$env:AZ_PROJECT in org=$env:AZ_DEVOPS_ORG" -ForegroundColor Green
+    $defaults = Get-AzDevOpsConfiguredDefaults
+    Write-Host "READY - Azure DevOps connection verified (org=$($defaults.Org) project=$($defaults.Project))" -ForegroundColor Green
 }
 
 
@@ -452,7 +453,7 @@ function Get-AzDevOpsAppRoot {
 #                     [System.History] (best-effort - WIQL has no first-class
 #                     "@-mention" predicate)
 #   hierarchy.json  - WorkItemLinks tree of Epic/Feature/User Story rows
-#                     in $env:AZ_PROJECT (parent->child Hierarchy-Forward)
+#                     in the configured project (parent->child Hierarchy-Forward)
 #   last-sync.json  - { Timestamp (round-trip), Counts: {dataset: rows} }
 #   sync.log        - append-only, rotated to sync.log.1 at ~1 MB
 #
@@ -537,7 +538,8 @@ function Initialize-AzDevOpsCacheDir {
 #                  projects without forcing users to hard-code their own area.
 # ---------------------------------------------------------------------------
 
-$script:AzDevOpsAreaToken = '{{AZ_AREA}}'
+$script:AzDevOpsAreaToken      = '{{AZ_AREA}}'
+$script:AzDevOpsUserEmailToken = '{{AZ_USER_EMAIL}}'
 
 $script:AzDevOpsDefaultEpicsWiql = @"
 Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.AreaPath] UNDER '{{AZ_AREA}}' AND [System.WorkItemType] IN GROUP 'Microsoft.EpicCategory'
@@ -551,6 +553,14 @@ $script:AzDevOpsDefaultUserStoriesWiql = @"
 Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.AreaPath], [System.Parent] From WorkItems Where [System.AreaPath] UNDER '{{AZ_AREA}}' AND [System.WorkItemType] IN GROUP 'Microsoft.RequirementCategory'
 "@
 
+$script:AzDevOpsDefaultAssignedWiql = @"
+Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.ChangedDate], [Microsoft.VSTS.Common.Priority] From WorkItems Where [System.AssignedTo] = @Me
+"@
+
+$script:AzDevOpsDefaultMentionsWiql = @"
+Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.ChangedBy], [System.AreaPath], [System.ChangedDate] From WorkItems Where [System.History] Contains '{{AZ_USER_EMAIL}}'
+"@
+
 
 function Get-AzDevOpsConfigPaths {
     $configDir  = Join-Path (Get-AzDevOpsAppRoot) 'config'
@@ -562,16 +572,18 @@ function Get-AzDevOpsConfigPaths {
         EpicsQuery       = Join-Path $queriesDir 'epics.wiql'
         FeaturesQuery    = Join-Path $queriesDir 'features.wiql'
         UserStoriesQuery = Join-Path $queriesDir 'user-stories.wiql'
+        AssignedQuery    = Join-Path $queriesDir 'assigned.wiql'
+        MentionsQuery    = Join-Path $queriesDir 'mentions.wiql'
     }
 }
 
 
-function Get-AzDevOpsHierarchyQueryDefaults {
-    # Single source of truth for the three hierarchy-tier WIQL files: their
-    # logical name (also the -Name parameter for Get-AzDevOpsWiql), their
-    # on-disk path, and the default WIQL seeded on first run. Initialize,
-    # read, sync, and the user-facing open shortcut all iterate this list,
-    # so adding a fourth tier later is a one-place edit.
+function Get-AzDevOpsQueryDefaults {
+    # Single source of truth for all WIQL files: their logical name (also the
+    # -Name parameter for Get-AzDevOpsWiql), their on-disk path, and the
+    # default WIQL seeded on first run. Initialize, read, sync, and the
+    # user-facing open shortcut all iterate this list, so adding a new query
+    # later is a one-place edit.
     $paths = Get-AzDevOpsConfigPaths
 
     $defaults = @(
@@ -589,6 +601,16 @@ function Get-AzDevOpsHierarchyQueryDefaults {
             Name    = 'user-stories'
             Path    = $paths.UserStoriesQuery
             Default = $script:AzDevOpsDefaultUserStoriesWiql
+        },
+        [PSCustomObject]@{
+            Name    = 'assigned'
+            Path    = $paths.AssignedQuery
+            Default = $script:AzDevOpsDefaultAssignedWiql
+        },
+        [PSCustomObject]@{
+            Name    = 'mentions'
+            Path    = $paths.MentionsQuery
+            Default = $script:AzDevOpsDefaultMentionsWiql
         }
     )
 
@@ -605,7 +627,7 @@ function Initialize-AzDevOpsQueryFiles {
     $paths = Get-AzDevOpsConfigPaths
     New-AzDevOpsDirectoryIfMissing -Path $paths.QueriesDir
 
-    $defaults = Get-AzDevOpsHierarchyQueryDefaults
+    $defaults = Get-AzDevOpsQueryDefaults
     $seeded = New-Object System.Collections.Generic.List[PSCustomObject]
 
     foreach ($entry in $defaults) {
@@ -630,9 +652,8 @@ function Initialize-AzDevOpsQueryFiles {
 
 
 function Get-AzDevOpsHierarchyQueryNames {
-    $defaults = Get-AzDevOpsHierarchyQueryDefaults
-    $names = @($defaults | ForEach-Object { $_.Name })
-    return $names
+    $hierarchyNames = @('epics', 'features', 'user-stories')
+    return $hierarchyNames
 }
 
 
@@ -640,28 +661,38 @@ function Get-AzDevOpsWiql {
     # Reads a named WIQL file from the user-machine config dir, substituting
     # known placeholder tokens. Defensively seeds defaults so callers don't
     # need to remember to call Initialize-AzDevOpsQueryFiles first.
+    #
+    # Tokens substituted at read time:
+    #   {{AZ_AREA}}       - $env:AZ_AREA (throws if missing for area-filtered queries)
+    #   {{AZ_USER_EMAIL}} - "@$env:AZ_USER_EMAIL" when set, otherwise "@" fallback
     param(
         [Parameter(Mandatory)]
-        [ValidateSet('epics', 'features', 'user-stories')]
+        [ValidateSet('epics', 'features', 'user-stories', 'assigned', 'mentions')]
         [string] $Name
     )
 
-    $init = Initialize-AzDevOpsQueryFiles
-
+    $init  = Initialize-AzDevOpsQueryFiles
     $entry = $init.Seeded | Where-Object { $_.Name -eq $Name } | Select-Object -First 1
-    $path = $entry.Path
-
-    if ([string]::IsNullOrWhiteSpace($env:AZ_AREA)) {
-        throw "Get-AzDevOpsWiql: `$env:AZ_AREA must be set to substitute $script:AzDevOpsAreaToken in $path."
-    }
+    $path  = $entry.Path
 
     $rawContent = Get-Content -LiteralPath $path -Raw
-    $raw = $rawContent.Trim()
+    $wiql       = $rawContent.Trim()
 
-    # Escape single quotes for WIQL string-literal safety — area paths with apostrophes
-    # would otherwise break out of the [System.AreaPath] UNDER '...' literal.
-    $areaEscaped = $env:AZ_AREA.Replace("'", "''")
-    $wiql = $raw.Replace($script:AzDevOpsAreaToken, $areaEscaped)
+    if ($wiql -match [regex]::Escape($script:AzDevOpsAreaToken)) {
+        if ([string]::IsNullOrWhiteSpace($env:AZ_AREA)) {
+            throw "Get-AzDevOpsWiql: `$env:AZ_AREA must be set to substitute $script:AzDevOpsAreaToken in $path."
+        }
+
+        # Escape single quotes — area paths with apostrophes would otherwise
+        # break out of the [System.AreaPath] UNDER '...' WIQL literal.
+        $areaEscaped = $env:AZ_AREA.Replace("'", "''")
+        $wiql        = $wiql.Replace($script:AzDevOpsAreaToken, $areaEscaped)
+    }
+
+    if ($wiql -match [regex]::Escape($script:AzDevOpsUserEmailToken)) {
+        $emailValue = if ($env:AZ_USER_EMAIL) { "@$env:AZ_USER_EMAIL" } else { '@' }
+        $wiql       = $wiql.Replace($script:AzDevOpsUserEmailToken, $emailValue)
+    }
 
     return $wiql
 }
@@ -822,27 +853,15 @@ function Write-AzDevOpsSyncStderr {
 function Get-AzDevOpsSyncDatasets {
     param([Parameter(Mandatory)] [PSCustomObject] $Paths)
 
-    # Mentions: WIQL has no first-class @-mention predicate. Best effort is
-    # [System.History] Contains 'literal'. Prefer "@<user-email>" when set,
-    # otherwise fall back to a bare "@" - the latter is noisy but at least
-    # populates the cache shape so downstream commands keep working.
-    $mentionsToken = if ($env:AZ_USER_EMAIL) { "@$env:AZ_USER_EMAIL" } else { '@' }
+    # Assigned and mentions WIQLs are read from user-editable files under
+    # ~/.bashcuts-az-devops-app/config/queries/ (assigned.wiql / mentions.wiql).
+    # Hierarchy is built from three per-tier WIQL files (epics.wiql /
+    # features.wiql / user-stories.wiql). Invoke-AzDevOpsHierarchyQueries runs
+    # each WIQL sequentially and merges results into hierarchy.json.
+    $assignedWiql = Get-AzDevOpsWiql -Name 'assigned'
+    $mentionsWiql = Get-AzDevOpsWiql -Name 'mentions'
 
-    $assignedWiql = 'Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.IterationPath], [System.ChangedDate], [Microsoft.VSTS.Common.Priority] From WorkItems Where [System.AssignedTo] = @Me'
-    $mentionsWiql = "Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.ChangedBy], [System.AreaPath], [System.ChangedDate] From WorkItems Where [System.History] Contains '$mentionsToken'"
-    # Hierarchy is built from three per-tier WIQL files under
-    # ~/.bashcuts-az-devops-app/config/queries/ (epics.wiql / features.wiql /
-    # user-stories.wiql). Invoke-AzDevOpsHierarchyQueries runs each WIQL
-    # sequentially via az boards query, then merges the work items into a
-    # single JSON array so hierarchy.json keeps its existing flat-list shape
-    # (Read-AzDevOpsHierarchyCache + az-Show-AzDevOpsTree are unchanged).
-    # Each WIQL filters by [System.AreaPath] UNDER '{{AZ_AREA}}' and one
-    # category group, which sidesteps the previous combined IN-GROUP query
-    # that returned partial results on larger projects. Project scope is
-    # still supplied by --project on each az invocation (Invoke-AzDevOpsAzJson
-    # injects it from $env:AZ_PROJECT).
-
-    $rowCounter = { param($parsed) @($parsed).Count }
+    $rowCounter  = { param($parsed) @($parsed).Count }
     $treeCounter = { param($parsed) Measure-AzDevOpsClassificationNodes -Node $parsed }
 
     $datasets = @(
@@ -857,7 +876,7 @@ function Get-AzDevOpsSyncDatasets {
         },
         @{
             Name     = 'mentions'
-            Label    = "System.History Contains '$mentionsToken'"
+            Label    = 'System.History Contains email (from mentions.wiql)'
             Path     = $Paths.Mentions
             Fetch    = { Invoke-AzDevOpsBoardsQuery -Wiql $mentionsWiql }.GetNewClosure()
             Counter  = $rowCounter
@@ -1562,17 +1581,19 @@ function Find-AzDevOpsCachedWorkItem {
 
 function Get-AzDevOpsWorkItemUrlPrefix {
     # Quiet URL-prefix builder. Returns "$org/$projectEnc/_workitems/edit/" when
-    # both env vars are set; returns '' when either is missing. Designed for
-    # callers that build URLs for many ids in a loop (e.g. Out-ConsoleGridView
-    # row projections in Get-AzDevOpsTreeRows) so the prefix is computed once
-    # instead of per row, and so per-row use does not pollute $LASTEXITCODE.
-    if (-not $env:AZ_DEVOPS_ORG -or -not $env:AZ_PROJECT) {
+    # az devops defaults are configured; returns '' when either is missing.
+    # Designed for callers that build URLs for many ids in a loop (e.g.
+    # Out-ConsoleGridView row projections in Get-AzDevOpsTreeRows) so the prefix
+    # is computed once instead of per row, and so per-row use does not pollute
+    # $LASTEXITCODE.
+    $defaults = Get-AzDevOpsConfiguredDefaults
+    if (-not $defaults.Org -or -not $defaults.Project) {
         return ''
     }
 
-    $org = $env:AZ_DEVOPS_ORG.TrimEnd('/')
-    $projectEnc = [uri]::EscapeDataString($env:AZ_PROJECT)
-    $prefix = "$org/$projectEnc/_workitems/edit/"
+    $org        = $defaults.Org.TrimEnd('/')
+    $projectEnc = [uri]::EscapeDataString($defaults.Project)
+    $prefix     = "$org/$projectEnc/_workitems/edit/"
     return $prefix
 }
 
@@ -1602,7 +1623,7 @@ function Open-AzDevOpsWorkItemUrl {
 
     $url = Get-AzDevOpsWorkItemUrl -Id $Id
     if ($null -eq $url) {
-        Write-Host "AZ_DEVOPS_ORG and AZ_PROJECT must both be set in your `$profile." -ForegroundColor Red
+        Write-Host "az devops defaults not configured. Run: az devops configure --defaults organization=<url> project=<name>" -ForegroundColor Red
         $global:LASTEXITCODE = 1
         return
     }
@@ -3314,7 +3335,6 @@ function Invoke-AzDevOpsWorkItemCreate {
         -Title       $Title `
         -Description $Description `
         -AssignedTo  $env:AZ_USER_EMAIL `
-        -Project     $env:AZ_PROJECT `
         -Area        $Area `
         -Iteration   $Iteration `
         -Fields      $fields
@@ -3342,12 +3362,10 @@ function Invoke-AzDevOpsWorkItemCreate {
 
     $newId = [int]$created.id
 
-    $url = if ($env:AZ_DEVOPS_ORG -and $env:AZ_PROJECT) {
-        $org = $env:AZ_DEVOPS_ORG.TrimEnd('/')
-        $projectEnc = [uri]::EscapeDataString($env:AZ_PROJECT)
-        "$org/$projectEnc/_workitems/edit/$newId"
-    }
-    else {
+    $urlPrefix = Get-AzDevOpsWorkItemUrlPrefix
+    $url = if ($urlPrefix) {
+        "$urlPrefix$newId"
+    } else {
         $null
     }
 
@@ -4006,7 +4024,7 @@ function az-New-AzDevOpsFeatureStories {
 # Schema directory: $HOME/.bashcuts-az-devops-app/schema/   (separate from the
 #                   auto-managed cache/ subtree under the same parent)
 # Schema file:      schema-<orgslug>.json                   (per-org keyed off
-#                   $env:AZ_DEVOPS_ORG; falls back to schema.json when unset)
+#                   the configured organization URL; falls back to schema.json when unset)
 #
 # Public functions:
 #   az-Get-AzDevOpsSchema          - print summary table of the configured
@@ -4087,14 +4105,15 @@ function Get-AzDevOpsSchemaSystemRefs {
 
 
 function Get-AzDevOpsSchemaOrgSlug {
-    # Per-org keying: the path-tail segment of $env:AZ_DEVOPS_ORG, lowercased
-    # and reduced to [a-z0-9-]. Returns $null when the env var is unset, so
-    # Get-AzDevOpsSchemaPaths can fall back to the unsuffixed schema.json.
-    if (-not $env:AZ_DEVOPS_ORG) {
+    # Per-org keying: the path-tail segment of the configured organization URL,
+    # lowercased and reduced to [a-z0-9-]. Returns $null when org is not
+    # configured, so Get-AzDevOpsSchemaPaths falls back to unsuffixed schema.json.
+    $defaults = Get-AzDevOpsConfiguredDefaults
+    if (-not $defaults.Org) {
         return $null
     }
 
-    $segment = ($env:AZ_DEVOPS_ORG.TrimEnd('/') -split '/')[-1]
+    $segment = ($defaults.Org.TrimEnd('/') -split '/')[-1]
     if (-not $segment) {
         return $null
     }


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Changes](#changes) | ✅ 3 files |
| [Test Plan](#test-plan) | 0/6 |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4446839013) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4446852256) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4446848211) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4446859042) |
| 🗺️ AzDO Diagrams Check | ✅ UPDATED — [View](#issuecomment-4446901099) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4446871798) |
| 📚 Docs Check | ✅ CURRENT — [View](#issuecomment-4446865718) |
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

`Get-AzDevOpsConfiguredDefaults` is the new shared foundation: it reads org and project from `az devops configure --defaults` (the user's Microsoft profile) on first call, caches the result per session in a global variable, and returns it to every consumer that previously read `$env:AZ_DEVOPS_ORG`/`$env:AZ_PROJECT` directly. `Get-AzDevOpsQueryDefaults` expands the WIQL file registry from three hierarchy tiers to all five query files, making `assigned.wiql` and `mentions.wiql` user-editable alongside the existing ones.

```mermaid
flowchart TD
    %% New public functions
    GetDefaults(["Get-AzDevOpsConfiguredDefaults"]):::pub
    QueryDefs(["Get-AzDevOpsQueryDefaults"]):::pub

    %% Cache decision
    Cache{"cached?"}
    ReturnCached(["return cached result"])
    AzCli["az devops configure --list"]:::io
    ParseLines["parse org= and project= lines"]
    CacheStore[("global cache\nOrg · Project")]:::io

    %% Consumers (pre-existing, now use the new helper)
    Consumers["URL prefix · schema slug\naz devops invoke route-params\nwork-item creation"]:::priv

    %% Project switcher cache invalidation
    UseProject["az-Use-AzDevOpsProject\n(updated — reads from map config)"]:::priv

    %% WIQL file registry
    FiveFiles[("5 .wiql files\nepics · features · user-stories\nassigned · mentions")]:::io
    WiqlReader["Get-AzDevOpsWiql (expanded)\n{{AZ_AREA}} · {{AZ_USER_EMAIL}} tokens"]:::priv

    %% Get-AzDevOpsConfiguredDefaults flow
    GetDefaults --> Cache
    Cache -- hit --> ReturnCached
    Cache -- miss --> AzCli --> ParseLines --> CacheStore --> ReturnCached
    ReturnCached --> Consumers

    %% Cache invalidation on project switch
    UseProject -.clears on switch.-> CacheStore

    %% Get-AzDevOpsQueryDefaults flow
    QueryDefs --> FiveFiles
    FiveFiles --> WiqlReader

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

- Removes `AZ_DEVOPS_ORG` and `AZ_PROJECT` as required profile env vars — org/project now come from `az devops configure --defaults` stored in the user's Microsoft profile
- Moves the `assigned` and `mentions` inline WIQL strings out of code and into user-editable `.wiql` files alongside the three hierarchy tier files
- Adds `Get-AzDevOpsConfiguredDefaults` (session-cached) to read current az devops defaults wherever org/project values are needed (URL builders, schema keying, `az devops invoke` route-params)
- Cache invalidation wired into `az-Use-AzDevOpsProject` so switching projects refreshes the cached values

## Changes

- `powcuts_by_cli/azdevops_db.ps1` — new `Get-AzDevOpsConfiguredDefaults`; removed org/project auto-injection from `Invoke-AzDevOpsAzJson` and `-SkipProjectFlag`
- `powcuts_by_cli/azdevops_workitems.ps1` — removed `Get-AzDevOpsMissingEnvVars`; repurposed env-var confirm/set steps; moved assigned + mentions WIQLs to files; expanded `Get-AzDevOpsQueryDefaults` to cover all 5 query files; added `{{AZ_USER_EMAIL}}` token substitution
- `powcuts_by_cli/azdevops_projects.ps1` — project switcher reads org/project from map config directly; clears `Get-AzDevOpsConfiguredDefaults` cache after switching

## Test Plan

- [ ] Run `az-Connect-AzDevOps` on a fresh machine — step 3 shows `AZ_USER_EMAIL`/`AZ_AREA` hints; step 6 shows current az defaults
- [ ] With `az devops configure --defaults` set but no profile env vars for org/project, run `az-Sync-AzDevOpsCache` — all five datasets sync
- [ ] Run `az-Open-AzDevOpsHierarchyWiqls` — all five `.wiql` files open (assigned + mentions newly seeded)
- [ ] Edit `assigned.wiql` to add a filter; re-run `az-Sync-AzDevOpsCache` — custom WIQL is used
- [ ] Call `az-Use-AzDevOpsProject -Name X` then immediately call `Get-AzDevOpsConfiguredDefaults` — returns the newly-switched org/project (cache cleared)
- [ ] Open a work item URL (`az-Open-AzDevOpsWorkItem`) — URL built correctly from configured defaults

🤖 Generated with [Claude Code](https://claude.ai/claude-code)