### PR TITLE
fix(timer): post full debrief body by switching join to HTML <br/>

### DIFF
--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -324,6 +324,15 @@ function Format-TimerCommentBody {
     # Compose the discussion-comment text. Header reflects outcome; body has
     # labeled Debrief and Next sections; a trailing attribution line lets a
     # reader trace the comment back to this command.
+    #
+    # The body is a SINGLE physical line with HTML <br/> separators. On
+    # Windows, PowerShell launches az.cmd via cmd.exe /c, which truncates the
+    # `--discussion` value at the first CRLF — so a `"`r`n"`-joined body
+    # arrived at Azure DevOps as only the header line. The AzDO Discussion
+    # field stores HTML, so <br/> renders as a visible line break in the UI
+    # and keeps the entire body intact through the shell hand-off. Italic
+    # accents use <em> for the same reason — Markdown `_..._` would render
+    # as literal underscores in an HTML field.
     param(
         [Parameter(Mandatory)] [bool]   $Interrupted,
         [Parameter(Mandatory)] [int]    $ElapsedSeconds,
@@ -349,7 +358,7 @@ function Format-TimerCommentBody {
 
     $lines = @(
         $header,
-        "_$timestamp_",
+        "<em>$timestamp</em>",
         '',
         "$iconMemo Debrief:",
         $Debrief,
@@ -357,10 +366,10 @@ function Format-TimerCommentBody {
         "$iconRocket Next:",
         $Next,
         '',
-        '_via bashcuts Start-TimerSession_'
+        '<em>via bashcuts Start-TimerSession</em>'
     )
 
-    $body = $lines -join "`r`n"
+    $body = $lines -join '<br/>'
     return $body
 }
 


### PR DESCRIPTION
<!-- toc:start -->
## Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #86 |
| [Changes](#changes) | ✅ 1 file |
| [Test Plan](#test-plan) | 0/5 (manual, post-merge) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE _(no bash files in diff)_ — [View](https://github.com/jdschleicher/bashcuts/pull/87#issuecomment-4482476401) |
| 💠 PowerShell Engineer Review | ✅ APPROVE _(2 LOW)_ — [View](https://github.com/jdschleicher/bashcuts/pull/87#issuecomment-4482479859) |
| 🛡️ Security Audit | ✅ PASS _(1 LOW — HTML-escape advisory, deferred per #86 out-of-scope)_ — [View](https://github.com/jdschleicher/bashcuts/pull/87#issuecomment-4482483525) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE _(1 LOW)_ — [View](https://github.com/jdschleicher/bashcuts/pull/87#issuecomment-4482481140) |
| 📚 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/87#issuecomment-4482490902) |
| ✅ Criteria Check | ✅ PASS _(3/3 automated, 1 skipped — pwsh n/a, 2 manual)_ — [View](https://github.com/jdschleicher/bashcuts/pull/87#issuecomment-4482495399) |
| 📐 AzDO Diagrams Check | ⏭️ N/A _(no AzDO source files changed; calls `Add-AzDevOpsDiscussionComment` via existing wrapper)_ |
<!-- toc:end -->

## Summary

Fixes the AzDO discussion comment posted by `Start-TimerSession` losing everything past the status header. On Windows, PowerShell launches `az.cmd` via `cmd.exe /c`, which truncates the `--discussion <body>` value at the first CRLF — so a body joined with `` "`r`n" `` arrived at `az` as only the `✅ Pomodoro complete — NN:00` (or `⚠️ interrupted`) header, with the timestamp / debrief / next-step / attribution all silently dropped.

Now the body is built as a single physical line with HTML `<br/>` separators (and `<em>` instead of Markdown `_..._` italics) so it survives the shell hand-off and still renders as multi-line text in the HTML-backed AzDO Discussion field.

## Issue

Closes #86

## Changes

- `powcuts_by_cli/pow_timer.ps1` — `Format-TimerCommentBody` joins lines with `<br/>` instead of `` "`r`n" ``; italic markers switched to `<em>...</em>`; added a code comment recording WHY (cmd.exe CRLF truncation + HTML-backed Discussion field) so the next reader doesn't "fix" it back

## Test Plan

- [ ] Open a fresh PowerShell terminal — no parse errors from `pow_timer.ps1`
- [ ] `Start-TimerSession -Minutes 1` → wait out the timer → type debrief + next-step
- [ ] Open the chosen work item in the AzDO web UI → verify the discussion comment shows the FULL body: status header, italic timestamp, `📝 Debrief:` + your text, `🚀 Next:` + your text, italic attribution — all with visible line breaks between sections
- [ ] Repeat with Esc-interrupt mid-timer → confirm the `⚠️ Session interrupted at MM:SS of NN:00` header and the same full body shape
- [ ] (Optional) `pwsh -NoProfile` parse `powcuts_by_cli/pow_timer.ps1` returns no errors

https://claude.ai/code/session_01CZ8p5nARN62dk5ZuxJeFCp