### PR TITLE
fix(azdevops): handle empty hierarchy.json cleanly + actionable diagnostic

### DIFF
--- a/powcuts_by_cli/azdevops_create_pickers.ps1
+++ b/powcuts_by_cli/azdevops_create_pickers.ps1
@@ -161,11 +161,27 @@ function Read-AzDevOpsParentPick {
     )
 
     $closedStates = Get-AzDevOpsClosedStates
+
+    $orphanLabel = "(no parent - orphan $ChildLabel)"
+
+    # Distinguish "cache is entirely empty" from "cache is populated but
+    # no matching ${ParentType}s" - the former almost always means the
+    # WIQL queries returned 0 rows (wrong AZ_AREA, custom process
+    # template, edited WIQL) and the user needs an actionable hint
+    # rather than a silent orphan path.
+    $hierarchyCount = @($Hierarchy).Count
+    if ($hierarchyCount -eq 0) {
+        Write-Host "hierarchy.json is empty (0 rows total) - the WIQL queries returned no work items." -ForegroundColor Yellow
+        Write-Host "  Check `$env:AZ_AREA = '$env:AZ_AREA'" -ForegroundColor Yellow
+        Write-Host "  Edit WIQLs:    az-Open-AzDevOpsHierarchyWiqls" -ForegroundColor Yellow
+        Write-Host "  Re-sync cache: az-Sync-AzDevOpsCache" -ForegroundColor Yellow
+        Write-Host "  $ChildLabel will be created as an orphan." -ForegroundColor Yellow
+        return 0
+    }
+
     $candidates = @($Hierarchy |
         Where-Object { $_.Type -eq $ParentType -and $_.State -notin $closedStates } |
         Sort-Object Id)
-
-    $orphanLabel = "(no parent - orphan $ChildLabel)"
 
     if ($candidates.Count -eq 0) {
         Write-Host "(no active ${ParentType}s in hierarchy.json - $ChildLabel will be orphaned)" -ForegroundColor Yellow

--- a/powcuts_by_cli/azdevops_paths.ps1
+++ b/powcuts_by_cli/azdevops_paths.ps1
@@ -360,22 +360,19 @@ function Invoke-AzDevOpsHierarchyQueries {
     # entire dataset opaquely. The cost is a string concat over per-item
     # JSON fragments - negligible at the tens-of-thousands-of-rows scale a
     # WIQL hierarchy returns.
-    $mergedJson = if ($merged.Count -eq 0) {
-        '[]'
-    }
-    else {
+    if ($merged.Count -eq 0) {
+        $mergedJson = '[]'
+    } else {
         $perItemJson = New-Object System.Collections.Generic.List[string]
         $rowIndex = 0
         foreach ($row in $merged) {
             try {
-                $rowJson = ConvertTo-Json -InputObject $row -Depth 10 -Compress
+                $rowJson = $row | ConvertTo-Json -Depth 10 -Compress
                 $perItemJson.Add($rowJson)
-            }
-            catch {
+            } catch {
                 $rowId = if ($row.id) {
                     $row.id
-                }
-                else {
+                } else {
                     "(row index $rowIndex)"
                 }
                 $perItemErrEnvelope = [PSCustomObject]@{
@@ -387,7 +384,7 @@ function Invoke-AzDevOpsHierarchyQueries {
             }
             $rowIndex++
         }
-        '[' + ($perItemJson -join ',') + ']'
+        $mergedJson = '[' + ($perItemJson -join ',') + ']'
     }
 
     $envelope = [PSCustomObject]@{

--- a/powcuts_by_cli/azdevops_paths.ps1
+++ b/powcuts_by_cli/azdevops_paths.ps1
@@ -349,7 +349,46 @@ function Invoke-AzDevOpsHierarchyQueries {
     # AsArray=$true (the hierarchy descriptor does). The -Depth 10 here is
     # only for the in-flight envelope passed back to that helper; downstream
     # depth is governed by the descriptor's JsonDepth.
-    $mergedJson = ConvertTo-Json -InputObject @($merged) -Depth 10 -AsArray
+    #
+    # Per-item ConvertTo-Json (rather than one whole-collection call with
+    # -AsArray) dodges a "argument types do not match" reflection failure
+    # observed when ConvertTo-Json walks a heterogeneous List[object] of
+    # az-boards-query rows whose property shapes differ across tiers
+    # (System.Parent null for Epics vs int for Features/User Stories, plus
+    # variable _links sub-objects). Serializing each row in isolation also
+    # surfaces the offending row in the catch block instead of failing the
+    # entire dataset opaquely. The cost is a string concat over per-item
+    # JSON fragments - negligible at the tens-of-thousands-of-rows scale a
+    # WIQL hierarchy returns.
+    $mergedJson = if ($merged.Count -eq 0) {
+        '[]'
+    }
+    else {
+        $perItemJson = New-Object System.Collections.Generic.List[string]
+        $rowIndex = 0
+        foreach ($row in $merged) {
+            try {
+                $rowJson = ConvertTo-Json -InputObject $row -Depth 10 -Compress
+                $perItemJson.Add($rowJson)
+            }
+            catch {
+                $rowId = if ($row.id) {
+                    $row.id
+                }
+                else {
+                    "(row index $rowIndex)"
+                }
+                $perItemErrEnvelope = [PSCustomObject]@{
+                    Json     = ''
+                    Error    = "ConvertTo-Json failed on row $rowId : $($_.Exception.Message)"
+                    ExitCode = 1
+                }
+                return $perItemErrEnvelope
+            }
+            $rowIndex++
+        }
+        '[' + ($perItemJson -join ',') + ']'
+    }
 
     $envelope = [PSCustomObject]@{
         Json     = $mergedJson

--- a/powcuts_by_cli/azdevops_views.ps1
+++ b/powcuts_by_cli/azdevops_views.ps1
@@ -161,6 +161,17 @@ function Read-AzDevOpsJsonCache {
         return $null
     }
 
+    # When the cached JSON is an empty array [], ConvertFrom-Json's
+    # array output unwraps through the pipeline to zero items and $raw
+    # lands as $null. Without this guard, $null | ForEach-Object would
+    # still invoke the converter once with $_ = $null and trip the
+    # converter's [Parameter(Mandatory)] guard with a confusing
+    # "Cannot bind argument to parameter 'Raw' because it is null"
+    # error - surface a clean empty cache instead.
+    if ($null -eq $raw) {
+        return @()
+    }
+
     $items = @($raw | ForEach-Object { & $Converter $_ })
     return $items
 }


### PR DESCRIPTION
## 📑 Table of Contents

| Section / Report | Verdict | Link |
|---|---|---|
| Summary | — | [#summary](#summary) |
| Issue | — | [#issue](#issue) |
| Root Cause | — | [#root-cause](#root-cause) |
| Changes | — | [#changes](#changes) |
| Test Plan | — | [#test-plan](#test-plan) |
| Shell Parity | — | [#shell-parity](#shell-parity) |
| 🐚 Senior Bash Engineer Review | APPROVE (N/A) | [comment](https://github.com/jdschleicher/bashcuts/pull/89#issuecomment-4489221641) |
| 💠 Senior PowerShell Engineer Review | APPROVE | [comment](https://github.com/jdschleicher/bashcuts/pull/89#issuecomment-4489238374) |
| 🛡️ Senior Security Engineer Review | PASS WITH NOTES | [comment](https://github.com/jdschleicher/bashcuts/pull/89#issuecomment-4489228523) |
| 🧼 Senior Clean-Code Engineer Review | APPROVE | [comment](https://github.com/jdschleicher/bashcuts/pull/89#issuecomment-4489233665) |
| 📚 Docs Check | CURRENT | [comment](https://github.com/jdschleicher/bashcuts/pull/89#issuecomment-4489248640) |
| 📋 Acceptance Criteria Check | ALL SATISFIED | [comment](https://github.com/jdschleicher/bashcuts/pull/89#issuecomment-4489253750) |
| 🗺️ AzDO Diagrams Check | CURRENT | [comment](https://github.com/jdschleicher/bashcuts/pull/89#issuecomment-4489254117) |

---

<!-- pr-diagram-start -->
## 🗺️ PR Flow Diagram

```mermaid
flowchart TD
    A["az-New-AzDevOpsUserStory<br/>az-New-AzDevOpsFeature<br/>az-New-AzDevOpsFeatureStories"] --> B[Read-AzDevOpsHierarchyCache]
    B --> C[Read-AzDevOpsJsonCache]
    C --> D{hierarchy.json content}
    D -->|missing file| E[return $null]
    D -->|"empty array []"| F["<b>NEW</b><br/>$null -eq $raw<br/>return @()"]
    D -->|populated array| G[ForEach-Object converter<br/>typed rows]
    F --> H["Read-AzDevOpsParentPick<br/>(Hierarchy = @())"]
    G --> H
    H --> I{hierarchy count}
    I -->|"0 — entire cache empty"| J["<b>NEW</b><br/>actionable diagnostic<br/>$env:AZ_AREA + WIQLs + sync<br/>return 0 (orphan)"]
    I -->|N rows| K["Where-Object Type -eq ParentType<br/>and active state"]
    K --> L{matching candidates}
    L -->|0| M["existing orphan path<br/>'no active ParentTypes'"]
    L -->|N| N[Out-ConsoleGridView picker]

    classDef newBranch fill:#fff4b8,stroke:#d4a017,stroke-width:2px,color:#000
    class F,J newBranch
```
<!-- pr-diagram-end -->

## Summary
Fix the `az-New-AzDevOps*` &#34;hierarchy is null&#34; failure mode when `hierarchy.json` is `[]` — the legitimate result of WIQL queries that return zero rows (wrong `$env:AZ_AREA`, brand-new project, custom process template, edited WIQL). The cache reader no longer trips the `&#34;Cannot bind argument to parameter &#39;Raw&#39; because it is null&#34;` PowerShell binding error, and the parent picker now prints an actionable diagnostic pointing at `$env:AZ_AREA`, the WIQL editor, and the re-sync command instead of silently orphaning.

## Issue
Closes #88

## Root Cause
`Get-Content -Raw | ConvertFrom-Json` unwraps the empty-array output through the pipeline to zero items, so `$raw` lands as `$null`. `$null | ForEach-Object { &amp; $Converter $_ }` still runs the converter once with `$_ = $null`, which hits the converter&#39;s `[Parameter(Mandatory)] $Raw` guard with a confusing binding error. Downstream, `az-New-AzDevOpsUserStory` / `az-New-AzDevOpsFeature` saw a non-null `$hierarchy` and fell through to the orphan path with a misleading &#34;no active Features&#34; message.

## Changes
| File | Change |
|------|--------|
| `powcuts_by_cli/azdevops_views.ps1` | `Read-AzDevOpsJsonCache` returns `@()` cleanly when `$raw -eq $null` after `ConvertFrom-Json` — benefits hierarchy, assigned, and mentions caches |
| `powcuts_by_cli/azdevops_create_pickers.ps1` | `Read-AzDevOpsParentPick` distinguishes &#34;entire cache empty&#34; from &#34;no matching parents&#34;, and prints an actionable yellow diagnostic with `$env:AZ_AREA`, `az-Open-AzDevOpsHierarchyWiqls`, and `az-Sync-AzDevOpsCache` next-steps when the hierarchy is empty |

## Test Plan
- [ ] Open a fresh PowerShell terminal — `[System.Management.Automation.Language.Parser]::ParseFile(...)` reports zero errors on both changed files
- [ ] `Set-Content ~/.bashcuts-az-devops-app/cache/hierarchy.json &#39;[]&#39;`, then run `az-New-AzDevOpsUserStory` — the new diagnostic appears (no &#34;Cannot bind argument&#34; red error) and the child is created as an orphan with a clear &#34;your WIQL returned 0 rows&#34; hint
- [ ] `az-Show-AzDevOpsTree` against an empty hierarchy cache prints `(no epics in hierarchy cache)` without binding errors
- [ ] `az-Get-AzDevOpsAssigned` and `az-Get-AzDevOpsMentions` against an empty `assigned.json` / `mentions.json` no longer surface the binding error either (same `Read-AzDevOpsJsonCache` codepath)
- [ ] Hierarchy with rows but no Features still falls through to the existing per-tier orphan message — no regression on the populated-cache path

## Shell Parity
PowerShell-only. The cache layer, the WIQL hierarchy queries, and the `az-New-AzDevOps*` create flow are all PowerShell-only. Bash has no equivalent work-item create surface.