### PR TITLE
Add unplanned-work firefighting sessions for Azure DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * [How to use bashcuts](#how-to)
 * [Azure DevOps work-item shortcuts](#azure-devops)
 * [Timer sessions](#timer-sessions)
+* [Unplanned work sessions](#unplanned-work)
 
 <br>
 
@@ -496,4 +497,45 @@ Register-TimerIntegration `
         "View: my-tracker open $Id"
     }
 ```
+
+<br>
+
+***
+
+# <a name="unplanned-work"></a>Unplanned work sessions
+
+`Start-UnplannedWork` is the free-for-all companion to the Pomodoro timer for firefighting that can't be time-boxed. Each day rolls up under a single **Unplanned Work — yyyy-MM-dd** User Story; every firefight you start becomes a child **Task** with its own debrief. PowerShell-only, like the timer (the Windows balloon reminder and key-poll loop have no bash counterpart).
+
+### Run a session
+
+```powershell
+# Prompts for the firefight title, reminds every 5 min
+Start-UnplannedWork
+
+# Skip the title prompt, custom reminder cadence
+Start-UnplannedWork -Title 'Help Dana with the deploy' -ReminderMinutes 10
+
+# No balloon reminder
+Start-UnplannedWork -NoReminder
+```
+
+Flow:
+1. Finds (or creates) today's daily **Unplanned Work** story, then creates a child **Task** for this firefight and links it
+2. Runs a foreground session — press **Space** to log a timestamped item, **Esc/Q** to stop
+3. A reminder balloon pops every `-ReminderMinutes` until you stop
+4. On stop: captured items flush to the Task **description**, then you're prompted for debrief notes and whether there's an opportunity for a new feature / user story to prevent the firefight in future (it can spin one up via `az-New-AzDevOpsUserStory`). A single debrief comment (time spent + notes + opportunity) is posted on the Task.
+
+Start three separate firefights in a day and you get three Tasks under the one daily story — exactly the "three different chats, three different efforts" shape.
+
+### End-of-day roll-up
+
+```powershell
+# Today
+New-UnplannedWorkDebrief
+
+# A past day
+New-UnplannedWorkDebrief -Date 2026-05-19
+```
+
+Reads the day's local ledger (kept under the AzDO cache dir so total time can be summed — AzDO doesn't store per-session minutes), prints the per-Task breakdown with total time, and on confirm posts a roll-up comment on the daily story.
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -1,6 +1,6 @@
 # Azure DevOps Functionality — Mermaid Diagrams
 
-Visual reference for the Azure DevOps work-item shortcuts in `powcuts_by_cli/azdevops_*.ps1` (split across `azdevops_auth.ps1`, `azdevops_paths.ps1`, `azdevops_sync.ps1`, `azdevops_views.ps1`, `azdevops_find.ps1`, `azdevops_classification.ps1`, `azdevops_create_pickers.ps1`, `azdevops_create.ps1`, `azdevops_schema.ps1`, `azdevops_openers.ps1`). Each diagram covers one subsystem; the last diagram is a cross-cutting function-dependency map.
+Visual reference for the Azure DevOps work-item shortcuts in `powcuts_by_cli/azdevops_*.ps1` (split across `azdevops_auth.ps1`, `azdevops_paths.ps1`, `azdevops_sync.ps1`, `azdevops_views.ps1`, `azdevops_find.ps1`, `azdevops_classification.ps1`, `azdevops_create_pickers.ps1`, `azdevops_create.ps1`, `azdevops_schema.ps1`, `azdevops_openers.ps1`, `azdevops_unplanned.ps1`). Each diagram covers one subsystem; the last diagram is a cross-cutting function-dependency map.
 
 - [1. High-level architecture](#1-high-level-architecture)
 - [2. `az-Connect-AzDevOps` — 8-step orchestrator](#2-az-connect-azdevops--8-step-orchestrator)
@@ -12,7 +12,8 @@ Visual reference for the Azure DevOps work-item shortcuts in `powcuts_by_cli/azd
 - [8. `az-New-AzDevOpsFeature` — interactive Feature create + child-story hand-off](#8-az-new-azdevopsfeature--interactive-feature-create--child-story-hand-off)
 - [9. `az-New-AzDevOpsFeatureStories` — batch child-story loop](#9-az-new-azdevopsfeaturestories--batch-child-story-loop)
 - [10. `az-Register-/az-Unregister-AzDevOpsSyncSchedule` — platform branch](#10-az-register-az-unregister-azdevopssyncschedule--platform-branch)
-- [11. Function dependency map](#11-function-dependency-map)
+- [11. `Start-UnplannedWork` — firefighting session loop + debrief](#11-start-unplannedwork--firefighting-session-loop--debrief)
+- [12. Function dependency map](#12-function-dependency-map)
 
 ---
 
@@ -569,7 +570,52 @@ Shared private helpers (named in CLAUDE.md):
 
 ---
 
-## 11. Function dependency map
+## 11. `Start-UnplannedWork` — firefighting session loop + debrief
+
+Free-for-all companion to the Pomodoro timer for work that can't be time-boxed. Each day rolls up under one **Unplanned Work — yyyy-MM-dd** User Story; every firefight is a child Task with its own debrief. PowerShell-only (the Windows balloon reminder + key-poll loop have no bash counterpart). `New-UnplannedWorkDebrief` is the end-of-day roll-up over a local per-day ledger.
+
+```mermaid
+flowchart TD
+    Start([Start-UnplannedWork]) --> Gate{Test-AzDevOpsCreateGate}
+    Gate -- false --> Abort1([abort])
+    Gate -- true --> Daily[Get-UnplannedWorkDailyStory]
+
+    Daily --> Find["Find-UnplannedWorkStoryId<br/>WIQL by title (+ AZ_AREA)<br/>→ Invoke-AzDevOpsBoardsQuery"]
+    Find -- found --> HaveStory[daily story id]
+    Find -- 0 --> NewStory["New-UnplannedWorkStory<br/>→ Invoke-AzDevOpsWorkItemCreate<br/>→ az boards work-item create (User Story)"]
+    NewStory --> HaveStory
+
+    HaveStory --> Task["New-UnplannedWorkTask<br/>→ New-AzDevOpsWorkItem (Task)<br/>→ Invoke-AzDevOpsParentLink"]
+    Task --> Loop[session loop — Read-UnplannedKeyPress poll]
+
+    Loop -- Space --> LogItem["Read-Host item<br/>append {Time, Text}"]
+    LogItem --> Loop
+    Loop -- every ReminderMinutes --> Balloon["Show-UnplannedReminder<br/>(New-UnplannedBalloon NotifyIcon)"]
+    Balloon --> Loop
+    Loop -- Esc/Q --> Debrief[Invoke-UnplannedDebrief]
+
+    Debrief --> FlushDesc["Format-UnplannedItemsDescription<br/>→ Set-AzDevOpsWorkItemField<br/>→ az boards work-item update (System.Description)"]
+    FlushDesc --> AskFuture{future-feature opportunity?}
+    AskFuture -- yes --> MaybeStory["(opt) az-New-AzDevOpsUserStory"]
+    AskFuture -- no --> PostComment
+    MaybeStory --> PostComment
+    PostComment["Format-UnplannedDebriefComment<br/>→ Add-AzDevOpsDiscussionComment<br/>→ az boards work-item update (--discussion)"]
+    PostComment --> Ledger["Add-UnplannedLedgerEntry<br/>unplanned-YYYY-MM-DD.json"]
+    Ledger --> Done([end])
+
+    DebriefDay([New-UnplannedWorkDebrief]) --> ReadLedger["read day ledger<br/>Measure-Object -Property Minutes"]
+    ReadLedger --> Rollup["Format-UnplannedDailyDebrief<br/>→ Add-AzDevOpsDiscussionComment on daily story"]
+    Rollup --> Done2([end])
+
+    classDef io fill:#5a3a1a,stroke:#ffaa55,color:#fff
+    class Find,NewStory,Task,FlushDesc,PostComment,Ledger,Rollup io
+```
+
+Capture lands in two places per firefight: the accumulated bullet items flush to the Task **description** once at stop, and a single **discussion comment** carries the time spent, debrief notes, and any future-feature opportunity. Pure-UI helpers (`Show-UnplannedStatus`, `Format-UnplannedElapsed`, `Read-UnplannedYesNo`) are session-internal and omitted from the dependency map below.
+
+---
+
+## 12. Function dependency map
 
 Public functions on the left, private helpers on the right. Helpers under "Shared scaffolding" exist specifically because their bodies were duplicated across the parallel `Get-/Open-` pairs and the parallel `Register-/Unregister-` pairs. The "Multi-project resolver layer" cluster collects the opt-in `$global:AzDevOpsProjectMap` switcher (`az-Use-/Show-/Get-AzDevOpsProject(s)`) plus every `Resolve-AzDevOpsType*` helper consumed by the `az-New-*` creators; when no map is defined, all resolvers return `$null`/`-1`/`@()` and the create paths fall through to today's prompt-driven flow.
 
@@ -609,6 +655,17 @@ graph LR
     ShowProj(["az-Show-AzDevOpsProject"]):::pub
     GetProjs(["az-Get-AzDevOpsProjects"]):::pub
     FindProj(["az-Find-AzDevOpsProject"]):::pub
+
+    %% Unplanned work sessions (azdevops_unplanned.ps1)
+    StartUW(["Start-UnplannedWork"]):::pub
+    NewUWDebrief(["New-UnplannedWorkDebrief"]):::pub
+    GetDaily[Get-UnplannedWorkDailyStory]:::priv
+    FindUW[Find-UnplannedWorkStoryId]:::priv
+    NewUWStory[New-UnplannedWorkStory]:::priv
+    NewUWTask[New-UnplannedWorkTask]:::priv
+    InvUWDebrief[Invoke-UnplannedDebrief]:::priv
+    UWBalloon[New-UnplannedBalloon]:::priv
+    UWLedger[Add-UnplannedLedgerEntry]:::priv
 
     %% Step helpers
     C1[az-Confirm-AzDevOpsCli]:::priv
@@ -660,6 +717,8 @@ graph LR
     NewWI[New-AzDevOpsWorkItem]:::priv
     AddRel[Add-AzDevOpsWorkItemRelation]:::priv
     AddDisc[Add-AzDevOpsDiscussionComment]:::priv
+    SetField[Set-AzDevOpsWorkItemField]:::priv
+    AssertTok[Assert-AzDevOpsFieldTokens]:::priv
     WITypeDef[Get-AzDevOpsWorkItemTypeDefinition]:::priv
     ConfDef[Get-AzDevOpsConfiguredDefaults]:::priv
 
@@ -831,6 +890,9 @@ graph LR
     Boards --> AzJson
     ClassList --> AzJson
     AddDisc --> AzJson
+    SetField --> AzJson
+    NewWI --> AssertTok
+    SetField --> AssertTok
     WITypeDef --> AzJson
     Boards --> EchoLn
     AzJson --> CmdDisp
@@ -989,6 +1051,23 @@ graph LR
     ResIA --> PKind
     CrLink --> InvCreate --> NewWI --> AzJson
     CrLink --> InvLink --> AddRel --> AzJson
+
+    %% Unplanned work sessions
+    StartUW --> CGate
+    StartUW --> GetDaily
+    GetDaily --> FindUW --> Boards
+    GetDaily --> NewUWStory --> InvCreate
+    StartUW --> NewUWTask
+    NewUWTask --> NewWI
+    NewUWTask --> InvLink
+    StartUW --> UWBalloon
+    StartUW --> InvUWDebrief
+    InvUWDebrief --> SetField
+    InvUWDebrief --> AddDisc
+    InvUWDebrief --> NewS
+    InvUWDebrief --> UWLedger
+    NewUWDebrief --> AddDisc
+    NewUWDebrief --> UWLedger
 
     %% Parent picker shared between Feature and Epic pickers
     PFeat --> PParent

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -213,6 +213,23 @@ function Get-AzDevOpsClassificationList {
 }
 
 
+function Assert-AzDevOpsFieldTokens {
+    # Guards the variadic `--fields` slot shared by New-AzDevOpsWorkItem and
+    # Set-AzDevOpsWorkItemField: every entry must be a 'Ref.Name=value'
+    # assignment so a stray `--`-prefixed token can't escape the slot and be
+    # reinterpreted by az's argparse as a new flag. The value (after the first
+    # '=') is intentionally unconstrained. Throws on the first malformed token.
+    # Private helper (unapproved verb is fine - not user-facing).
+    param([string[]] $Fields)
+
+    foreach ($f in $Fields) {
+        if ($f -notmatch '^[A-Za-z][A-Za-z0-9_.]*=') {
+            throw "Invalid field assignment '$f' (expected 'Field.Name=value')."
+        }
+    }
+}
+
+
 function New-AzDevOpsWorkItem {
     # `az boards work-item create` wrapper. Title and Type are required; every
     # other parameter is optional so callers can populate only what they have.
@@ -231,15 +248,7 @@ function New-AzDevOpsWorkItem {
         [switch]   $Open
     )
 
-    # Reject `--`-prefixed or otherwise malformed field tokens so a stray
-    # value cannot escape the variadic --fields slot and be reinterpreted
-    # by az's argparse as a new flag (defense in depth — callers are
-    # interactive and self-trusted but the class of bug is worth killing).
-    foreach ($f in $Fields) {
-        if ($f -notmatch '^[A-Za-z][A-Za-z0-9_.]*=') {
-            throw "Invalid field assignment '$f' (expected 'Field.Name=value')."
-        }
-    }
+    Assert-AzDevOpsFieldTokens -Fields $Fields
 
     $argList = @(
         'boards', 'work-item', 'create',
@@ -327,11 +336,7 @@ function Set-AzDevOpsWorkItemField {
         [Parameter(Mandatory)] [string[]] $Fields
     )
 
-    foreach ($f in $Fields) {
-        if ($f -notmatch '^[A-Za-z][A-Za-z0-9_.]*=') {
-            throw "Invalid field assignment '$f' (expected 'Field.Name=value')."
-        }
-    }
+    Assert-AzDevOpsFieldTokens -Fields $Fields
 
     $argList = @('boards', 'work-item', 'update', '--id', "$Id", '--fields') + $Fields
 

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -315,6 +315,31 @@ function Add-AzDevOpsDiscussionComment {
 }
 
 
+function Set-AzDevOpsWorkItemField {
+    # `az boards work-item update --id <id> --fields Field=value ...` wrapper.
+    # Each entry of -Fields is a 'Ref.Name=value' assignment (e.g.
+    # 'System.Description=...'). Field tokens are validated the same way
+    # New-AzDevOpsWorkItem validates them so a stray '--'-prefixed value can't
+    # escape the variadic --fields slot and be reinterpreted as a new flag.
+    # Returns the canonical { Json, Error, ExitCode } envelope.
+    param(
+        [Parameter(Mandatory)] [int]      $Id,
+        [Parameter(Mandatory)] [string[]] $Fields
+    )
+
+    foreach ($f in $Fields) {
+        if ($f -notmatch '^[A-Za-z][A-Za-z0-9_.]*=') {
+            throw "Invalid field assignment '$f' (expected 'Field.Name=value')."
+        }
+    }
+
+    $argList = @('boards', 'work-item', 'update', '--id', "$Id", '--fields') + $Fields
+
+    $result = Invoke-AzDevOpsAzJson -ArgList $argList
+    return $result
+}
+
+
 function Get-AzDevOpsWorkItemTypeDefinition {
     # `az devops invoke --area wit --resource workitemtypes` wrapper. Returns
     # the type's field-instance definitions inside the canonical envelope so

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -484,6 +484,75 @@ function Format-UnplannedDailyDebrief {
 }
 
 
+function Invoke-UnplannedDebrief {
+    # Stop-of-session tail, split out of Start-UnplannedWork so the orchestrator
+    # reads as gate -> story -> task -> loop -> debrief. Flushes the captured
+    # items to the Task description, prompts for debrief notes + an optional
+    # future-feature opportunity (offering to create a user story for it via
+    # az-New-AzDevOpsUserStory), posts the debrief comment, and records the
+    # session in the day's ledger. Elapsed minutes come from $StartTime so the
+    # recorded time is accurate regardless of the on-screen counter.
+    param(
+        [Parameter(Mandatory)] [int]      $TaskId,
+        [Parameter(Mandatory)] [int]      $StoryId,
+        [Parameter(Mandatory)] [string]   $Title,
+        [Parameter(Mandatory)] [datetime] $StartTime,
+        [object[]] $Items
+    )
+
+    $itemList = @($Items)
+
+    $elapsedMinutes = [int][math]::Round(((Get-Date) - $StartTime).TotalMinutes)
+    if ($elapsedMinutes -lt 1) {
+        $elapsedMinutes = 1
+    }
+
+    Clear-Host
+    $iconCheck = $script:UnplannedIconCheck
+    Write-Host "$iconCheck Unplanned session complete - $elapsedMinutes min, $($itemList.Count) item(s)." -ForegroundColor Green
+    Write-Host ""
+
+    $descriptionBody = Format-UnplannedItemsDescription -TaskTitle $Title -Items $itemList
+    Write-Host "Updating Task #$TaskId description with captured items..." -ForegroundColor Cyan
+    $descResult = Set-AzDevOpsWorkItemField -Id $TaskId -Fields @("System.Description=$descriptionBody")
+    if ($descResult.ExitCode -ne 0) {
+        Write-Host "  Could not update description: $($descResult.Error)" -ForegroundColor Yellow
+    }
+
+    $iconMemo = $script:UnplannedIconMemo
+    $debrief = Read-Host "$iconMemo Debrief notes for this firefight"
+
+    $futureFeature = ''
+    if (Read-UnplannedYesNo -Prompt 'Is there an opportunity for a new feature / user story to prevent this firefight in future?') {
+        $futureFeature = Read-Host '  Describe the opportunity (one line)'
+
+        if ($futureFeature -and (Read-UnplannedYesNo -Prompt '  Create that user story now?')) {
+            if (Get-Command az-New-AzDevOpsUserStory -ErrorAction SilentlyContinue) {
+                az-New-AzDevOpsUserStory -Title $futureFeature | Out-Null
+            }
+        }
+    }
+
+    $commentBody = Format-UnplannedDebriefComment `
+        -ElapsedMinutes $elapsedMinutes `
+        -ItemCount      $itemList.Count `
+        -Debrief        $debrief `
+        -FutureFeature  $futureFeature
+
+    Write-Host ""
+    Write-Host "Posting debrief comment to Task #$TaskId..." -ForegroundColor Cyan
+    $commentResult = Add-AzDevOpsDiscussionComment -Id $TaskId -Body $commentBody
+    if ($commentResult.ExitCode -eq 0) {
+        Write-Host "$iconCheck Debrief posted on Task #$TaskId." -ForegroundColor Green
+        Write-Host "   View: az-Open-AzDevOpsAssigned $TaskId" -ForegroundColor DarkGray
+    } else {
+        Write-Host "Debrief comment failed: $($commentResult.Error)" -ForegroundColor Red
+    }
+
+    Add-UnplannedLedgerEntry -StoryId $StoryId -TaskId $TaskId -Title $Title -Minutes $elapsedMinutes -ItemCount $itemList.Count
+}
+
+
 function Start-UnplannedWork {
     # Orchestrator. Find-or-create today's daily story, create a child Task for
     # this firefight, then run the foreground session: Space logs a timestamped
@@ -574,6 +643,7 @@ function Start-UnplannedWork {
                         $items.Add($record)
                     }
 
+                    $elapsed = [int]((Get-Date) - $startTime).TotalSeconds
                     Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds $elapsed -ItemCount $items.Count -ReminderMinutes $ReminderMinutes
                     break
                 }
@@ -585,7 +655,10 @@ function Start-UnplannedWork {
                 break
             }
 
-            $elapsed++
+            # Drive the display from wall-clock, not the iteration count - the
+            # space branch's blocking Read-Host means a single iteration can
+            # span many seconds, so $elapsed++ would undercount.
+            $elapsed = [int]((Get-Date) - $startTime).TotalSeconds
 
             Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds $elapsed -ItemCount $items.Count -ReminderMinutes $ReminderMinutes
 
@@ -595,57 +668,7 @@ function Start-UnplannedWork {
             }
         }
 
-        $endTime = Get-Date
-        $elapsedMinutes = [int][math]::Round(($endTime - $startTime).TotalMinutes)
-        if ($elapsedMinutes -lt 1) {
-            $elapsedMinutes = 1
-        }
-
-        [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-
-        Clear-Host
-        $iconCheck = $script:UnplannedIconCheck
-        Write-Host "$iconCheck Unplanned session complete - $elapsedMinutes min, $($items.Count) item(s)." -ForegroundColor Green
-        Write-Host ""
-
-        $descriptionBody = Format-UnplannedItemsDescription -TaskTitle $Title -Items @($items)
-        Write-Host "Updating Task #$taskId description with captured items..." -ForegroundColor Cyan
-        $descResult = Set-AzDevOpsWorkItemField -Id $taskId -Fields @("System.Description=$descriptionBody")
-        if ($descResult.ExitCode -ne 0) {
-            Write-Host "  Could not update description: $($descResult.Error)" -ForegroundColor Yellow
-        }
-
-        $iconMemo = $script:UnplannedIconMemo
-        $debrief = Read-Host "$iconMemo Debrief notes for this firefight"
-
-        $futureFeature = ''
-        if (Read-UnplannedYesNo -Prompt 'Is there an opportunity for a new feature / user story to prevent this firefight in future?') {
-            $futureFeature = Read-Host '  Describe the opportunity (one line)'
-
-            if ($futureFeature -and (Read-UnplannedYesNo -Prompt '  Create that user story now?')) {
-                if (Get-Command az-New-AzDevOpsUserStory -ErrorAction SilentlyContinue) {
-                    az-New-AzDevOpsUserStory -Title $futureFeature | Out-Null
-                }
-            }
-        }
-
-        $commentBody = Format-UnplannedDebriefComment `
-            -ElapsedMinutes $elapsedMinutes `
-            -ItemCount      $items.Count `
-            -Debrief        $debrief `
-            -FutureFeature  $futureFeature
-
-        Write-Host ""
-        Write-Host "Posting debrief comment to Task #$taskId..." -ForegroundColor Cyan
-        $commentResult = Add-AzDevOpsDiscussionComment -Id $taskId -Body $commentBody
-        if ($commentResult.ExitCode -eq 0) {
-            Write-Host "$iconCheck Debrief posted on Task #$taskId." -ForegroundColor Green
-            Write-Host "   View: az-Open-AzDevOpsAssigned $taskId" -ForegroundColor DarkGray
-        } else {
-            Write-Host "Debrief comment failed: $($commentResult.Error)" -ForegroundColor Red
-        }
-
-        Add-UnplannedLedgerEntry -StoryId $storyId -TaskId $taskId -Title $Title -Minutes $elapsedMinutes -ItemCount $items.Count
+        Invoke-UnplannedDebrief -TaskId $taskId -StoryId $storyId -Title $Title -StartTime $startTime -Items @($items)
     }
     finally {
         [Console]::OutputEncoding = $previousEncoding

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -1,0 +1,703 @@
+# ============================================================================
+# Azure DevOps — Unplanned / firefighting work sessions
+# ============================================================================
+# A free-for-all companion to the Pomodoro timer (pow_timer.ps1) for work that
+# can't be time-boxed. Each day rolls up under a single "Unplanned Work" User
+# Story; every firefight you start becomes a child Task with its own debrief.
+#
+# Public surface:
+#   Start-UnplannedWork      - find-or-create today's daily story, create a
+#                              child Task for this firefight, then run a
+#                              foreground session: press Space to log an item,
+#                              Esc/Q to stop and debrief. A reminder balloon
+#                              pops every -ReminderMinutes until you stop. On
+#                              stop the captured items flush to the Task
+#                              description and a debrief comment is posted.
+#   New-UnplannedWorkDebrief - read the day's ledger, total the time across all
+#                              firefights, and post a roll-up comment on the
+#                              daily story.
+#
+# Like pow_timer.ps1 this is PowerShell-only - the Windows balloon reminder and
+# the non-blocking key poll have no bash counterpart.
+#
+# Loaded by powcuts_home.ps1. See azdevops_auth.ps1 for the master docstring.
+
+$script:UnplannedStoryTitlePrefix       = 'Unplanned Work'
+$script:UnplannedTitleDash              = "$([char]0x2014)"            # em dash
+$script:UnplannedDefaultReminderMinutes = 5
+$script:UnplannedDefaultStoryPriority   = 2
+$script:UnplannedPollIntervalMs         = 100
+$script:UnplannedPollsPerSecond         = 10
+
+$script:UnplannedIconFire   = [char]::ConvertFromUtf32(0x1F525)   # fire
+$script:UnplannedIconMemo   = [char]::ConvertFromUtf32(0x1F4DD)   # memo
+$script:UnplannedIconClock  = [char]::ConvertFromUtf32(0x23F0)    # alarm clock
+$script:UnplannedIconCheck  = [char]::ConvertFromUtf32(0x2705)    # check mark
+$script:UnplannedIconRocket = [char]::ConvertFromUtf32(0x1F680)   # rocket
+$script:UnplannedIconBullet = [char]::ConvertFromUtf32(0x2022)    # bullet
+
+
+function Test-UnplannedIsWindows {
+    $isWin = ($IsWindows -or ($env:OS -eq 'Windows_NT'))
+    return $isWin
+}
+
+
+function Read-UnplannedYesNo {
+    param([Parameter(Mandatory)] [string] $Prompt)
+
+    $raw = Read-Host "$Prompt [y/N]"
+    if (-not $raw) {
+        return $false
+    }
+
+    $normalized = $raw.Trim().ToLowerInvariant()
+    $result = ($normalized -eq 'y' -or $normalized -eq 'yes')
+    return $result
+}
+
+
+function Format-UnplannedElapsed {
+    # mm:ss for short firefights, h:mm:ss once a session crosses the hour mark
+    # (unplanned work has no fixed cap, unlike the Pomodoro countdown).
+    param([Parameter(Mandatory)] [int] $Seconds)
+
+    $ts = [TimeSpan]::FromSeconds($Seconds)
+    $display = if ($ts.TotalHours -ge 1) {
+        '{0:00}:{1:00}:{2:00}' -f [int]$ts.TotalHours, $ts.Minutes, $ts.Seconds
+    } else {
+        '{0:00}:{1:00}' -f $ts.Minutes, $ts.Seconds
+    }
+
+    return $display
+}
+
+
+function Get-UnplannedWorkDailyStoryTitle {
+    param([datetime] $Date = (Get-Date))
+
+    $stamp  = $Date.ToString('yyyy-MM-dd')
+    $prefix = $script:UnplannedStoryTitlePrefix
+    $dash   = $script:UnplannedTitleDash
+    $title  = "$prefix $dash $stamp"
+
+    return $title
+}
+
+
+function Find-UnplannedWorkStoryId {
+    # WIQL lookup for an existing daily story by exact title. Narrowed to
+    # $env:AZ_AREA when set so a same-named story in another area doesn't match.
+    # Returns the work-item id, or 0 when none exists / the query fails.
+    param([Parameter(Mandatory)] [string] $Title)
+
+    $titleLiteral = $Title.Replace("'", "''")
+    $wiql = "SELECT [System.Id] FROM WorkItems WHERE [System.WorkItemType] = 'User Story' AND [System.Title] = '$titleLiteral'"
+
+    if ($env:AZ_AREA) {
+        $areaLiteral = $env:AZ_AREA.Replace("'", "''")
+        $wiql = "$wiql AND [System.AreaPath] UNDER '$areaLiteral'"
+    }
+
+    $result = Invoke-AzDevOpsBoardsQuery -Wiql $wiql
+    if ($result.ExitCode -ne 0) {
+        Write-Host "Could not query for the daily story: $($result.Error)" -ForegroundColor Red
+        return 0
+    }
+
+    try {
+        $parsed = $result.Json | ConvertFrom-Json
+    }
+    catch {
+        return 0
+    }
+
+    $rows = @($parsed)
+    if ($rows.Count -eq 0) {
+        return 0
+    }
+
+    $first = $rows[0]
+    $id = if ($first.id) {
+        [int]$first.id
+    } else {
+        [int]$first.fields.'System.Id'
+    }
+
+    return $id
+}
+
+
+function New-UnplannedWorkStory {
+    # Creates the daily catch-all User Story via the shared create path so
+    # priority / area / iteration / schema handling matches az-New-AzDevOps*.
+    # Returns the new id, or 0 on failure.
+    param([Parameter(Mandatory)] [string] $Title)
+
+    $resolved = Resolve-AzDevOpsIterationArea -Type 'USER_STORY'
+    if (-not $resolved.Ok) {
+        return 0
+    }
+
+    $description = 'Daily catch-all for unplanned / firefighting work. Each firefight is a child Task with its own debrief.'
+
+    $createArgs = @{
+        Title              = $Title
+        Description        = $description
+        Priority           = $script:UnplannedDefaultStoryPriority
+        StoryPoints        = -1
+        AcceptanceCriteria = ''
+        Iteration          = $resolved.Iteration
+        Area               = $resolved.Area
+    }
+
+    $created = Invoke-AzDevOpsWorkItemCreate @createArgs
+    if (-not $created.Ok) {
+        Write-Host "Failed to create the daily Unplanned Work story: $($created.Error)" -ForegroundColor Red
+        return 0
+    }
+
+    $newId = $created.Id
+    return $newId
+}
+
+
+function Get-UnplannedWorkDailyStory {
+    # Find-or-create today's daily story. -NoCreate returns 0 instead of
+    # creating when none exists (used by the daily-debrief reader).
+    param([switch] $NoCreate)
+
+    $title = Get-UnplannedWorkDailyStoryTitle
+
+    $existingId = Find-UnplannedWorkStoryId -Title $title
+    if ($existingId -gt 0) {
+        Write-Host "Using existing daily story #$existingId : $title" -ForegroundColor DarkGray
+        return $existingId
+    }
+
+    if ($NoCreate) {
+        return 0
+    }
+
+    Write-Host "No daily story for today yet - creating '$title'..." -ForegroundColor Cyan
+    $newId = New-UnplannedWorkStory -Title $title
+    return $newId
+}
+
+
+function New-UnplannedWorkTask {
+    # Creates the firefight Task and links it to the daily story as a child.
+    # Tasks carry no priority / story-points / acceptance-criteria in the stock
+    # templates, so this goes straight through New-AzDevOpsWorkItem rather than
+    # Invoke-AzDevOpsWorkItemCreate (which always stamps those fields). Returns
+    # the new Task id, or 0 on create failure; a link failure is surfaced but
+    # still returns the id so the session can proceed.
+    param(
+        [Parameter(Mandatory)] [string] $Title,
+        [Parameter(Mandatory)] [int]    $StoryId
+    )
+
+    $created = New-AzDevOpsWorkItem `
+        -Type       'Task' `
+        -Title      $Title `
+        -AssignedTo $env:AZ_USER_EMAIL `
+        -Area       $env:AZ_AREA `
+        -Iteration  $env:AZ_ITERATION
+
+    if ($created.ExitCode -ne 0) {
+        Write-Host "Failed to create the firefight Task: $($created.Error)" -ForegroundColor Red
+        return 0
+    }
+
+    try {
+        $taskObj = $created.Json | ConvertFrom-Json
+    }
+    catch {
+        Write-Host "Created the Task but could not parse its id." -ForegroundColor Red
+        return 0
+    }
+
+    $taskId = [int]$taskObj.id
+
+    $link = Invoke-AzDevOpsParentLink -Id $taskId -ParentId $StoryId
+    if (-not $link.Ok) {
+        Write-Host "Task #$taskId created but linking to story #$StoryId failed: $($link.Error)" -ForegroundColor Yellow
+        Write-Host "  Re-link manually if needed." -ForegroundColor Yellow
+    }
+
+    return $taskId
+}
+
+
+function New-UnplannedBalloon {
+    # One reusable NotifyIcon for the whole session - reused on each reminder
+    # tick and disposed in the orchestrator's finally so a multi-hour session
+    # doesn't accumulate tray icons. Returns $null off Windows or when the
+    # Windows.Forms types aren't available, in which case reminders no-op.
+    if (-not (Test-UnplannedIsWindows)) {
+        return $null
+    }
+
+    try {
+        if (-not ([System.Management.Automation.PSTypeName]'System.Windows.Forms.NotifyIcon').Type) {
+            Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+        }
+
+        $balloon = New-Object System.Windows.Forms.NotifyIcon
+        $balloon.Icon = [System.Drawing.Icon]::ExtractAssociatedIcon((Get-Process -Id $PID).Path)
+        $balloon.Visible = $true
+        return $balloon
+    }
+    catch {
+        return $null
+    }
+}
+
+
+function Show-UnplannedReminder {
+    param(
+        $Balloon,
+        [Parameter(Mandatory)] [int]    $TaskId,
+        [Parameter(Mandatory)] [string] $TaskTitle
+    )
+
+    if ($null -eq $Balloon) {
+        return
+    }
+
+    $iconFire = $script:UnplannedIconFire
+
+    $Balloon.BalloonTipIcon  = [System.Windows.Forms.ToolTipIcon]::Warning
+    $Balloon.BalloonTipTitle = "$iconFire Unplanned work in progress"
+    $Balloon.BalloonTipText  = "Task #$TaskId still open: $TaskTitle. Space = log item, Esc = stop."
+    $Balloon.ShowBalloonTip(0)
+}
+
+
+function Read-UnplannedKeyPress {
+    # Non-blocking probe. Returns 'space', 'stop' (Esc or Q), or '' when no key
+    # is waiting. Guarded so the loop still runs in hosts without a console
+    # keyboard - there the session becomes time-only (reminders still fire,
+    # Space/Esc are disabled) until the user closes the terminal.
+    try {
+        if ([Console]::KeyAvailable) {
+            $key = [Console]::ReadKey($true)
+
+            if ($key.Key -eq [ConsoleKey]::Spacebar) {
+                return 'space'
+            }
+
+            if ($key.Key -eq [ConsoleKey]::Escape -or $key.Key -eq [ConsoleKey]::Q) {
+                return 'stop'
+            }
+        }
+    }
+    catch {
+        # Host does not expose console keyboard - treat as no key pressed.
+    }
+
+    return ''
+}
+
+
+function Show-UnplannedStatus {
+    param(
+        [Parameter(Mandatory)] [int]    $TaskId,
+        [Parameter(Mandatory)] [string] $TaskTitle,
+        [Parameter(Mandatory)] [int]    $ElapsedSeconds,
+        [Parameter(Mandatory)] [int]    $ItemCount,
+        [Parameter(Mandatory)] [int]    $ReminderMinutes
+    )
+
+    $iconFire  = $script:UnplannedIconFire
+    $iconClock = $script:UnplannedIconClock
+    $elapsed   = Format-UnplannedElapsed -Seconds $ElapsedSeconds
+
+    Clear-Host
+    Write-Host ""
+    Write-Host "  $iconFire UNPLANNED WORK SESSION" -ForegroundColor Red
+    Write-Host "  Task #$TaskId  $TaskTitle" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "  $iconClock Elapsed: $elapsed     Items captured: $ItemCount" -ForegroundColor Cyan
+    Write-Host "  Reminder every $ReminderMinutes min" -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "  [Space] log an item     [Esc/Q] stop and debrief" -ForegroundColor DarkGray
+}
+
+
+function Format-UnplannedItemsDescription {
+    # Composes the Task description from the captured items as a single physical
+    # line with <br/> separators - same cmd.exe-CRLF-truncation guard the timer
+    # uses for its discussion body (see Format-TimerCommentBody).
+    param(
+        [Parameter(Mandatory)] [string] $TaskTitle,
+        [object[]] $Items
+    )
+
+    $bullet = $script:UnplannedIconBullet
+    $header = "Unplanned work log: $TaskTitle"
+    $lines  = @($header, '')
+
+    if (@($Items).Count -eq 0) {
+        $lines += '(no items captured)'
+    } else {
+        foreach ($entry in $Items) {
+            $lines += "$bullet [$($entry.Time)] $($entry.Text)"
+        }
+    }
+
+    $body = $lines -join '<br/>'
+    return $body
+}
+
+
+function Format-UnplannedDebriefComment {
+    param(
+        [Parameter(Mandatory)] [int]    $ElapsedMinutes,
+        [Parameter(Mandatory)] [int]    $ItemCount,
+        [string] $Debrief,
+        [string] $FutureFeature
+    )
+
+    $iconCheck  = $script:UnplannedIconCheck
+    $iconMemo   = $script:UnplannedIconMemo
+    $iconRocket = $script:UnplannedIconRocket
+    $timestamp  = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+
+    $lines = @(
+        "$iconCheck Unplanned work debrief - $ElapsedMinutes min, $ItemCount item(s)",
+        "<em>$timestamp</em>",
+        ''
+    )
+
+    if ($Debrief) {
+        $lines += "$iconMemo Debrief:"
+        $lines += $Debrief
+        $lines += ''
+    }
+
+    if ($FutureFeature) {
+        $lines += "$iconRocket Future opportunity:"
+        $lines += $FutureFeature
+        $lines += ''
+    }
+
+    $lines += '<em>via bashcuts Start-UnplannedWork</em>'
+
+    $body = $lines -join '<br/>'
+    return $body
+}
+
+
+function Get-UnplannedLedgerPath {
+    # Per-day ledger under the AzDO cache dir so New-UnplannedWorkDebrief can
+    # total time across firefights (AzDO doesn't store our per-session minutes).
+    # Returns $null when the cache layout isn't available.
+    param([datetime] $Date = (Get-Date))
+
+    if (-not (Get-Command Get-AzDevOpsCachePaths -ErrorAction SilentlyContinue)) {
+        return $null
+    }
+
+    $paths = Get-AzDevOpsCachePaths
+    if (-not $paths.Dir) {
+        return $null
+    }
+
+    $stamp = $Date.ToString('yyyy-MM-dd')
+    $path  = Join-Path $paths.Dir "unplanned-$stamp.json"
+    return $path
+}
+
+
+function Add-UnplannedLedgerEntry {
+    param(
+        [Parameter(Mandatory)] [int]    $StoryId,
+        [Parameter(Mandatory)] [int]    $TaskId,
+        [Parameter(Mandatory)] [string] $Title,
+        [Parameter(Mandatory)] [int]    $Minutes,
+        [Parameter(Mandatory)] [int]    $ItemCount
+    )
+
+    $path = Get-UnplannedLedgerPath
+    if (-not $path) {
+        return
+    }
+
+    $dir = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    $existing = @()
+    if (Test-Path -LiteralPath $path) {
+        try {
+            $existing = @(Get-Content -LiteralPath $path -Raw | ConvertFrom-Json)
+        }
+        catch {
+            $existing = @()
+        }
+    }
+
+    $entry = [PSCustomObject]@{
+        StoryId   = $StoryId
+        TaskId    = $TaskId
+        Title     = $Title
+        Minutes   = $Minutes
+        ItemCount = $ItemCount
+        EndedAt   = (Get-Date).ToString('o')
+    }
+
+    $all  = @($existing) + $entry
+    $json = ConvertTo-Json -InputObject @($all) -Depth 5 -AsArray
+    Set-Content -LiteralPath $path -Value $json -Encoding UTF8
+}
+
+
+function Format-UnplannedDailyDebrief {
+    param(
+        [Parameter(Mandatory)] [object[]] $Entries,
+        [Parameter(Mandatory)] [int]      $TotalMinutes,
+        [datetime] $Date = (Get-Date)
+    )
+
+    $iconCheck = $script:UnplannedIconCheck
+    $iconClock = $script:UnplannedIconClock
+    $bullet    = $script:UnplannedIconBullet
+    $stamp     = $Date.ToString('yyyy-MM-dd')
+
+    $lines = @(
+        "$iconCheck Unplanned work daily roll-up - $stamp",
+        "$iconClock $($Entries.Count) firefight(s), $TotalMinutes min total",
+        ''
+    )
+
+    foreach ($e in $Entries) {
+        $lines += "$bullet Task #$($e.TaskId) - $($e.Minutes) min, $($e.ItemCount) item(s): $($e.Title)"
+    }
+
+    $lines += ''
+    $lines += '<em>via bashcuts New-UnplannedWorkDebrief</em>'
+
+    $body = $lines -join '<br/>'
+    return $body
+}
+
+
+function Start-UnplannedWork {
+    # Orchestrator. Find-or-create today's daily story, create a child Task for
+    # this firefight, then run the foreground session: Space logs a timestamped
+    # item, Esc/Q stops. A reminder balloon fires every -ReminderMinutes. On
+    # stop the captured items flush to the Task description and a debrief comment
+    # (time spent + notes + optional future-feature opportunity) is posted; the
+    # session is recorded in the day's ledger for New-UnplannedWorkDebrief.
+    #
+    # UTF-8 output encoding is applied around the loop so the glyphs render in
+    # non-UTF-8 codepages, and restored on exit (including Ctrl-C) via finally.
+    [CmdletBinding()]
+    param(
+        [string] $Title,
+        [ValidateRange(1, [int]::MaxValue)] [int] $ReminderMinutes = $script:UnplannedDefaultReminderMinutes,
+        [switch] $NoReminder
+    )
+
+    if (-not (Test-AzDevOpsCreateGate -CommandName 'Start-UnplannedWork')) {
+        return
+    }
+
+    $storyId = Get-UnplannedWorkDailyStory
+    if ($storyId -le 0) {
+        Write-Host "No daily Unplanned Work story available - aborting." -ForegroundColor Red
+        return
+    }
+
+    if (-not $Title) {
+        $Title = Read-Host 'What is this firefight about? (Task title)'
+    }
+    if (-not $Title) {
+        Write-Host "Task title is required - aborting." -ForegroundColor Red
+        return
+    }
+
+    $taskId = New-UnplannedWorkTask -Title $Title -StoryId $storyId
+    if ($taskId -le 0) {
+        Write-Host "Could not create the firefight Task - aborting." -ForegroundColor Red
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Firefight Task #$taskId created under story #$storyId." -ForegroundColor Green
+    Write-Host "Starting session. Space logs an item, Esc/Q stops and debriefs." -ForegroundColor Green
+    Start-Sleep -Seconds 2
+
+    $startTime = Get-Date
+    $items = New-Object System.Collections.Generic.List[object]
+
+    $balloon = if ($NoReminder) {
+        $null
+    } else {
+        New-UnplannedBalloon
+    }
+
+    $previousEncoding = [Console]::OutputEncoding
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+    try {
+        $reminderSeconds = $ReminderMinutes * 60
+        $pollsPerSecond  = $script:UnplannedPollsPerSecond
+        $pollIntervalMs  = $script:UnplannedPollIntervalMs
+
+        $elapsed        = 0
+        $lastReminderAt = 0
+        $stopRequested  = $false
+
+        Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds 0 -ItemCount 0 -ReminderMinutes $ReminderMinutes
+
+        while (-not $stopRequested) {
+            for ($p = 0; $p -lt $pollsPerSecond; $p++) {
+                $key = Read-UnplannedKeyPress
+
+                if ($key -eq 'stop') {
+                    $stopRequested = $true
+                    break
+                }
+
+                if ($key -eq 'space') {
+                    Write-Host ""
+                    $itemText = Read-Host 'Log item'
+
+                    if ($itemText) {
+                        $record = [PSCustomObject]@{
+                            Time = (Get-Date).ToString('HH:mm')
+                            Text = $itemText
+                        }
+                        $items.Add($record)
+                    }
+
+                    Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds $elapsed -ItemCount $items.Count -ReminderMinutes $ReminderMinutes
+                    break
+                }
+
+                Start-Sleep -Milliseconds $pollIntervalMs
+            }
+
+            if ($stopRequested) {
+                break
+            }
+
+            $elapsed++
+
+            Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds $elapsed -ItemCount $items.Count -ReminderMinutes $ReminderMinutes
+
+            if (-not $NoReminder -and ($elapsed - $lastReminderAt) -ge $reminderSeconds) {
+                Show-UnplannedReminder -Balloon $balloon -TaskId $taskId -TaskTitle $Title
+                $lastReminderAt = $elapsed
+            }
+        }
+
+        $endTime = Get-Date
+        $elapsedMinutes = [int][math]::Round(($endTime - $startTime).TotalMinutes)
+        if ($elapsedMinutes -lt 1) {
+            $elapsedMinutes = 1
+        }
+
+        [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+        Clear-Host
+        $iconCheck = $script:UnplannedIconCheck
+        Write-Host "$iconCheck Unplanned session complete - $elapsedMinutes min, $($items.Count) item(s)." -ForegroundColor Green
+        Write-Host ""
+
+        $descriptionBody = Format-UnplannedItemsDescription -TaskTitle $Title -Items @($items)
+        Write-Host "Updating Task #$taskId description with captured items..." -ForegroundColor Cyan
+        $descResult = Set-AzDevOpsWorkItemField -Id $taskId -Fields @("System.Description=$descriptionBody")
+        if ($descResult.ExitCode -ne 0) {
+            Write-Host "  Could not update description: $($descResult.Error)" -ForegroundColor Yellow
+        }
+
+        $iconMemo = $script:UnplannedIconMemo
+        $debrief = Read-Host "$iconMemo Debrief notes for this firefight"
+
+        $futureFeature = ''
+        if (Read-UnplannedYesNo -Prompt 'Is there an opportunity for a new feature / user story to prevent this firefight in future?') {
+            $futureFeature = Read-Host '  Describe the opportunity (one line)'
+
+            if ($futureFeature -and (Read-UnplannedYesNo -Prompt '  Create that user story now?')) {
+                if (Get-Command az-New-AzDevOpsUserStory -ErrorAction SilentlyContinue) {
+                    az-New-AzDevOpsUserStory -Title $futureFeature | Out-Null
+                }
+            }
+        }
+
+        $commentBody = Format-UnplannedDebriefComment `
+            -ElapsedMinutes $elapsedMinutes `
+            -ItemCount      $items.Count `
+            -Debrief        $debrief `
+            -FutureFeature  $futureFeature
+
+        Write-Host ""
+        Write-Host "Posting debrief comment to Task #$taskId..." -ForegroundColor Cyan
+        $commentResult = Add-AzDevOpsDiscussionComment -Id $taskId -Body $commentBody
+        if ($commentResult.ExitCode -eq 0) {
+            Write-Host "$iconCheck Debrief posted on Task #$taskId." -ForegroundColor Green
+            Write-Host "   View: az-Open-AzDevOpsAssigned $taskId" -ForegroundColor DarkGray
+        } else {
+            Write-Host "Debrief comment failed: $($commentResult.Error)" -ForegroundColor Red
+        }
+
+        Add-UnplannedLedgerEntry -StoryId $storyId -TaskId $taskId -Title $Title -Minutes $elapsedMinutes -ItemCount $items.Count
+    }
+    finally {
+        [Console]::OutputEncoding = $previousEncoding
+        if ($null -ne $balloon) {
+            $balloon.Dispose()
+        }
+    }
+}
+
+
+function New-UnplannedWorkDebrief {
+    # End-of-day roll-up. Reads the day's ledger, totals time across firefights,
+    # prints the per-Task breakdown, and (on confirm) posts a roll-up comment on
+    # the daily story. -Date debriefs a past day's ledger.
+    [CmdletBinding()]
+    param([datetime] $Date = (Get-Date))
+
+    if (-not (Test-AzDevOpsCreateGate -CommandName 'New-UnplannedWorkDebrief')) {
+        return
+    }
+
+    $path = Get-UnplannedLedgerPath -Date $Date
+    if (-not $path -or -not (Test-Path -LiteralPath $path)) {
+        Write-Host "No unplanned-work ledger for $($Date.ToString('yyyy-MM-dd'))." -ForegroundColor Yellow
+        return
+    }
+
+    $entries = @(Get-Content -LiteralPath $path -Raw | ConvertFrom-Json)
+    if ($entries.Count -eq 0) {
+        Write-Host "Ledger is empty for $($Date.ToString('yyyy-MM-dd'))." -ForegroundColor Yellow
+        return
+    }
+
+    $totalMinutes = [int]($entries | Measure-Object -Property Minutes -Sum).Sum
+    $storyId = [int]$entries[0].StoryId
+
+    Write-Host ""
+    Write-Host "Unplanned work - $($Date.ToString('yyyy-MM-dd'))" -ForegroundColor Cyan
+    foreach ($e in $entries) {
+        Write-Host ("  Task #{0}  {1} min  {2} item(s)  {3}" -f $e.TaskId, $e.Minutes, $e.ItemCount, $e.Title)
+    }
+    Write-Host ("  Total: {0} firefight(s), {1} min" -f $entries.Count, $totalMinutes) -ForegroundColor Green
+
+    if (-not (Read-UnplannedYesNo -Prompt "Post a roll-up debrief comment on story #${storyId}?")) {
+        return
+    }
+
+    $body = Format-UnplannedDailyDebrief -Entries $entries -TotalMinutes $totalMinutes -Date $Date
+    $result = Add-AzDevOpsDiscussionComment -Id $storyId -Body $body
+    if ($result.ExitCode -eq 0) {
+        Write-Host "Posted daily roll-up on story #$storyId." -ForegroundColor Green
+    } else {
+        Write-Host "Failed to post roll-up: $($result.Error)" -ForegroundColor Red
+    }
+}

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -105,6 +105,13 @@ if ($azdevops_create -ne $NULL) {
     Write-Host "no azdevops_create.ps1"
 }
 
+$azdevops_unplanned = Get-Content "$path_to_bashcuts\powcuts_by_cli\azdevops_unplanned.ps1"
+if ($azdevops_unplanned -ne $NULL) {
+ . "$path_to_bashcuts\powcuts_by_cli\azdevops_unplanned.ps1"
+} else {
+    Write-Host "no azdevops_unplanned.ps1"
+}
+
 $azdevops_schema = Get-Content "$path_to_bashcuts\powcuts_by_cli\azdevops_schema.ps1"
 if ($azdevops_schema -ne $NULL) {
  . "$path_to_bashcuts\powcuts_by_cli\azdevops_schema.ps1"


### PR DESCRIPTION
<!-- toc:start -->
## Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #90 |
| [Changes](#changes) | ✅ 5 files |
| [Test Plan](#test-plan) | ✅ 4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4498798161) |
| 💠 PowerShell Engineer Review | ✅ APPROVE w/ nits — [View](#issuecomment-4498826447) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4498809604) |
| 🧼 Clean-Code Engineer Review | ❌→✅ fixed in `d01d635` — [View](#issuecomment-4498804048) |
| ✅ Criteria Check | ✅ PASS (7/9, 2 manual) — [View](#issuecomment-4498859661) |
| 📚 Docs Check | ✅ CURRENT (ran inline) |

> Review fix-ups: `d01d635` extracted `Assert-AzDevOpsFieldTokens` (clean-code blocking HIGH), drove the on-screen timer from wall-clock (PowerShell HIGH), and split out `Invoke-UnplannedDebrief`. `6956191` added the §11 subsystem diagram + §12 dependency-map cluster. `f8d6b78` prefixed the public commands with `az-` for tab-completion discovery (`az-Start-UnplannedWork`, `az-New-UnplannedWorkDebrief`, and the existing `az-Start-TimerSession`). The only outstanding gate is a local `pwsh` parse (unavailable on this runner).
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

`az-Start-UnplannedWork` gates on auth, finds-or-creates today's daily story and a child Task, then runs a foreground session (Space logs an item, a balloon nags every `-ReminderMinutes`, Esc/Q stops). On stop `Invoke-UnplannedDebrief` flushes items to the Task description, posts one debrief comment, optionally hands off to `az-New-AzDevOpsUserStory`, and records the session in a per-day ledger that `az-New-UnplannedWorkDebrief` later totals into a roll-up comment.

```mermaid
flowchart TD
    Start([az-Start-UnplannedWork]):::pub --> Gate{Test-AzDevOpsCreateGate}
    Gate -- abort --> Done0([return])
    Gate -- ok --> Daily[Get-UnplannedWorkDailyStory<br/>find-or-create]:::priv
    Daily --> AzCreate["az boards work-item create<br/>Story + child Task + parent link"]:::io
    AzCreate --> Loop{session loop<br/>Read-UnplannedKeyPress}

    Loop -- Space --> LogItem[append timestamped item]:::priv
    LogItem --> Loop
    Loop -- every ReminderMinutes --> Balloon["balloon reminder<br/>NotifyIcon"]:::io
    Balloon --> Loop
    Loop -- Esc/Q --> Debrief[Invoke-UnplannedDebrief]:::priv

    Debrief --> Desc["Set-AzDevOpsWorkItemField<br/>flush items to description"]:::io
    Debrief --> Comment["Add-AzDevOpsDiscussionComment<br/>time + notes + opportunity"]:::io
    Debrief -. future opportunity .-> NewStory([az-New-AzDevOpsUserStory]):::pub
    Debrief --> Ledger[(unplanned-DATE.json)]:::io

    DebriefDay([az-New-UnplannedWorkDebrief]):::pub --> ReadLedger[read + total Minutes]:::priv
    ReadLedger --> Ledger
    ReadLedger --> Rollup["roll-up comment<br/>on daily story"]:::io

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Adds `az-Start-UnplannedWork`, a free-for-all companion to the Pomodoro timer for firefighting that can't be time-boxed. Each day rolls up under a single **Unplanned Work — yyyy-MM-dd** User Story; every firefight becomes a child **Task** with its own debrief. PowerShell-only, mirroring `az-Start-TimerSession` (the Windows balloon reminder + key-poll loop have no bash counterpart).

## Issue

Closes #90

## Changes

- **`powcuts_by_cli/azdevops_unplanned.ps1`** (new) — `az-Start-UnplannedWork` (find-or-create daily story → child Task → foreground Space-to-log / Esc-Q-to-stop loop with a balloon reminder every `-ReminderMinutes` → flush items to the Task description + post a debrief comment with time, notes, and an optional future-feature opportunity) and `az-New-UnplannedWorkDebrief` (per-day local ledger roll-up onto the daily story).
- **`powcuts_by_cli/azdevops_db.ps1`** — adds `Set-AzDevOpsWorkItemField` data-plane wrapper + the shared `Assert-AzDevOpsFieldTokens` `--fields` guard.
- **`powcuts_by_cli/pow_timer.ps1`** — renames `Start-TimerSession` → `az-Start-TimerSession` for `az-<tab>` discovery parity.
- **`powcuts_home.ps1`** — dot-sources the new file.
- **`docs/azure-devops-diagrams.md`** — §11 unplanned-work subsystem flowchart + §12 dependency-map cluster.
- **`README.md`** — "Unplanned work sessions" section + ToC entry.

## Test Plan

- [ ] `[Parser]::ParseFile(...)` passes for `azdevops_unplanned.ps1`, `azdevops_db.ps1`, and `pow_timer.ps1` (CI gate couldn't run — `pwsh` not on the runner)
- [ ] Fresh PowerShell terminal: reload `$profile`, then `az-Start-Unpla<Tab>` / `az-New-UnplannedWork<Tab>` / `az-Start-Timer<Tab>` autocomplete
- [ ] `az-Start-UnplannedWork -Title "test" -ReminderMinutes 1` creates a daily story + child Task, logs an item on Space, fires a balloon after 1 min, and on Esc writes the description + posts a debrief comment
- [ ] `az-New-UnplannedWorkDebrief` totals the day's firefights and posts a roll-up comment on the daily story

https://claude.ai/code/session_01K4cU9bkhq1ujGXwegPcg4t