### PR TITLE
Fix double-quote escaping when az-New-AzDevOps* creators pass titles/fields to the az CLI

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -727,6 +727,7 @@ graph LR
     CmdDisp[Format-AzDevOpsCommandDisplay]:::priv
     CmdHead[Get-AzDevOpsCommandHeadline]:::priv
     EchoLn[Write-AzDevOpsQueryEcho]:::priv
+    ConvNative[ConvertTo-AzDevOpsNativeArgList]:::priv
 
     %% Platform + on-open background-sync helpers
     Plat[Get-AzDevOpsPlatform]:::priv
@@ -899,6 +900,7 @@ graph LR
     AzJson --> CmdDisp
     AzJson --> CmdHead
     AzJson --> EchoLn
+    AzJson --> ConvNative
     AzJson --> Az
     InvokeDS --> Stderr1
     InvokeDS --> DStatus

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -125,6 +125,39 @@ function Get-AzDevOpsConfiguredDefaults {
 }
 
 
+function ConvertTo-AzDevOpsNativeArgList {
+    # Escapes embedded double quotes in each native-command argument so values
+    # survive the hand-off to the az CLI intact. PowerShell does not escape an
+    # embedded " when marshaling an argument array to a native process on
+    # Windows PowerShell 5.1, nor when the target is a batch wrapper like
+    # az.cmd under PowerShell 7.x - the quote terminates the argument early and
+    # a Title such as  Add "dark mode" toggle  reaches az mangled.
+    #
+    # Per the Win32 CommandLineToArgvW rules each literal " becomes \" and any
+    # run of backslashes immediately preceding a quote is doubled, so the
+    # python process az.cmd launches reconstructs the original text. Outer
+    # quoting (for values containing spaces) is left to PowerShell's Legacy
+    # marshaling, which Invoke-AzDevOpsAzJson pins. Private helper - unapproved
+    # verb is fine since it isn't user-facing.
+    param([Parameter(Mandatory)] [string[]] $ArgList)
+
+    $quoteEscapePattern = '(\\*)"'
+    $quoteEscapeReplace = '${1}${1}\"'
+
+    $escaped = @(foreach ($arg in $ArgList) {
+        $value = [string]$arg
+
+        if ($value -notmatch '"') {
+            $value
+        } else {
+            $value -replace $quoteEscapePattern, $quoteEscapeReplace
+        }
+    })
+
+    return $escaped
+}
+
+
 function Invoke-AzDevOpsAzJson {
     # Generic wrapper around `az ... --output json` that captures stdout JSON
     # and stderr text separately. The canonical JSON+error path used by every
@@ -143,10 +176,20 @@ function Invoke-AzDevOpsAzJson {
     $commandDisplay = Format-AzDevOpsCommandDisplay -ArgList $ArgList
     Write-AzDevOpsQueryEcho -Message $commandDisplay -Color 'DarkCyan'
 
+    $invokeArgs = ConvertTo-AzDevOpsNativeArgList -ArgList $ArgList
+
+    # Pin Legacy native-arg marshaling so the manual " -> \" escaping in
+    # ConvertTo-AzDevOpsNativeArgList is the only escaping applied. Under
+    # PowerShell 7.3+ Standard mode PS would re-escape our backslashes and
+    # double-mangle the value; Legacy leaves them untouched and just adds outer
+    # quotes for values containing spaces. The variable does not exist on
+    # Windows PowerShell 5.1 (already Legacy), where this is a harmless local.
+    $PSNativeCommandArgumentPassing = 'Legacy'
+
     $stderrFile = [System.IO.Path]::GetTempFileName()
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     try {
-        $json = & az @ArgList --output json 2>$stderrFile
+        $json = & az @invokeArgs --output json 2>$stderrFile
         $exit = $LASTEXITCODE
         $stderr = if (Test-Path -LiteralPath $stderrFile) {
             (Get-Content -LiteralPath $stderrFile -Raw)


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #94 |
| [Changes](#changes) | ✅ 1 file |
| [Test Plan](#test-plan) | 6 items (manual) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4522086000) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4522093519) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4522094642) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4522090849) |
| 📚 Docs Check | ✅ CURRENT — [View](#issuecomment-4522102473) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4522108159) |
<!-- toc:end -->

## Summary

`az-New-AzDevOps*` creators (`az-New-AzDevOpsUserStory`, `az-New-AzDevOpsFeature`, `az-New-AzDevOpsFeatureStories`) funnel every `az` call through `Invoke-AzDevOpsAzJson`, which ran `& az @ArgList` with no quote handling. PowerShell does not escape an embedded `"` when marshaling an argument array to a native process on Windows PowerShell 5.1, nor to the `az.cmd` batch wrapper under PS 7.x — so a Title such as `Add "dark mode" toggle` reached `az` mangled (truncated title or argparse error).

This fixes the escaping once at the single choke point, so create / update / relation-add / `--fields` are all hardened.

## Issue

Closes #94

## Changes

- `powcuts_by_cli/azdevops_db.ps1`
  - New private helper `ConvertTo-AzDevOpsNativeArgList` — applies Win32 `CommandLineToArgvW` escaping (each `"` → `\"`, and runs of backslashes immediately preceding a quote are doubled).
  - `Invoke-AzDevOpsAzJson` now transforms `$ArgList` through the helper and pins `$PSNativeCommandArgumentPassing = 'Legacy'` before `& az`, so the manual escaping is the *only* escaping applied — consistent on PS 5.1 and 7.x (avoids 7.3+ Standard-mode double-escaping).
  - The command-echo line (`Format-AzDevOpsCommandDisplay`) is unchanged — it already renders `\"` for display.
- `docs/azure-devops-diagrams.md` — added the new private helper as a node + `AzJson --> ConvNative` edge in Diagram 9 (the dependency completeness map).

This is **PowerShell-only**: the bash side (`bashcuts_by_cli/.az_bashcuts`) passes values through ordinary `"$VAR"` expansion and already preserves embedded quotes.

## Test Plan

- [ ] `. ./powcuts_home.ps1` in a fresh PowerShell terminal
- [ ] `az-New-AzDevOpsUserStory -Title 'Add "dark mode" toggle' -Description 'see "spec"'` — created work item retains the literal double quotes in title and description
- [ ] Acceptance Criteria / custom `--fields` value containing `"` is preserved
- [ ] Echoed `az ...` line still renders `\"` and matches what ran
- [ ] No regression: a plain no-quote create and a WIQL view (e.g. `az-Show-AzDevOpsAssigned`) still work
- [ ] Verify on both Windows PowerShell 5.1 and PowerShell 7.x if available

> Note: no `pwsh` is available in the CI/build container, so the parser check was skipped and the above must be verified in a real PowerShell session.