### PR TITLE
Template the User Story description prompt into As-a / I-want / So-that

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -389,7 +389,7 @@ flowchart TD
     TitleEmpty -- yes --> Abort4([abort])
     TitleEmpty -- no --> Desc
 
-    Desc -- no --> ReadDesc["Read-Host 'description'"]
+    Desc -- no --> ReadDesc["Read-AzDevOpsUserStoryDescription<br/>(As-a / I-want / so-that prompts)"]
     Desc -- yes --> Prio{Priority 1-4?}
     ReadDesc --> Prio
     Prio -- no --> ReadPrio[Read-AzDevOpsPriority]
@@ -782,6 +782,7 @@ graph LR
     Pri[Read-AzDevOpsPriority]:::priv
     Pts[Read-AzDevOpsStoryPoints]:::priv
     AC[Read-AzDevOpsAcceptanceCriteria]:::priv
+    USDesc[Read-AzDevOpsUserStoryDescription]:::priv
     PFeat[Read-AzDevOpsFeaturePick]:::priv
     PEpic[Read-AzDevOpsEpicPick]:::priv
     PParent[Read-AzDevOpsParentPick]:::priv
@@ -1011,6 +1012,7 @@ graph LR
 
     NewS --> CGate
     NewS --> ReadH
+    NewS --> USDesc
     NewS --> Pri
     NewS --> Pts
     NewS --> AC

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -379,7 +379,7 @@ function az-New-AzDevOpsUserStory {
     }
 
     if (-not $PSBoundParameters.ContainsKey('Description')) {
-        $Description = Read-Host 'What is the description?'
+        $Description = Read-AzDevOpsUserStoryDescription
     }
 
     if ($Priority -lt 1 -or $Priority -gt 4) {

--- a/powcuts_by_cli/azdevops_create_pickers.ps1
+++ b/powcuts_by_cli/azdevops_create_pickers.ps1
@@ -103,6 +103,32 @@ function Read-AzDevOpsAcceptanceCriteria {
 }
 
 
+function Read-AzDevOpsUserStoryDescription {
+    # Builds the User Story description from the canonical three-clause
+    # template. Each clause is required - re-prompts until a non-empty value
+    # is entered - then joins them single-spaced into one prose sentence:
+    # "As a <persona> I want <outcome> so that <benefit>".
+    $persona = ''
+    while (-not $persona) {
+        $persona = (Read-Host 'As a ...').Trim()
+    }
+
+    $outcome = ''
+    while (-not $outcome) {
+        $outcome = (Read-Host 'I want ...').Trim()
+    }
+
+    $benefit = ''
+    while (-not $benefit) {
+        $benefit = (Read-Host 'so that ...').Trim()
+    }
+
+    $description = "As a $persona I want $outcome so that $benefit"
+
+    return $description
+}
+
+
 function Test-AzDevOpsAreaPathMatch {
     # Returns $true when $CandidatePath equals any element of $AllowedPaths
     # exactly OR is a sub-path of one (matches at backslash boundary). Path


### PR DESCRIPTION

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #95 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | ✅ 4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4522409123) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4522412667) |
| 🛡️ Security Audit | ✅ APPROVE — [View](#issuecomment-4522406561) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4522413561) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4522420125) |

<!-- pr-diagram:start -->
## How it works

`az-New-AzDevOpsUserStory` is the entry point. When `-Description` is omitted it now delegates to the new private helper `Read-AzDevOpsUserStoryDescription`, which collects the three required user-story clauses and joins them into one prose sentence before the rest of the create flow (priority, story points, acceptance criteria, feature pick, `az` work-item create) proceeds unchanged.

```mermaid
flowchart TD
    NewS([az-New-AzDevOpsUserStory]):::pub
    DescQ{Description<br/>param bound?}
    Helper[Read-AzDevOpsUserStoryDescription]:::priv
    Persona["prompt: As a ...<br/>(each clause re-prompts<br/>until non-empty)"]
    Outcome["prompt: I want ..."]
    Benefit["prompt: so that ..."]
    Build["join single-spaced:<br/>As a {persona} I want {outcome} so that {benefit}"]
    Rest["rest of create flow<br/>(priority, story points, AC,<br/>feature pick, az work-item create)"]:::io

    NewS --> DescQ
    DescQ -- "yes (use supplied value)" --> Rest
    DescQ -- no --> Helper
    Helper --> Persona --> Outcome --> Benefit --> Build
    Build --> Rest

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
`az-New-AzDevOpsUserStory` now builds its description from the canonical three-clause user-story template instead of a single free-form prompt. A new `Read-AzDevOpsUserStoryDescription` helper prompts `As a ...`, `I want ...`, `so that ...` (each required, re-prompts on empty) and joins the answers single-spaced into `As a {persona} I want {outcome} so that {benefit}`.

## Issue
Closes #95

## Changes
- `powcuts_by_cli/azdevops_create_pickers.ps1` — add `Read-AzDevOpsUserStoryDescription` helper
- `powcuts_by_cli/azdevops_create.ps1` — `az-New-AzDevOpsUserStory` calls the helper in place of the single `Read-Host`

Passing `-Description "<text>"` still bypasses the prompts (existing parameter behavior preserved). PowerShell-only by request — bash `az-create-userstory` is intentionally out of scope.

## Test Plan
- [ ] Fresh PowerShell terminal — `az-New-AzDevOpsUserStory`, answer the three prompts, confirm the created story description reads `As a {persona} I want {outcome} so that {benefit}`
- [ ] Each prompt re-asks when left blank
- [ ] `az-New-AzDevOpsUserStory -Description "explicit text" -Title "t"` skips the three template prompts
- [ ] `azdevops_create.ps1` and `azdevops_create_pickers.ps1` parse cleanly under `pwsh` (unavailable in CI env — verify locally)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gn8J97RwzhguuvXZ7UpUyC)_