### PR TITLE
Replace timer countdown with WPF circular overlay and add action buttons

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -601,13 +601,16 @@ flowchart TD
     NewStory --> HaveStory
 
     HaveStory --> Task["New-UnplannedWorkTask<br/>→ New-AzDevOpsWorkItem (Task)<br/>→ Invoke-AzDevOpsParentLink"]
-    Task --> Loop[session loop — Read-UnplannedKeyPress poll]
+    Task --> PlatCheck{Test-WpfIsWindows?}
+    PlatCheck -- Windows --> WpfLoop["Show-WpfStopwatch<br/>(WPF circular overlay)<br/>Log Item / Capture Story / Stop"]
+    PlatCheck -- macOS/Linux --> Loop[session loop — Read-UnplannedKeyPress poll]
 
     Loop -- Space --> LogItem["Read-Host item<br/>append {Time, Text}"]
     LogItem --> Loop
     Loop -- every ReminderMinutes --> Balloon["Show-UnplannedReminder<br/>(New-UnplannedBalloon NotifyIcon)"]
     Balloon --> Loop
     Loop -- Esc/Q --> Debrief[Invoke-UnplannedDebrief]
+    WpfLoop -- Stop/right-click --> Debrief
 
     Debrief --> FlushDesc["Format-UnplannedItemsDescription<br/>→ Set-AzDevOpsWorkItemField<br/>→ az boards work-item update (System.Description)"]
     FlushDesc --> AskFuture{future-feature opportunity?}
@@ -680,6 +683,7 @@ graph LR
     NewUWTask[New-UnplannedWorkTask]:::priv
     InvUWDebrief[Invoke-UnplannedDebrief]:::priv
     UWBalloon[New-UnplannedBalloon]:::priv
+    WpfStopwatch[Show-WpfStopwatch]:::priv
     UWLedger[Add-UnplannedLedgerEntry]:::priv
 
     %% Step helpers
@@ -1130,6 +1134,7 @@ graph LR
     NewUWTask --> NewWI
     NewUWTask --> InvLink
     StartUW --> UWBalloon
+    StartUW --> WpfStopwatch
     StartUW --> InvUWDebrief
     InvUWDebrief --> SetField
     InvUWDebrief --> AddDisc

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -37,12 +37,6 @@ $script:UnplannedIconRocket = [char]::ConvertFromUtf32(0x1F680)   # rocket
 $script:UnplannedIconBullet = [char]::ConvertFromUtf32(0x2022)    # bullet
 
 
-function Test-UnplannedIsWindows {
-    $isWin = ($IsWindows -or ($env:OS -eq 'Windows_NT'))
-    return $isWin
-}
-
-
 function Read-UnplannedYesNo {
     param([Parameter(Mandatory)] [string] $Prompt)
 
@@ -234,7 +228,7 @@ function New-UnplannedBalloon {
     # tick and disposed in the orchestrator's finally so a multi-hour session
     # doesn't accumulate tray icons. Returns $null off Windows or when the
     # Windows.Forms types aren't available, in which case reminders no-op.
-    if (-not (Test-UnplannedIsWindows)) {
+    if (-not (Test-WpfIsWindows)) {
         return $null
     }
 
@@ -818,7 +812,7 @@ function az-Start-UnplannedWork {
     [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
     try {
-        $onWindows = Test-UnplannedIsWindows
+        $onWindows = Test-WpfIsWindows
 
         if ($onWindows) {
             $items = Show-WpfStopwatch `

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -553,6 +553,292 @@ function Invoke-UnplannedDebrief {
 }
 
 
+function Show-WpfStopwatch {
+    # WPF circular overlay stopwatch for Windows unplanned-work sessions.
+    # Arc fills as time passes (amber colour distinguishes it from the Pomodoro
+    # blue). "Log Item" opens an input dialog; "Capture Story" hides the overlay,
+    # runs az-New-AzDevOpsUserStory in the terminal, then resumes. "Stop" /
+    # right-click closes and returns the list of captured items.
+    param(
+        [Parameter(Mandatory)] [int]    $TaskId,
+        [Parameter(Mandatory)] [string] $TaskTitle,
+        [Parameter(Mandatory)] [int]    $ReminderMinutes,
+        [switch] $NoReminder
+    )
+
+    Add-Type -AssemblyName PresentationFramework, WindowsBase, PresentationCore
+    Add-Type -AssemblyName Microsoft.VisualBasic
+
+    $colorBg       = $script:WpfColorBackground
+    $colorStroke   = $script:WpfColorStroke
+    $colorButton   = $script:WpfColorButton
+    $colorHint     = $script:WpfColorHint
+    $colorProgress = '#D97706'   # Amber — distinguishes unplanned from Pomodoro (blue)
+
+    $converter     = [System.Windows.Media.BrushConverter]::new()
+    $brushBg       = $converter.ConvertFromString($colorBg)
+    $brushStroke   = $converter.ConvertFromString($colorStroke)
+    $brushProgress = $converter.ConvertFromString($colorProgress)
+    $brushButton   = $converter.ConvertFromString($colorButton)
+    $brushHint     = $converter.ConvertFromString($colorHint)
+    $brushWhite    = [System.Windows.Media.Brushes]::White
+    $brushClear    = [System.Windows.Media.Brushes]::Transparent
+
+    $windowSize     = $script:WpfWindowSize
+    $center         = $script:WpfCircleCenter
+    $radius         = $script:WpfCircleRadius
+    $arcStartX      = $script:WpfArcStartX
+    $arcStartY      = $script:WpfArcStartY
+    $maxDisplaySecs = 3600   # arc fills to full at 60 minutes
+
+    $Script:WpfElapsed = 0.0
+    $Script:WpfItems   = New-Object System.Collections.Generic.List[object]
+
+    $balloon = if ($NoReminder) {
+        $null
+    } else {
+        New-UnplannedBalloon
+    }
+
+    $reminderIntervalMs = $ReminderMinutes * 60 * 1000
+
+    # ---- Build window ----
+
+    $mainWin = New-Object System.Windows.Window -Property @{
+        Title                 = 'Unplanned Work'
+        SizeToContent         = 'WidthAndHeight'
+        WindowStyle           = 'None'
+        AllowsTransparency    = $true
+        Background            = $brushClear
+        Topmost               = $true
+        WindowStartupLocation = 'CenterScreen'
+    }
+
+    $circleGrid = New-Object System.Windows.Controls.Grid -Property @{
+        Width  = $windowSize
+        Height = $windowSize
+    }
+
+    $mainCircle = New-Object System.Windows.Shapes.Ellipse -Property @{
+        Fill            = $brushBg
+        Stroke          = $brushStroke
+        StrokeThickness = 2
+    }
+    $circleGrid.Children.Add($mainCircle) | Out-Null
+
+    $pathGeometry = New-Object System.Windows.Media.PathGeometry
+    $pathFigure   = New-Object System.Windows.Media.PathFigure -Property @{
+        StartPoint = "$arcStartX,$arcStartY"
+        IsClosed   = $false
+    }
+    $arcSegment = New-Object System.Windows.Media.ArcSegment -Property @{
+        Size           = "$radius,$radius"
+        SweepDirection = 'Clockwise'
+        IsLargeArc     = $false
+    }
+    $pathFigure.Segments.Add($arcSegment) | Out-Null
+    $pathGeometry.Figures.Add($pathFigure) | Out-Null
+
+    $progressRing = New-Object System.Windows.Shapes.Path -Property @{
+        Stroke             = $brushProgress
+        StrokeThickness    = 6
+        StrokeStartLineCap = 'Round'
+        StrokeEndLineCap   = 'Round'
+        Data               = $pathGeometry
+    }
+    $circleGrid.Children.Add($progressRing) | Out-Null
+
+    $vbox = New-Object System.Windows.Controls.StackPanel -Property @{
+        VerticalAlignment   = 'Center'
+        HorizontalAlignment = 'Center'
+    }
+
+    $titleLabel = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text                = "Task #$TaskId"
+        FontSize            = 11
+        Foreground          = $brushHint
+        HorizontalAlignment = 'Center'
+        Margin              = '0,0,0,2'
+    }
+    $vbox.Children.Add($titleLabel) | Out-Null
+
+    $clockText = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text                = '00:00.0'
+        FontSize            = 34
+        FontFamily          = 'Consolas'
+        Foreground          = $brushWhite
+        HorizontalAlignment = 'Center'
+        Margin              = '0,0,0,6'
+    }
+    $vbox.Children.Add($clockText) | Out-Null
+
+    $itemCountLabel = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text                = '0 item(s)'
+        FontSize            = 11
+        Foreground          = $brushHint
+        HorizontalAlignment = 'Center'
+        Margin              = '0,0,0,6'
+    }
+    $vbox.Children.Add($itemCountLabel) | Out-Null
+
+    $btnRow = New-Object System.Windows.Controls.StackPanel -Property @{
+        Orientation         = 'Horizontal'
+        HorizontalAlignment = 'Center'
+        Margin              = '0,0,0,5'
+    }
+    $btnLogItem = New-Object System.Windows.Controls.Button -Property @{
+        Content    = 'Log Item'
+        Width      = 72
+        Height     = 22
+        Background = $brushButton
+        Foreground = $brushWhite
+        Margin     = 2
+    }
+    $btnCapture = New-Object System.Windows.Controls.Button -Property @{
+        Content    = 'Capture Story'
+        Width      = 88
+        Height     = 22
+        Background = $brushButton
+        Foreground = $brushWhite
+        Margin     = 2
+    }
+    $btnStop = New-Object System.Windows.Controls.Button -Property @{
+        Content    = 'Stop'
+        Width      = 44
+        Height     = 22
+        Background = $brushButton
+        Foreground = $brushWhite
+        Margin     = 2
+    }
+    $btnRow.Children.Add($btnLogItem) | Out-Null
+    $btnRow.Children.Add($btnCapture) | Out-Null
+    $btnRow.Children.Add($btnStop)    | Out-Null
+    $vbox.Children.Add($btnRow) | Out-Null
+
+    $exitHint = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text                = 'Right-click to stop'
+        FontSize            = 9
+        Foreground          = $brushHint
+        HorizontalAlignment = 'Center'
+        Margin              = '0,8,0,0'
+    }
+    $vbox.Children.Add($exitHint) | Out-Null
+
+    $circleGrid.Children.Add($vbox) | Out-Null
+    $mainWin.Content = $circleGrid
+
+    # ---- UI update helper ----
+
+    $updateUi = {
+        $ts = [TimeSpan]::FromSeconds($Script:WpfElapsed)
+        $clockText.Text      = $ts.ToString('mm\:ss\.f')
+        $itemCountLabel.Text = "$($Script:WpfItems.Count) item(s)"
+
+        $pct = $Script:WpfElapsed / $maxDisplaySecs
+
+        if ($pct -ge 0.9999) {
+            $pct = 0.9999
+        }
+
+        if ($pct -le 0.0001) {
+            $pct = 0.0001
+        }
+
+        $angle    = $pct * 360
+        $angleRad = [Math]::PI * ($angle - 90) / 180
+        $x        = $center + $radius * [Math]::Cos($angleRad)
+        $y        = $center + $radius * [Math]::Sin($angleRad)
+
+        $arcSegment.IsLargeArc = ($angle -gt 180)
+        $arcSegment.Point      = New-Object System.Windows.Point($x, $y)
+    }
+
+    $clockTick = New-Object System.Windows.Threading.DispatcherTimer -Property @{
+        Interval = [TimeSpan]::FromMilliseconds(100)
+    }
+
+    $reminderTick = New-Object System.Windows.Threading.DispatcherTimer -Property @{
+        Interval = [TimeSpan]::FromMilliseconds($reminderIntervalMs)
+    }
+
+    # ---- Event handlers ----
+
+    $mainWin.Add_MouseLeftButtonDown({ $mainWin.DragMove() })
+
+    $mainWin.Add_MouseRightButtonDown({
+        $clockTick.Stop()
+        $reminderTick.Stop()
+        $mainWin.Close()
+    })
+
+    $clockTick.Add_Tick({
+        $Script:WpfElapsed += 0.1
+        & $updateUi
+    })
+
+    $reminderTick.Add_Tick({
+        if ($null -ne $balloon) {
+            Show-UnplannedReminder -Balloon $balloon -TaskId $TaskId -TaskTitle $TaskTitle
+        }
+    })
+
+    $btnLogItem.Add_Click({
+        $clockTick.Stop()
+        $itemText = [Microsoft.VisualBasic.Interaction]::InputBox('What happened?', 'Log Item', '')
+
+        if ($itemText) {
+            $record = [PSCustomObject]@{
+                Time = (Get-Date).ToString('HH:mm')
+                Text = $itemText
+            }
+            $Script:WpfItems.Add($record)
+            & $updateUi
+        }
+
+        $clockTick.Start()
+    })
+
+    $btnCapture.Add_Click({
+        $clockTick.Stop()
+        $reminderTick.Stop()
+        $mainWin.Hide()
+
+        az-New-AzDevOpsUserStory
+
+        $mainWin.Show()
+        $clockTick.Start()
+
+        if (-not $NoReminder) {
+            $reminderTick.Start()
+        }
+    })
+
+    $btnStop.Add_Click({
+        $clockTick.Stop()
+        $reminderTick.Stop()
+        $mainWin.Close()
+    })
+
+    # ---- Show ----
+
+    & $updateUi
+    $clockTick.Start()
+
+    if (-not $NoReminder) {
+        $reminderTick.Start()
+    }
+
+    $mainWin.ShowDialog() | Out-Null
+
+    if ($null -ne $balloon) {
+        $balloon.Dispose()
+    }
+
+    $items = @($Script:WpfItems)
+    return $items
+}
+
+
 function az-Start-UnplannedWork {
     # Orchestrator. Find-or-create today's daily story, create a child Task for
     # this firefight, then run the foreground session: Space logs a timestamped
@@ -596,75 +882,85 @@ function az-Start-UnplannedWork {
 
     Write-Host ""
     Write-Host "Firefight Task #$taskId created under story #$storyId." -ForegroundColor Green
-    Write-Host "Starting session. Space logs an item, Esc/Q stops and debriefs." -ForegroundColor Green
+    Write-Host "Starting session." -ForegroundColor Green
     Start-Sleep -Seconds 2
 
     $startTime = Get-Date
-    $items = New-Object System.Collections.Generic.List[object]
-
-    $balloon = if ($NoReminder) {
-        $null
-    } else {
-        New-UnplannedBalloon
-    }
+    $balloon   = $null
 
     $previousEncoding = [Console]::OutputEncoding
     [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
     try {
-        $reminderSeconds = $ReminderMinutes * 60
-        $pollsPerSecond  = $script:UnplannedPollsPerSecond
-        $pollIntervalMs  = $script:UnplannedPollIntervalMs
+        $onWindows = Test-UnplannedIsWindows
 
-        $elapsed        = 0
-        $lastReminderAt = 0
-        $stopRequested  = $false
+        if ($onWindows) {
+            $items = Show-WpfStopwatch `
+                -TaskId          $taskId `
+                -TaskTitle       $Title `
+                -ReminderMinutes $ReminderMinutes `
+                -NoReminder:$NoReminder
+        } else {
+            # Console loop — macOS / Linux fallback
+            $items   = New-Object System.Collections.Generic.List[object]
+            $balloon = New-UnplannedBalloon
 
-        Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds 0 -ItemCount 0 -ReminderMinutes $ReminderMinutes
+            $reminderSeconds = $ReminderMinutes * 60
+            $pollsPerSecond  = $script:UnplannedPollsPerSecond
+            $pollIntervalMs  = $script:UnplannedPollIntervalMs
 
-        while (-not $stopRequested) {
-            for ($p = 0; $p -lt $pollsPerSecond; $p++) {
-                $key = Read-UnplannedKeyPress
+            $elapsed        = 0
+            $lastReminderAt = 0
+            $stopRequested  = $false
 
-                if ($key -eq 'stop') {
-                    $stopRequested = $true
-                    break
-                }
+            Write-Host "Space logs an item, Esc/Q stops and debriefs." -ForegroundColor Green
 
-                if ($key -eq 'space') {
-                    Write-Host ""
-                    $itemText = Read-Host 'Log item'
+            Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds 0 -ItemCount 0 -ReminderMinutes $ReminderMinutes
 
-                    if ($itemText) {
-                        $record = [PSCustomObject]@{
-                            Time = (Get-Date).ToString('HH:mm')
-                            Text = $itemText
-                        }
-                        $items.Add($record)
+            while (-not $stopRequested) {
+                for ($p = 0; $p -lt $pollsPerSecond; $p++) {
+                    $key = Read-UnplannedKeyPress
+
+                    if ($key -eq 'stop') {
+                        $stopRequested = $true
+                        break
                     }
 
-                    $elapsed = [int]((Get-Date) - $startTime).TotalSeconds
-                    Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds $elapsed -ItemCount $items.Count -ReminderMinutes $ReminderMinutes
+                    if ($key -eq 'space') {
+                        Write-Host ""
+                        $itemText = Read-Host 'Log item'
+
+                        if ($itemText) {
+                            $record = [PSCustomObject]@{
+                                Time = (Get-Date).ToString('HH:mm')
+                                Text = $itemText
+                            }
+                            $items.Add($record)
+                        }
+
+                        $elapsed = [int]((Get-Date) - $startTime).TotalSeconds
+                        Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds $elapsed -ItemCount $items.Count -ReminderMinutes $ReminderMinutes
+                        break
+                    }
+
+                    Start-Sleep -Milliseconds $pollIntervalMs
+                }
+
+                if ($stopRequested) {
                     break
                 }
 
-                Start-Sleep -Milliseconds $pollIntervalMs
-            }
+                # Drive the display from wall-clock, not the iteration count — the
+                # space branch's blocking Read-Host means a single iteration can
+                # span many seconds, so $elapsed++ would undercount.
+                $elapsed = [int]((Get-Date) - $startTime).TotalSeconds
 
-            if ($stopRequested) {
-                break
-            }
+                Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds $elapsed -ItemCount $items.Count -ReminderMinutes $ReminderMinutes
 
-            # Drive the display from wall-clock, not the iteration count - the
-            # space branch's blocking Read-Host means a single iteration can
-            # span many seconds, so $elapsed++ would undercount.
-            $elapsed = [int]((Get-Date) - $startTime).TotalSeconds
-
-            Show-UnplannedStatus -TaskId $taskId -TaskTitle $Title -ElapsedSeconds $elapsed -ItemCount $items.Count -ReminderMinutes $ReminderMinutes
-
-            if (-not $NoReminder -and ($elapsed - $lastReminderAt) -ge $reminderSeconds) {
-                Show-UnplannedReminder -Balloon $balloon -TaskId $taskId -TaskTitle $Title
-                $lastReminderAt = $elapsed
+                if (-not $NoReminder -and ($elapsed - $lastReminderAt) -ge $reminderSeconds) {
+                    Show-UnplannedReminder -Balloon $balloon -TaskId $taskId -TaskTitle $Title
+                    $lastReminderAt = $elapsed
+                }
             }
         }
 
@@ -672,6 +968,7 @@ function az-Start-UnplannedWork {
     }
     finally {
         [Console]::OutputEncoding = $previousEncoding
+
         if ($null -ne $balloon) {
             $balloon.Dispose()
         }

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -569,27 +569,7 @@ function Show-WpfStopwatch {
     Add-Type -AssemblyName PresentationFramework, WindowsBase, PresentationCore
     Add-Type -AssemblyName Microsoft.VisualBasic
 
-    $colorBg       = $script:WpfColorBackground
-    $colorStroke   = $script:WpfColorStroke
-    $colorButton   = $script:WpfColorButton
-    $colorHint     = $script:WpfColorHint
-    $colorProgress = '#D97706'   # Amber — distinguishes unplanned from Pomodoro (blue)
-
-    $converter     = [System.Windows.Media.BrushConverter]::new()
-    $brushBg       = $converter.ConvertFromString($colorBg)
-    $brushStroke   = $converter.ConvertFromString($colorStroke)
-    $brushProgress = $converter.ConvertFromString($colorProgress)
-    $brushButton   = $converter.ConvertFromString($colorButton)
-    $brushHint     = $converter.ConvertFromString($colorHint)
-    $brushWhite    = [System.Windows.Media.Brushes]::White
-    $brushClear    = [System.Windows.Media.Brushes]::Transparent
-
-    $windowSize     = $script:WpfWindowSize
-    $center         = $script:WpfCircleCenter
-    $radius         = $script:WpfCircleRadius
-    $arcStartX      = $script:WpfArcStartX
-    $arcStartY      = $script:WpfArcStartY
-    $maxDisplaySecs = 3600   # arc fills to full at 60 minutes
+    $maxDisplaySecs = $script:WpfStopwatchMaxSeconds
 
     $Script:WpfElapsed = 0.0
     $Script:WpfItems   = New-Object System.Collections.Generic.List[object]
@@ -604,49 +584,11 @@ function Show-WpfStopwatch {
 
     # ---- Build window ----
 
-    $mainWin = New-Object System.Windows.Window -Property @{
-        Title                 = 'Unplanned Work'
-        SizeToContent         = 'WidthAndHeight'
-        WindowStyle           = 'None'
-        AllowsTransparency    = $true
-        Background            = $brushClear
-        Topmost               = $true
-        WindowStartupLocation = 'CenterScreen'
-    }
-
-    $circleGrid = New-Object System.Windows.Controls.Grid -Property @{
-        Width  = $windowSize
-        Height = $windowSize
-    }
-
-    $mainCircle = New-Object System.Windows.Shapes.Ellipse -Property @{
-        Fill            = $brushBg
-        Stroke          = $brushStroke
-        StrokeThickness = 2
-    }
-    $circleGrid.Children.Add($mainCircle) | Out-Null
-
-    $pathGeometry = New-Object System.Windows.Media.PathGeometry
-    $pathFigure   = New-Object System.Windows.Media.PathFigure -Property @{
-        StartPoint = "$arcStartX,$arcStartY"
-        IsClosed   = $false
-    }
-    $arcSegment = New-Object System.Windows.Media.ArcSegment -Property @{
-        Size           = "$radius,$radius"
-        SweepDirection = 'Clockwise'
-        IsLargeArc     = $false
-    }
-    $pathFigure.Segments.Add($arcSegment) | Out-Null
-    $pathGeometry.Figures.Add($pathFigure) | Out-Null
-
-    $progressRing = New-Object System.Windows.Shapes.Path -Property @{
-        Stroke             = $brushProgress
-        StrokeThickness    = 6
-        StrokeStartLineCap = 'Round'
-        StrokeEndLineCap   = 'Round'
-        Data               = $pathGeometry
-    }
-    $circleGrid.Children.Add($progressRing) | Out-Null
+    $brushes    = New-WpfBrushSet -ProgressColor $script:WpfColorProgressUnplanned
+    $circleRes  = New-WpfCircleResources -Title 'Unplanned Work' -Brushes $brushes -ArcStartsFull $false
+    $mainWin    = $circleRes.Window
+    $circleGrid = $circleRes.Grid
+    $arcSegment = $circleRes.ArcSegment
 
     $vbox = New-Object System.Windows.Controls.StackPanel -Property @{
         VerticalAlignment   = 'Center'
@@ -656,7 +598,7 @@ function Show-WpfStopwatch {
     $titleLabel = New-Object System.Windows.Controls.TextBlock -Property @{
         Text                = "Task #$TaskId"
         FontSize            = 11
-        Foreground          = $brushHint
+        Foreground          = $brushes.Hint
         HorizontalAlignment = 'Center'
         Margin              = '0,0,0,2'
     }
@@ -666,7 +608,7 @@ function Show-WpfStopwatch {
         Text                = '00:00.0'
         FontSize            = 34
         FontFamily          = 'Consolas'
-        Foreground          = $brushWhite
+        Foreground          = $brushes.White
         HorizontalAlignment = 'Center'
         Margin              = '0,0,0,6'
     }
@@ -675,7 +617,7 @@ function Show-WpfStopwatch {
     $itemCountLabel = New-Object System.Windows.Controls.TextBlock -Property @{
         Text                = '0 item(s)'
         FontSize            = 11
-        Foreground          = $brushHint
+        Foreground          = $brushes.Hint
         HorizontalAlignment = 'Center'
         Margin              = '0,0,0,6'
     }
@@ -690,24 +632,24 @@ function Show-WpfStopwatch {
         Content    = 'Log Item'
         Width      = 72
         Height     = 22
-        Background = $brushButton
-        Foreground = $brushWhite
+        Background = $brushes.Button
+        Foreground = $brushes.White
         Margin     = 2
     }
     $btnCapture = New-Object System.Windows.Controls.Button -Property @{
         Content    = 'Capture Story'
         Width      = 88
         Height     = 22
-        Background = $brushButton
-        Foreground = $brushWhite
+        Background = $brushes.Button
+        Foreground = $brushes.White
         Margin     = 2
     }
     $btnStop = New-Object System.Windows.Controls.Button -Property @{
         Content    = 'Stop'
         Width      = 44
         Height     = 22
-        Background = $brushButton
-        Foreground = $brushWhite
+        Background = $brushes.Button
+        Foreground = $brushes.White
         Margin     = 2
     }
     $btnRow.Children.Add($btnLogItem) | Out-Null
@@ -718,14 +660,13 @@ function Show-WpfStopwatch {
     $exitHint = New-Object System.Windows.Controls.TextBlock -Property @{
         Text                = 'Right-click to stop'
         FontSize            = 9
-        Foreground          = $brushHint
+        Foreground          = $brushes.Hint
         HorizontalAlignment = 'Center'
         Margin              = '0,8,0,0'
     }
     $vbox.Children.Add($exitHint) | Out-Null
 
     $circleGrid.Children.Add($vbox) | Out-Null
-    $mainWin.Content = $circleGrid
 
     # ---- UI update helper ----
 
@@ -735,22 +676,7 @@ function Show-WpfStopwatch {
         $itemCountLabel.Text = "$($Script:WpfItems.Count) item(s)"
 
         $pct = $Script:WpfElapsed / $maxDisplaySecs
-
-        if ($pct -ge 0.9999) {
-            $pct = 0.9999
-        }
-
-        if ($pct -le 0.0001) {
-            $pct = 0.0001
-        }
-
-        $angle    = $pct * 360
-        $angleRad = [Math]::PI * ($angle - 90) / 180
-        $x        = $center + $radius * [Math]::Cos($angleRad)
-        $y        = $center + $radius * [Math]::Sin($angleRad)
-
-        $arcSegment.IsLargeArc = ($angle -gt 180)
-        $arcSegment.Point      = New-Object System.Windows.Point($x, $y)
+        Set-WpfArcPoint -Pct $pct -ArcSegment $arcSegment
     }
 
     $clockTick = New-Object System.Windows.Threading.DispatcherTimer -Property @{

--- a/powcuts_by_cli/pow_common.ps1
+++ b/powcuts_by_cli/pow_common.ps1
@@ -93,3 +93,134 @@ function Test-ConsoleGridAvailable {
     $available = ($null -ne $cmd)
     return $available
 }
+
+
+function Test-WpfIsWindows {
+    $result = ($IsWindows -or ($env:OS -eq 'Windows_NT'))
+    return $result
+}
+
+
+function New-WpfBrushSet {
+    # Creates a named brush bundle from the shared WPF color constants
+    # (defined in pow_timer.ps1). -ProgressColor overrides the arc color so
+    # the Pomodoro (blue) and unplanned-work stopwatch (amber) share one helper.
+    param([Parameter(Mandatory)] [string] $ProgressColor)
+
+    $converter = [System.Windows.Media.BrushConverter]::new()
+    $result = [PSCustomObject]@{
+        Bg       = $converter.ConvertFromString($script:WpfColorBackground)
+        Stroke   = $converter.ConvertFromString($script:WpfColorStroke)
+        Progress = $converter.ConvertFromString($ProgressColor)
+        Button   = $converter.ConvertFromString($script:WpfColorButton)
+        Hint     = $converter.ConvertFromString($script:WpfColorHint)
+        White    = [System.Windows.Media.Brushes]::White
+        DarkRed  = [System.Windows.Media.Brushes]::DarkRed
+        Clear    = [System.Windows.Media.Brushes]::Transparent
+    }
+    return $result
+}
+
+
+function New-WpfCircleResources {
+    # Builds the shared WPF infrastructure: transparent Window, fixed-size Grid,
+    # dark Ellipse background, and progress-ring arc Path. Returns a PSCustomObject
+    # with Window, Grid, MainCircle, and ArcSegment so callers can add their own
+    # controls to the Grid and wire event handlers. -ArcStartsFull $true (default)
+    # sets the initial arc to full-circle (countdown drain); $false starts empty
+    # (stopwatch fill).
+    param(
+        [Parameter(Mandatory)] [string] $Title,
+        [Parameter(Mandatory)] $Brushes,
+        [bool] $ArcStartsFull = $true
+    )
+
+    $windowSize = $script:WpfWindowSize
+    $arcStartX  = $script:WpfArcStartX
+    $arcStartY  = $script:WpfArcStartY
+    $radius     = $script:WpfCircleRadius
+
+    $mainWin = New-Object System.Windows.Window -Property @{
+        Title                 = $Title
+        SizeToContent         = 'WidthAndHeight'
+        WindowStyle           = 'None'
+        AllowsTransparency    = $true
+        Background            = $Brushes.Clear
+        Topmost               = $true
+        WindowStartupLocation = 'CenterScreen'
+    }
+
+    $circleGrid = New-Object System.Windows.Controls.Grid -Property @{
+        Width  = $windowSize
+        Height = $windowSize
+    }
+
+    $mainCircle = New-Object System.Windows.Shapes.Ellipse -Property @{
+        Fill            = $Brushes.Bg
+        Stroke          = $Brushes.Stroke
+        StrokeThickness = 2
+    }
+    $circleGrid.Children.Add($mainCircle) | Out-Null
+
+    $pathGeometry = New-Object System.Windows.Media.PathGeometry
+    $pathFigure   = New-Object System.Windows.Media.PathFigure -Property @{
+        StartPoint = "$arcStartX,$arcStartY"
+        IsClosed   = $false
+    }
+    $arcSegment = New-Object System.Windows.Media.ArcSegment -Property @{
+        Size           = "$radius,$radius"
+        SweepDirection = 'Clockwise'
+        IsLargeArc     = $ArcStartsFull
+    }
+    $pathFigure.Segments.Add($arcSegment) | Out-Null
+    $pathGeometry.Figures.Add($pathFigure) | Out-Null
+
+    $progressRing = New-Object System.Windows.Shapes.Path -Property @{
+        Stroke             = $Brushes.Progress
+        StrokeThickness    = 6
+        StrokeStartLineCap = 'Round'
+        StrokeEndLineCap   = 'Round'
+        Data               = $pathGeometry
+    }
+    $circleGrid.Children.Add($progressRing) | Out-Null
+
+    $mainWin.Content = $circleGrid
+
+    $result = [PSCustomObject]@{
+        Window     = $mainWin
+        Grid       = $circleGrid
+        MainCircle = $mainCircle
+        ArcSegment = $arcSegment
+    }
+    return $result
+}
+
+
+function Set-WpfArcPoint {
+    # Updates the arc endpoint for a progress ring. $Pct is clamped to
+    # (0.0001, 0.9999) so the arc is always a genuine arc (never a full circle,
+    # which renders as nothing in WPF path geometry).
+    param(
+        [Parameter(Mandatory)] [double] $Pct,
+        [Parameter(Mandatory)] $ArcSegment
+    )
+
+    $center = $script:WpfCircleCenter
+    $radius = $script:WpfCircleRadius
+
+    if ($Pct -ge 0.9999) {
+        $Pct = 0.9999
+    }
+
+    if ($Pct -le 0.0001) {
+        $Pct = 0.0001
+    }
+
+    $angle    = $Pct * 360
+    $angleRad = [Math]::PI * ($angle - 90) / 180
+    $x        = $center + $radius * [Math]::Cos($angleRad)
+    $y        = $center + $radius * [Math]::Sin($angleRad)
+
+    $ArcSegment.IsLargeArc = ($angle -gt 180)
+    $ArcSegment.Point      = New-Object System.Windows.Point($x, $y)
+}

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -44,6 +44,18 @@ $script:TimerPollsPerSecond = 10
 
 $script:TimerIntegrations = @()
 
+$script:WpfColorBackground = '#2D2D30'
+$script:WpfColorStroke     = '#444444'
+$script:WpfColorProgress   = '#007ACC'
+$script:WpfColorButton     = '#3E3E42'
+$script:WpfColorHint       = '#888888'
+
+$script:WpfWindowSize   = 260
+$script:WpfCircleCenter = 130
+$script:WpfCircleRadius = 124
+$script:WpfArcStartX    = 130
+$script:WpfArcStartY    = 6
+
 
 function Test-TimerEscPressed {
     # Non-blocking probe for an Esc keypress. Guarded so the timer still
@@ -256,11 +268,19 @@ function Get-TimerItemPick {
 
 
 function Show-TimerCountdown {
-    # Snake-animation countdown. Each elapsed second redraws the frame; the
-    # per-second wait is split into ~100ms key polls so Esc interrupts feel
-    # immediate without making the animation flicker. Returns the outcome so
-    # the orchestrator can branch on Interrupted.
+    # Delegates to the WPF circular overlay on Windows; falls back to the
+    # snake-animation on macOS / Linux. Returns the same outcome shape in
+    # both paths so the orchestrator (az-Start-TimerSession) is unchanged.
     param([Parameter(Mandatory)] [int] $Seconds)
+
+    $onWindows = ($IsWindows -or ($env:OS -eq 'Windows_NT'))
+
+    if ($onWindows) {
+        $result = Show-WpfTimerCountdown -Seconds $Seconds
+        return $result
+    }
+
+    # ---- Snake-animation fallback (macOS / Linux) ----
 
     $iconSnakeHead = $script:TimerIconSnakeHead
     $iconSnakeBody = $script:TimerIconSnakeBody
@@ -320,6 +340,356 @@ function Show-TimerCountdown {
 }
 
 
+function Show-WpfTimerCountdown {
+    # WPF circular overlay countdown for Windows. Returns the same result shape
+    # as Show-TimerCountdown so az-Start-TimerSession needs no changes.
+    # If "Capture Story" is clicked the overlay closes, az-New-AzDevOpsUserStory
+    # runs in the terminal, then the overlay reopens with the remaining time.
+    param([Parameter(Mandatory)] [int] $Seconds)
+
+    Add-Type -AssemblyName PresentationFramework, WindowsBase, PresentationCore
+
+    $colorBg       = $script:WpfColorBackground
+    $colorStroke   = $script:WpfColorStroke
+    $colorProgress = $script:WpfColorProgress
+    $colorButton   = $script:WpfColorButton
+    $colorHint     = $script:WpfColorHint
+
+    $converter     = [System.Windows.Media.BrushConverter]::new()
+    $brushBg       = $converter.ConvertFromString($colorBg)
+    $brushStroke   = $converter.ConvertFromString($colorStroke)
+    $brushProgress = $converter.ConvertFromString($colorProgress)
+    $brushButton   = $converter.ConvertFromString($colorButton)
+    $brushHint     = $converter.ConvertFromString($colorHint)
+    $brushWhite    = [System.Windows.Media.Brushes]::White
+    $brushDarkRed  = [System.Windows.Media.Brushes]::DarkRed
+    $brushClear    = [System.Windows.Media.Brushes]::Transparent
+
+    $windowSize    = $script:WpfWindowSize
+    $center        = $script:WpfCircleCenter
+    $radius        = $script:WpfCircleRadius
+    $arcStartX     = $script:WpfArcStartX
+    $arcStartY     = $script:WpfArcStartY
+    $flashMaxTicks = 15
+
+    $defaultSeconds = $Seconds
+
+    $Script:WpfTimeRemaining = [double]$Seconds
+    $Script:WpfTotalSeconds  = [double]$Seconds
+    $Script:WpfOutcome       = 'Complete'
+
+    do {
+        $Script:WpfOutcome    = 'Complete'
+        $Script:WpfIsFlashing = $false
+        $Script:WpfFlashCount = 0
+
+        # ---- Build window ----
+
+        $mainWin = New-Object System.Windows.Window -Property @{
+            Title                 = 'Timer Session'
+            SizeToContent         = 'WidthAndHeight'
+            WindowStyle           = 'None'
+            AllowsTransparency    = $true
+            Background            = $brushClear
+            Topmost               = $true
+            WindowStartupLocation = 'CenterScreen'
+        }
+
+        $circleGrid = New-Object System.Windows.Controls.Grid -Property @{
+            Width  = $windowSize
+            Height = $windowSize
+        }
+
+        $mainCircle = New-Object System.Windows.Shapes.Ellipse -Property @{
+            Fill            = $brushBg
+            Stroke          = $brushStroke
+            StrokeThickness = 2
+        }
+        $circleGrid.Children.Add($mainCircle) | Out-Null
+
+        $pathGeometry = New-Object System.Windows.Media.PathGeometry
+        $pathFigure   = New-Object System.Windows.Media.PathFigure -Property @{
+            StartPoint = "$arcStartX,$arcStartY"
+            IsClosed   = $false
+        }
+        $arcSegment = New-Object System.Windows.Media.ArcSegment -Property @{
+            Size           = "$radius,$radius"
+            SweepDirection = 'Clockwise'
+            IsLargeArc     = $true
+        }
+        $pathFigure.Segments.Add($arcSegment) | Out-Null
+        $pathGeometry.Figures.Add($pathFigure) | Out-Null
+
+        $progressRing = New-Object System.Windows.Shapes.Path -Property @{
+            Stroke             = $brushProgress
+            StrokeThickness    = 6
+            StrokeStartLineCap = 'Round'
+            StrokeEndLineCap   = 'Round'
+            Data               = $pathGeometry
+        }
+        $circleGrid.Children.Add($progressRing) | Out-Null
+
+        $vbox = New-Object System.Windows.Controls.StackPanel -Property @{
+            VerticalAlignment   = 'Center'
+            HorizontalAlignment = 'Center'
+        }
+
+        $clockText = New-Object System.Windows.Controls.TextBlock -Property @{
+            Text                = '00:00.0'
+            FontSize            = 34
+            FontFamily          = 'Consolas'
+            Foreground          = $brushWhite
+            HorizontalAlignment = 'Center'
+            Margin              = '0,0,0,8'
+            Cursor              = [System.Windows.Input.Cursors]::Hand
+        }
+        $vbox.Children.Add($clockText) | Out-Null
+
+        $adjustRow = New-Object System.Windows.Controls.StackPanel -Property @{
+            Orientation         = 'Horizontal'
+            HorizontalAlignment = 'Center'
+            Margin              = '0,0,0,5'
+        }
+        $btnPlus5 = New-Object System.Windows.Controls.Button -Property @{
+            Content    = '+5 Min'
+            Width      = 55
+            Height     = 22
+            Background = $brushButton
+            Foreground = $brushWhite
+            Margin     = 2
+        }
+        $btnPlus10 = New-Object System.Windows.Controls.Button -Property @{
+            Content    = '+10 Min'
+            Width      = 55
+            Height     = 22
+            Background = $brushButton
+            Foreground = $brushWhite
+            Margin     = 2
+        }
+        $adjustRow.Children.Add($btnPlus5)  | Out-Null
+        $adjustRow.Children.Add($btnPlus10) | Out-Null
+        $vbox.Children.Add($adjustRow) | Out-Null
+
+        $pomoRow = New-Object System.Windows.Controls.StackPanel -Property @{
+            Orientation         = 'Horizontal'
+            HorizontalAlignment = 'Center'
+            Margin              = '0,0,0,5'
+        }
+        $btnNewPomo = New-Object System.Windows.Controls.Button -Property @{
+            Content    = 'New Pomodoro'
+            Width      = 120
+            Height     = 24
+            Background = $brushButton
+            Foreground = $brushWhite
+        }
+        $pomoRow.Children.Add($btnNewPomo) | Out-Null
+        $vbox.Children.Add($pomoRow) | Out-Null
+
+        $actionRow = New-Object System.Windows.Controls.StackPanel -Property @{
+            Orientation         = 'Horizontal'
+            HorizontalAlignment = 'Center'
+            Margin              = '0,0,0,5'
+        }
+        $btnCapture = New-Object System.Windows.Controls.Button -Property @{
+            Content    = 'Capture Story'
+            Width      = 92
+            Height     = 22
+            Background = $brushButton
+            Foreground = $brushWhite
+            Margin     = 2
+        }
+        $btnComplete = New-Object System.Windows.Controls.Button -Property @{
+            Content    = 'Mark Complete'
+            Width      = 92
+            Height     = 22
+            Background = $brushButton
+            Foreground = $brushWhite
+            Margin     = 2
+        }
+        $actionRow.Children.Add($btnCapture)  | Out-Null
+        $actionRow.Children.Add($btnComplete) | Out-Null
+        $vbox.Children.Add($actionRow) | Out-Null
+
+        $exitHint = New-Object System.Windows.Controls.TextBlock -Property @{
+            Text                = 'Click time to pause  ·  Right-click to exit'
+            FontSize            = 9
+            Foreground          = $brushHint
+            HorizontalAlignment = 'Center'
+            Margin              = '0,8,0,0'
+        }
+        $vbox.Children.Add($exitHint) | Out-Null
+
+        $circleGrid.Children.Add($vbox) | Out-Null
+        $mainWin.Content = $circleGrid
+
+        # ---- Timer state and UI update helper ----
+
+        $updateUi = {
+            if ($Script:WpfTimeRemaining -le 0) {
+                $Script:WpfTimeRemaining = 0
+            }
+
+            $ts = [TimeSpan]::FromSeconds($Script:WpfTimeRemaining)
+            $clockText.Text = $ts.ToString('mm\:ss\.f')
+
+            if ($Script:WpfTotalSeconds -gt 0) {
+                $pct = $Script:WpfTimeRemaining / $Script:WpfTotalSeconds
+
+                if ($pct -ge 0.9999) {
+                    $pct = 0.9999
+                }
+
+                if ($pct -le 0.0001) {
+                    $pct = 0.0001
+                }
+
+                $angle    = $pct * 360
+                $angleRad = [Math]::PI * ($angle - 90) / 180
+                $x        = $center + $radius * [Math]::Cos($angleRad)
+                $y        = $center + $radius * [Math]::Sin($angleRad)
+
+                $arcSegment.IsLargeArc = ($angle -gt 180)
+                $arcSegment.Point      = New-Object System.Windows.Point($x, $y)
+            }
+        }
+
+        $clockTick = New-Object System.Windows.Threading.DispatcherTimer -Property @{
+            Interval = [TimeSpan]::FromMilliseconds(100)
+        }
+
+        $flashTick = New-Object System.Windows.Threading.DispatcherTimer -Property @{
+            Interval = [TimeSpan]::FromMilliseconds(300)
+        }
+
+        # ---- Event handlers ----
+
+        $mainWin.Add_MouseLeftButtonDown({ $mainWin.DragMove() })
+
+        $mainWin.Add_MouseRightButtonDown({
+            $clockTick.Stop()
+            $flashTick.Stop()
+            $Script:WpfOutcome = 'Interrupted'
+            $mainWin.Close()
+        })
+
+        $clockText.Add_MouseLeftButtonDown({
+            if ($Script:WpfTimeRemaining -le 0) {
+                return
+            }
+
+            $flashTick.Stop()
+            $mainCircle.Fill = $brushBg
+
+            if ($clockTick.IsEnabled) {
+                $clockTick.Stop()
+            } else {
+                $clockTick.Start()
+            }
+        })
+
+        $clockTick.Add_Tick({
+            $Script:WpfTimeRemaining -= 0.1
+            & $updateUi
+
+            if ($Script:WpfTimeRemaining -le 0) {
+                $clockTick.Stop()
+                $Script:WpfFlashCount = 0
+                $flashTick.Start()
+            }
+        })
+
+        $flashTick.Add_Tick({
+            $Script:WpfFlashCount++
+
+            if ($Script:WpfFlashCount -ge $flashMaxTicks) {
+                $flashTick.Stop()
+                $mainCircle.Fill = $brushBg
+                $mainWin.Close()
+                return
+            }
+
+            if ($Script:WpfIsFlashing) {
+                $mainCircle.Fill      = $brushBg
+                $Script:WpfIsFlashing = $false
+            } else {
+                $mainCircle.Fill      = $brushDarkRed
+                $Script:WpfIsFlashing = $true
+            }
+        })
+
+        $btnPlus5.Add_Click({
+            if (-not $clockTick.IsEnabled) {
+                $Script:WpfTotalSeconds  += 300
+                $Script:WpfTimeRemaining  = $Script:WpfTotalSeconds
+                & $updateUi
+            }
+        })
+
+        $btnPlus10.Add_Click({
+            if (-not $clockTick.IsEnabled) {
+                $Script:WpfTotalSeconds  += 600
+                $Script:WpfTimeRemaining  = $Script:WpfTotalSeconds
+                & $updateUi
+            }
+        })
+
+        $btnNewPomo.Add_Click({
+            $clockTick.Stop()
+            $flashTick.Stop()
+            $mainCircle.Fill         = $brushBg
+            $Script:WpfTotalSeconds  = [double]$defaultSeconds
+            $Script:WpfTimeRemaining = $Script:WpfTotalSeconds
+            & $updateUi
+        })
+
+        $btnCapture.Add_Click({
+            $clockTick.Stop()
+            $flashTick.Stop()
+            $Script:WpfOutcome = 'CaptureStory'
+            $mainWin.Close()
+        })
+
+        $btnComplete.Add_Click({
+            $confirmMsg    = 'End this session early and go to debrief?'
+            $confirmTitle  = 'Mark Complete Early'
+            $confirmResult = [System.Windows.MessageBox]::Show(
+                $confirmMsg,
+                $confirmTitle,
+                [System.Windows.MessageBoxButton]::YesNo,
+                [System.Windows.MessageBoxImage]::Question
+            )
+
+            if ($confirmResult -eq [System.Windows.MessageBoxResult]::Yes) {
+                $clockTick.Stop()
+                $flashTick.Stop()
+                $Script:WpfOutcome = 'Interrupted'
+                $mainWin.Close()
+            }
+        })
+
+        # ---- Show ----
+
+        & $updateUi
+        $mainWin.ShowDialog() | Out-Null
+
+        if ($Script:WpfOutcome -eq 'CaptureStory') {
+            az-New-AzDevOpsUserStory
+        }
+
+    } while ($Script:WpfOutcome -eq 'CaptureStory')
+
+    $elapsed     = [int]($Seconds - $Script:WpfTimeRemaining)
+    $interrupted = ($Script:WpfOutcome -eq 'Interrupted')
+
+    $result = [PSCustomObject]@{
+        ElapsedSeconds = $elapsed
+        TotalSeconds   = $Seconds
+        Interrupted    = $interrupted
+    }
+    return $result
+}
+
+
 function Format-TimerCommentBody {
     # Compose the discussion-comment text. Header reflects outcome; body has
     # labeled Debrief and Next sections; a trailing attribution line lets a
@@ -373,159 +743,15 @@ function Format-TimerCommentBody {
     return $body
 }
 
-function Show-ModernMultiLinePrompt {
-    param (
-        [string]$PromptText,
-        [string]$WindowTitle = "Prompt"
-    )
-
-    # 1. LAZY LOAD TYPES: Ensure UI assemblies are ready
-    if (-not ([System.Management.Automation.PSTypeName]'System.Windows.Forms.Form').Type) {
-        Add-Type -AssemblyName System.Windows.Forms
-        Add-Type -AssemblyName System.Drawing
-        [System.Windows.Forms.Application]::EnableVisualStyles()
-    }
-
-    # 2. NESTED HELPER FUNCTION: Creates and fires the OS balloon notification
-    function Show-BalloonNotification {
-        param (
-            [string]$Title = "Action Required",
-            [string]$Message = "Please complete your notes to proceed."
-        )
-        $notifyIcon = New-Object System.Windows.Forms.NotifyIcon
-        # Extracts the native PowerShell engine icon to use in the system tray
-        $notifyIcon.Icon = [System.Drawing.Icon]::ExtractAssociatedIcon((Get-Process -Id $PID).Path)
-        $notifyIcon.BalloonTipIcon = [System.Windows.Forms.ToolTipIcon]::Warning
-        $notifyIcon.BalloonTipTitle = $Title
-        $notifyIcon.BalloonTipText = $Message
-        $notifyIcon.Visible = $true
-        
-        # Flash balloon for 3 seconds, then clean up memory immediately
-        $notifyIcon.ShowBalloonTip(3000)
-        Start-Sleep -Milliseconds 100
-        $notifyIcon.Dispose()
-    }
-
-    # 3. Modern Window Layout Canvas
-    $form = New-Object System.Windows.Forms.Form
-    $form.Text = $WindowTitle
-    $form.Size = New-Object System.Drawing.Size(420, 300)
-    $form.StartPosition = "CenterScreen"
-    $form.FormBorderStyle = "FixedDialog"
-    $form.MaximizeBox = $false
-    $form.MinimizeBox = $false
-    $form.BackColor = [System.Drawing.Color]::FromArgb(245, 246, 248)
-    $form.Font = New-Object System.Drawing.Font("Segoe UI", 10)
-
-    # 4. Clean Typography Label
-    $label = New-Object System.Windows.Forms.Label
-    $label.Text = $PromptText
-    $label.Location = New-Object System.Drawing.Point(20, 15)
-    $label.Size = New-Object System.Drawing.Size(365, 25)
-    $label.ForeColor = [System.Drawing.Color]::FromArgb(33, 37, 41)
-    $form.Controls.Add($label)
-
-    # 5. Modern Multi-Line TextBox
-    $textBox = New-Object System.Windows.Forms.TextBox
-    $textBox.Multiline = $true
-    $textBox.ScrollBars = "Vertical"
-    $textBox.Location = New-Object System.Drawing.Point(20, 45)
-    $textBox.Size = New-Object System.Drawing.Size(365, 130)
-    $textBox.BorderStyle = [System.Windows.Forms.BorderStyle]::FixedSingle
-    $textBox.BackColor = [System.Drawing.Color]::White
-    $textBox.AcceptsReturn = $true 
-    $form.Controls.Add($textBox)
-
-    # 6. IN-FORM ALERT LABEL: Red error warning block
-    $errorLabel = New-Object System.Windows.Forms.Label
-    $errorLabel.Text = "⚠️ Field cannot be empty! Please provide notes."
-    $errorLabel.Location = New-Object System.Drawing.Point(20, 185)
-    $errorLabel.Size = New-Object System.Drawing.Size(250, 25)
-    $errorLabel.ForeColor = [System.Drawing.Color]::Red
-    $errorLabel.Visible = $false
-    $form.Controls.Add($errorLabel)
-
-    # 7. Styled Button Control
-    $okButton = New-Object System.Windows.Forms.Button
-    $okButton.Text = "Submit"
-    $okButton.Location = New-Object System.Drawing.Point(285, 185)
-    $okButton.Size = New-Object System.Drawing.Size(100, 32)
-    $okButton.FlatStyle = [System.Windows.Forms.FlatStyle]::System
-    $form.Controls.Add($okButton)
-
-    # 8. VALIDATION LOGIC: Check form fields on Submit click
-    $okButton.add_Click({
-        if ([string]::IsNullOrWhiteSpace($textBox.Text)) {
-            $errorLabel.Visible = $true
-            [System.Media.SystemSounds]::Hand.Play()
-            # Fire the balloon notification on a bad submit attempt
-            Show-BalloonNotification -Title "Submission Blocked" -Message "You must enter details for '$WindowTitle' before submitting."
-        } else {
-            $form.DialogResult = [System.Windows.Forms.DialogResult]::OK
-            $form.Close()
-        }
-    })
-
-    # Clear red warning block instantly when user resumes typing
-    $textBox.add_TextChanged({
-        if ($errorLabel.Visible -and -not [string]::IsNullOrWhiteSpace($textBox.Text)) {
-            $errorLabel.Visible = $false
-        }
-    })
-
-    # Keyboard Shortcut Integration (Ctrl + Enter)
-    $textBox.add_KeyDown({
-        param($sender, $e)
-        if ($e.Control -and $e.KeyCode -eq [System.Windows.Forms.Keys]::Enter) {
-            $e.SuppressKeyPress = $true 
-            $okButton.PerformClick()
-        }
-    })
-
-    # 9. BACKGROUND TIMER: Fires every 5 seconds if form remains empty
-    $timer = New-Object System.Windows.Forms.Timer
-    $timer.Interval = 5000 
-    
-    $timer.add_Tick({
-        if ([string]::IsNullOrWhiteSpace($textBox.Text)) {
-            [System.Media.SystemSounds]::Asterisk.Play()
-            $errorLabel.Visible = $true
-            # Fire system notification loop reminder
-            Show-BalloonNotification -Title "Friendly Reminder" -Message "Don't forget to fill out your '$WindowTitle' prompt!"
-        }
-    })
-
-    $form.add_Load({ 
-        $timer.Start()
-        $textBox.Focus()
-    })
-    $form.add_FormClosing({ $timer.Stop(); $timer.Dispose() })
-
-    # 10. Persistent Window Execution Execution Loop
-    while ($true) {
-        $result = $form.ShowDialog()
-        if ($result -eq [System.Windows.Forms.DialogResult]::OK) {
-            return $textBox.Text
-        }
-        # If user clicks the application exit 'X' icon:
-        [System.Media.SystemSounds]::Hand.Play()
-        Show-BalloonNotification -Title "Form Closed Prematurely" -Message "Data entry is required. The form has restarted."
-    }
-}
-
-
 function az-Start-TimerSession {
     # Orchestrator. Pick an integration (or use -Integration to skip),
-    # fetch + pick an item, run the snake countdown (Esc to end early),
-    # prompt for debrief notes, post the composed comment via the chosen
-    # integration's AddComment. On an Esc-interrupted session also prompt
-    # whether to start another session — same -Minutes, fresh integration
-    # / item pick so the user can pivot to a different story.
+    # fetch + pick an item, run the countdown (WPF overlay on Windows, snake
+    # animation elsewhere), prompt for debrief notes in the terminal, post
+    # the composed comment via the chosen integration's AddComment. On an
+    # interrupted session also prompt whether to start another session.
     #
-    # UTF-8 encoding is applied around the snake animation so the emoji
-    # glyphs render in terminals that default to a non-UTF-8 codepage; the
-    # previous encoding is restored on exit (including Ctrl-C) so we don't
-    # leak a process-wide mutation back to the shell.
+    # UTF-8 encoding is applied so emoji glyphs render in terminals that
+    # default to a non-UTF-8 codepage; restored on exit (including Ctrl-C).
     [CmdletBinding()]
     param(
         [ValidateRange(1, [int]::MaxValue)] [int] $Minutes = $script:TimerDefaultMinutes,
@@ -569,37 +795,17 @@ function az-Start-TimerSession {
             Write-Host "Starting $Minutes-minute session on item $($pickedItem.Id): $($pickedItem.Title)" -ForegroundColor Green
             Start-Sleep -Seconds 2
 
-            $seconds = $Minutes * 60
+            $seconds         = $Minutes * 60
             $countdownResult = Show-TimerCountdown -Seconds $seconds
-
-            if (-not ([System.Management.Automation.PSTypeName]'System.Windows.Forms.NotifyIcon').Type) {
-                Add-Type -AssemblyName System.Windows.Forms, System.Drawing
-            }
-
-            # Instantiate the objects cleanly
-            $Balloon = New-Object System.Windows.Forms.NotifyIcon
-            $Balloon.Icon = [System.Drawing.Icon]::ExtractAssociatedIcon((Get-Process -Id $PID).Path)
-
-            # Configure the alert elements
-            $Balloon.BalloonTipIcon  = [System.Windows.Forms.ToolTipIcon]::Warning
-            $Balloon.BalloonTipTitle = "🚨 POMODORO TASK EXPIRED! 🚨"
-            $Balloon.BalloonTipText  = "⏰ Time's up! Please provide debrief and next steps. 🛑"
-            $Balloon.Visible = $true
-
-            # Fire balloon simultaneously
-            $Balloon.ShowBalloonTip(0)
 
             Clear-Host
             $finishIcon = $script:TimerIconFinish
             Write-Host "$finishIcon SESSION COMPLETE! $finishIcon" -ForegroundColor Green
+            Write-Host ""
 
-            # --- Execution ---
-            $debrief = Show-ModernMultiLinePrompt -PromptText "Enter your debrief notes (Ctrl+Enter to submit):" -WindowTitle "Debrief"
-            $next    = Show-ModernMultiLinePrompt -PromptText "What's Next? (Ctrl+Enter to submit):" -WindowTitle "Next Steps"
-
-            Write-Host "`n--- SAVED DATA ---" -ForegroundColor Green
-            Write-Host "Debrief Note:`n$debrief"
-            Write-Host "`nNext Note:`n$next"
+            $iconMemo = $script:TimerIconMemo
+            $debrief  = Read-Host "$iconMemo Debrief — what did you accomplish?"
+            $next     = Read-Host "$iconMemo Next — what's the next step?"
 
             $body = Format-TimerCommentBody `
                 -Interrupted    $countdownResult.Interrupted `
@@ -613,7 +819,7 @@ function az-Start-TimerSession {
             $commentResult = & $chosen.AddComment -Id $pickedItem.Id -Body $body
 
             $exitCode = if ($commentResult -and $commentResult.PSObject.Properties['ExitCode']) {
-
+                $commentResult.ExitCode
             } else {
                 0
             }

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -514,6 +514,8 @@ function Show-WpfTimerCountdown {
             } else {
                 $clockTick.Start()
             }
+
+            $args[1].Handled = $true
         })
 
         $clockTick.Add_Tick({

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -56,6 +56,9 @@ $script:WpfCircleRadius = 124
 $script:WpfArcStartX    = 130
 $script:WpfArcStartY    = 6
 
+$script:WpfColorProgressUnplanned = '#D97706'
+$script:WpfStopwatchMaxSeconds    = 3600
+
 
 function Test-TimerEscPressed {
     # Non-blocking probe for an Esc keypress. Guarded so the timer still
@@ -273,7 +276,7 @@ function Show-TimerCountdown {
     # both paths so the orchestrator (az-Start-TimerSession) is unchanged.
     param([Parameter(Mandatory)] [int] $Seconds)
 
-    $onWindows = ($IsWindows -or ($env:OS -eq 'Windows_NT'))
+    $onWindows = Test-WpfIsWindows
 
     if ($onWindows) {
         $result = Show-WpfTimerCountdown -Seconds $Seconds
@@ -349,34 +352,14 @@ function Show-WpfTimerCountdown {
 
     Add-Type -AssemblyName PresentationFramework, WindowsBase, PresentationCore
 
-    $colorBg       = $script:WpfColorBackground
-    $colorStroke   = $script:WpfColorStroke
-    $colorProgress = $script:WpfColorProgress
-    $colorButton   = $script:WpfColorButton
-    $colorHint     = $script:WpfColorHint
-
-    $converter     = [System.Windows.Media.BrushConverter]::new()
-    $brushBg       = $converter.ConvertFromString($colorBg)
-    $brushStroke   = $converter.ConvertFromString($colorStroke)
-    $brushProgress = $converter.ConvertFromString($colorProgress)
-    $brushButton   = $converter.ConvertFromString($colorButton)
-    $brushHint     = $converter.ConvertFromString($colorHint)
-    $brushWhite    = [System.Windows.Media.Brushes]::White
-    $brushDarkRed  = [System.Windows.Media.Brushes]::DarkRed
-    $brushClear    = [System.Windows.Media.Brushes]::Transparent
-
-    $windowSize    = $script:WpfWindowSize
-    $center        = $script:WpfCircleCenter
-    $radius        = $script:WpfCircleRadius
-    $arcStartX     = $script:WpfArcStartX
-    $arcStartY     = $script:WpfArcStartY
-    $flashMaxTicks = 15
-
+    $flashMaxTicks  = 15
     $defaultSeconds = $Seconds
 
     $Script:WpfTimeRemaining = [double]$Seconds
     $Script:WpfTotalSeconds  = [double]$Seconds
     $Script:WpfOutcome       = 'Complete'
+
+    $brushes = New-WpfBrushSet -ProgressColor $script:WpfColorProgress
 
     do {
         $Script:WpfOutcome    = 'Complete'
@@ -385,49 +368,11 @@ function Show-WpfTimerCountdown {
 
         # ---- Build window ----
 
-        $mainWin = New-Object System.Windows.Window -Property @{
-            Title                 = 'Timer Session'
-            SizeToContent         = 'WidthAndHeight'
-            WindowStyle           = 'None'
-            AllowsTransparency    = $true
-            Background            = $brushClear
-            Topmost               = $true
-            WindowStartupLocation = 'CenterScreen'
-        }
-
-        $circleGrid = New-Object System.Windows.Controls.Grid -Property @{
-            Width  = $windowSize
-            Height = $windowSize
-        }
-
-        $mainCircle = New-Object System.Windows.Shapes.Ellipse -Property @{
-            Fill            = $brushBg
-            Stroke          = $brushStroke
-            StrokeThickness = 2
-        }
-        $circleGrid.Children.Add($mainCircle) | Out-Null
-
-        $pathGeometry = New-Object System.Windows.Media.PathGeometry
-        $pathFigure   = New-Object System.Windows.Media.PathFigure -Property @{
-            StartPoint = "$arcStartX,$arcStartY"
-            IsClosed   = $false
-        }
-        $arcSegment = New-Object System.Windows.Media.ArcSegment -Property @{
-            Size           = "$radius,$radius"
-            SweepDirection = 'Clockwise'
-            IsLargeArc     = $true
-        }
-        $pathFigure.Segments.Add($arcSegment) | Out-Null
-        $pathGeometry.Figures.Add($pathFigure) | Out-Null
-
-        $progressRing = New-Object System.Windows.Shapes.Path -Property @{
-            Stroke             = $brushProgress
-            StrokeThickness    = 6
-            StrokeStartLineCap = 'Round'
-            StrokeEndLineCap   = 'Round'
-            Data               = $pathGeometry
-        }
-        $circleGrid.Children.Add($progressRing) | Out-Null
+        $circleRes  = New-WpfCircleResources -Title 'Timer Session' -Brushes $brushes
+        $mainWin    = $circleRes.Window
+        $circleGrid = $circleRes.Grid
+        $mainCircle = $circleRes.MainCircle
+        $arcSegment = $circleRes.ArcSegment
 
         $vbox = New-Object System.Windows.Controls.StackPanel -Property @{
             VerticalAlignment   = 'Center'
@@ -438,7 +383,7 @@ function Show-WpfTimerCountdown {
             Text                = '00:00.0'
             FontSize            = 34
             FontFamily          = 'Consolas'
-            Foreground          = $brushWhite
+            Foreground          = $brushes.White
             HorizontalAlignment = 'Center'
             Margin              = '0,0,0,8'
             Cursor              = [System.Windows.Input.Cursors]::Hand
@@ -454,16 +399,16 @@ function Show-WpfTimerCountdown {
             Content    = '+5 Min'
             Width      = 55
             Height     = 22
-            Background = $brushButton
-            Foreground = $brushWhite
+            Background = $brushes.Button
+            Foreground = $brushes.White
             Margin     = 2
         }
         $btnPlus10 = New-Object System.Windows.Controls.Button -Property @{
             Content    = '+10 Min'
             Width      = 55
             Height     = 22
-            Background = $brushButton
-            Foreground = $brushWhite
+            Background = $brushes.Button
+            Foreground = $brushes.White
             Margin     = 2
         }
         $adjustRow.Children.Add($btnPlus5)  | Out-Null
@@ -479,8 +424,8 @@ function Show-WpfTimerCountdown {
             Content    = 'New Pomodoro'
             Width      = 120
             Height     = 24
-            Background = $brushButton
-            Foreground = $brushWhite
+            Background = $brushes.Button
+            Foreground = $brushes.White
         }
         $pomoRow.Children.Add($btnNewPomo) | Out-Null
         $vbox.Children.Add($pomoRow) | Out-Null
@@ -494,16 +439,16 @@ function Show-WpfTimerCountdown {
             Content    = 'Capture Story'
             Width      = 92
             Height     = 22
-            Background = $brushButton
-            Foreground = $brushWhite
+            Background = $brushes.Button
+            Foreground = $brushes.White
             Margin     = 2
         }
         $btnComplete = New-Object System.Windows.Controls.Button -Property @{
             Content    = 'Mark Complete'
             Width      = 92
             Height     = 22
-            Background = $brushButton
-            Foreground = $brushWhite
+            Background = $brushes.Button
+            Foreground = $brushes.White
             Margin     = 2
         }
         $actionRow.Children.Add($btnCapture)  | Out-Null
@@ -513,14 +458,13 @@ function Show-WpfTimerCountdown {
         $exitHint = New-Object System.Windows.Controls.TextBlock -Property @{
             Text                = 'Click time to pause  ·  Right-click to exit'
             FontSize            = 9
-            Foreground          = $brushHint
+            Foreground          = $brushes.Hint
             HorizontalAlignment = 'Center'
             Margin              = '0,8,0,0'
         }
         $vbox.Children.Add($exitHint) | Out-Null
 
         $circleGrid.Children.Add($vbox) | Out-Null
-        $mainWin.Content = $circleGrid
 
         # ---- Timer state and UI update helper ----
 
@@ -534,22 +478,7 @@ function Show-WpfTimerCountdown {
 
             if ($Script:WpfTotalSeconds -gt 0) {
                 $pct = $Script:WpfTimeRemaining / $Script:WpfTotalSeconds
-
-                if ($pct -ge 0.9999) {
-                    $pct = 0.9999
-                }
-
-                if ($pct -le 0.0001) {
-                    $pct = 0.0001
-                }
-
-                $angle    = $pct * 360
-                $angleRad = [Math]::PI * ($angle - 90) / 180
-                $x        = $center + $radius * [Math]::Cos($angleRad)
-                $y        = $center + $radius * [Math]::Sin($angleRad)
-
-                $arcSegment.IsLargeArc = ($angle -gt 180)
-                $arcSegment.Point      = New-Object System.Windows.Point($x, $y)
+                Set-WpfArcPoint -Pct $pct -ArcSegment $arcSegment
             }
         }
 
@@ -578,7 +507,7 @@ function Show-WpfTimerCountdown {
             }
 
             $flashTick.Stop()
-            $mainCircle.Fill = $brushBg
+            $mainCircle.Fill = $brushes.Bg
 
             if ($clockTick.IsEnabled) {
                 $clockTick.Stop()
@@ -603,16 +532,16 @@ function Show-WpfTimerCountdown {
 
             if ($Script:WpfFlashCount -ge $flashMaxTicks) {
                 $flashTick.Stop()
-                $mainCircle.Fill = $brushBg
+                $mainCircle.Fill = $brushes.Bg
                 $mainWin.Close()
                 return
             }
 
             if ($Script:WpfIsFlashing) {
-                $mainCircle.Fill      = $brushBg
+                $mainCircle.Fill      = $brushes.Bg
                 $Script:WpfIsFlashing = $false
             } else {
-                $mainCircle.Fill      = $brushDarkRed
+                $mainCircle.Fill      = $brushes.DarkRed
                 $Script:WpfIsFlashing = $true
             }
         })
@@ -636,7 +565,7 @@ function Show-WpfTimerCountdown {
         $btnNewPomo.Add_Click({
             $clockTick.Stop()
             $flashTick.Stop()
-            $mainCircle.Fill         = $brushBg
+            $mainCircle.Fill         = $brushes.Bg
             $Script:WpfTotalSeconds  = [double]$defaultSeconds
             $Script:WpfTimeRemaining = $Script:WpfTotalSeconds
             & $updateUi

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -105,6 +105,13 @@ if ($azdevops_create -ne $NULL) {
     Write-Host "no azdevops_create.ps1"
 }
 
+$pow_timer = Get-Content "$path_to_bashcuts\powcuts_by_cli\pow_timer.ps1"
+if ($pow_timer -ne $NULL) {
+ . "$path_to_bashcuts\powcuts_by_cli\pow_timer.ps1"
+} else {
+    Write-Host "no pow_timer.ps1"
+}
+
 $azdevops_unplanned = Get-Content "$path_to_bashcuts\powcuts_by_cli\azdevops_unplanned.ps1"
 if ($azdevops_unplanned -ne $NULL) {
  . "$path_to_bashcuts\powcuts_by_cli\azdevops_unplanned.ps1"
@@ -138,13 +145,6 @@ if ($azdevops_help -ne $NULL) {
  . "$path_to_bashcuts\powcuts_by_cli\azdevops_help.ps1"
 } else {
     Write-Host "no azdevops_help.ps1"
-}
-
-$pow_timer = Get-Content "$path_to_bashcuts\powcuts_by_cli\pow_timer.ps1"
-if ($pow_timer -ne $NULL) {
- . "$path_to_bashcuts\powcuts_by_cli\pow_timer.ps1"
-} else {
-    Write-Host "no pow_timer.ps1"
 }
 
 # On shell open: silently refresh the Azure DevOps cache in the background when


### PR DESCRIPTION
<!-- pr-diagram:start -->
## How it works

Both orchestrators (`az-Start-TimerSession` and `az-Start-UnplannedWork`) call `Test-WpfIsWindows` to branch at runtime: on Windows they delegate to the new WPF circular overlays (`Show-WpfTimerCountdown` / `Show-WpfStopwatch`), which are built from three shared helpers in `pow_common.ps1`; on macOS/Linux the existing console loops run unchanged. Mid-session action buttons in the WPF overlays hand control back to the terminal (`az-New-AzDevOpsUserStory`) before re-launching the overlay with remaining time.

```mermaid
flowchart TD
    TS[az-Start-TimerSession]
    UW[az-Start-UnplannedWork]

    Gate1{Test-WpfIsWindows?}
    Gate2{Test-WpfIsWindows?}

    WpfTimer[Show-WpfTimerCountdown]
    WpfStop[Show-WpfStopwatch]

    Brushes[New-WpfBrushSet]
    Circle[New-WpfCircleResources]
    Arc[Set-WpfArcPoint]

    SnakeLoop[Console snake loop - macOS and Linux]
    ConsoleLoop[Console key loop - macOS and Linux]
    CaptureStory[az-New-AzDevOpsUserStory - terminal]

    TS --> Gate1
    Gate1 -- Windows --> WpfTimer
    Gate1 -- other --> SnakeLoop

    UW --> Gate2
    Gate2 -- Windows --> WpfStop
    Gate2 -- other --> ConsoleLoop

    WpfTimer --> Brushes
    WpfTimer --> Circle
    WpfTimer --> Arc
    WpfTimer -. Capture Story .-> CaptureStory
    CaptureStory -. resumes .-> WpfTimer

    WpfStop --> Brushes
    WpfStop --> Circle
    WpfStop --> Arc
    WpfStop -. Capture Story .-> CaptureStory
```
<!-- pr-diagram:end -->

<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #100 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | 0/7 |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/101#issuecomment-4525833028) |
| 💠 PowerShell Engineer Review | ❌ REQUEST CHANGES — [View](https://github.com/jdschleicher/bashcuts/pull/101#issuecomment-4525849884) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/101#issuecomment-4525818300) |
| 🧼 Clean-Code Engineer Review | ❌ REQUEST CHANGES — [View](https://github.com/jdschleicher/bashcuts/pull/101#issuecomment-4525837821) |
| 📚 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/101#issuecomment-4525859476) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/101#issuecomment-4525869684) |
<!-- toc:end -->

## Summary
- Replaces the console snake-animation countdown and WinForms debrief form with a WPF circular overlay and terminal `Read-Host` prompts
- Adds mid-session action buttons: **Capture Story Idea** (pauses timer, runs `az-New-AzDevOpsUserStory` in terminal, resumes) and **Mark Complete Early** (WPF confirmation → terminal debrief)
- Adds an amber filling-arc WPF stopwatch overlay to `az-Start-UnplannedWork` on Windows
- Both overlays fall back to the existing console behaviour on macOS/Linux

## Issue
Closes #100

## Changes
| File | Change |
|------|--------|
| `powcuts_by_cli/pow_timer.ps1` | Add `Show-WpfTimerCountdown`; update `Show-TimerCountdown` to delegate; remove `Show-ModernMultiLinePrompt`; update `az-Start-TimerSession` debrief to `Read-Host`; add `$script:WpfColor*` / `$script:WpfSize*` constants |
| `powcuts_by_cli/azdevops_unplanned.ps1` | Add `Show-WpfStopwatch`; update `az-Start-UnplannedWork` to use it on Windows |

## Test Plan
- [ ] Run `az-Start-TimerSession` on Windows — WPF circular blue overlay appears, click time display to start; +5/+10/New Pomodoro buttons work
- [ ] Click **Capture Story** mid-session — overlay closes, `az-New-AzDevOpsUserStory` prompts in terminal, overlay reopens with remaining time
- [ ] Click **Mark Complete Early** — WPF confirm dialog appears; confirm → terminal debrief prompts
- [ ] Let timer expire naturally — overlay flashes red, auto-closes after ~4.5 s, terminal debrief starts
- [ ] Run `az-Start-TimerSession` on macOS/Linux — snake animation runs as before
- [ ] Run `az-Start-UnplannedWork` on Windows — amber stopwatch overlay appears, Log Item / Capture Story / Stop work
- [ ] `pwsh -NoProfile` parse passes on both changed files with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


