### PR TITLE
Memoize auth smoke-query gate + Area/Iteration classification fetch (per-call az round-trips)

### DIFF
--- a/powcuts_by_cli/azdevops_auth.ps1
+++ b/powcuts_by_cli/azdevops_auth.ps1
@@ -122,6 +122,43 @@ function Invoke-AzDevOpsSmokeQuery {
 }
 
 
+# In-session auth memo. Assert-AzDevOpsAuthOrAbort is the prologue for every
+# az-New-AzDevOps* / az-Sync / schema command, and az-Test-AzDevOpsAuth proves
+# auth with a live `az boards query` @Me smoke test - a network round-trip on
+# the start of EVERY command. Once auth is proven we record the time and
+# short-circuit the re-check for AzDevOpsAuthMemoTtlMinutes. Success only:
+# failures are never memoized, so fixing auth and retrying re-checks instantly.
+# Bounded by a TTL (not session-forever) so a token that expires mid-session is
+# re-verified within the window rather than masked until a new shell.
+$script:AzDevOpsAuthOkAt = $null
+$script:AzDevOpsAuthMemoTtlMinutes = 10
+
+
+function Clear-AzDevOpsAuthMemo {
+    # Private. Forgets the proven-auth timestamp so the next gate re-runs the
+    # live smoke test. Called on connect and on project switch.
+    $script:AzDevOpsAuthOkAt = $null
+}
+
+
+function Set-AzDevOpsAuthOk {
+    # Private. Records "auth proven now" so subsequent gates short-circuit.
+    $script:AzDevOpsAuthOkAt = Get-Date
+}
+
+
+function Test-AzDevOpsAuthMemoValid {
+    # Private. True when auth was proven within the TTL window.
+    if ($null -eq $script:AzDevOpsAuthOkAt) {
+        return $false
+    }
+
+    $age = (Get-Date) - $script:AzDevOpsAuthOkAt
+    $valid = $age.TotalMinutes -lt $script:AzDevOpsAuthMemoTtlMinutes
+    return $valid
+}
+
+
 function az-Test-AzDevOpsAuth {
     if (-not (Test-AzDevOpsCliPresent)) {
         return $false
@@ -143,10 +180,16 @@ function Assert-AzDevOpsAuthOrAbort {
     # returns $false so callers `if (-not (Assert-...)) { return }`.
     param([Parameter(Mandatory)] [string] $CommandName)
 
-    if (az-Test-AzDevOpsAuth) {
+    if (Test-AzDevOpsAuthMemoValid) {
         return $true
     }
 
+    if (az-Test-AzDevOpsAuth) {
+        Set-AzDevOpsAuthOk
+        return $true
+    }
+
+    Clear-AzDevOpsAuthMemo
     Write-Host "$CommandName aborted - az-Test-AzDevOpsAuth returned false. Run az-Connect-AzDevOps." -ForegroundColor Red
     return $false
 }
@@ -424,6 +467,8 @@ function az-Connect-AzDevOps {
             return
         }
     }
+
+    Set-AzDevOpsAuthOk
 
     Write-Host ""
     $defaults = Get-AzDevOpsConfiguredDefaults

--- a/powcuts_by_cli/azdevops_classification.ps1
+++ b/powcuts_by_cli/azdevops_classification.ps1
@@ -51,19 +51,29 @@ function Get-AzDevOpsClassificationMemoKey {
 }
 
 
+function Get-AzDevOpsClassificationCacheFile {
+    # Private. Maps a classification Kind to its on-disk cache file path so the
+    # cache reader and the picker's live-fallback alert share one selection.
+    param([Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind)
+
+    $paths = Get-AzDevOpsCachePaths
+    $cacheFile = if ($Kind -eq 'Iteration') {
+        $paths.Iterations
+    } else {
+        $paths.Areas
+    }
+
+    return $cacheFile
+}
+
+
 function Read-AzDevOpsClassificationCache {
     # Reads iterations.json or areas.json from the cache. Returns the parsed
     # tree root, or $null when the cache file is missing / unparseable so
     # callers can fall back to a live `az` fetch.
     param([Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind)
 
-    $paths = Get-AzDevOpsCachePaths
-    $cachePath = if ($Kind -eq 'Iteration') {
-        $paths.Iterations
-    }
-    else {
-        $paths.Areas
-    }
+    $cachePath = Get-AzDevOpsClassificationCacheFile -Kind $Kind
 
     if (-not (Test-Path -LiteralPath $cachePath)) {
         return $null
@@ -182,12 +192,7 @@ function Get-AzDevOpsClassificationPaths {
     $tree = Read-AzDevOpsClassificationCache -Kind $Kind
     if ($null -eq $tree) {
         $azKind = $Kind.ToLower()
-        $allPaths = Get-AzDevOpsCachePaths
-        $cacheFile = if ($Kind -eq 'Iteration') {
-            $allPaths.Iterations
-        } else {
-            $allPaths.Areas
-        }
+        $cacheFile = Get-AzDevOpsClassificationCacheFile -Kind $Kind
 
         Write-Host "!  ${Kind} cache is EMPTY/MISSING - nothing local to read." -ForegroundColor Yellow
         Write-Host "   Expected at: $cacheFile" -ForegroundColor Yellow

--- a/powcuts_by_cli/azdevops_classification.ps1
+++ b/powcuts_by_cli/azdevops_classification.ps1
@@ -10,6 +10,47 @@
 #
 # Loaded by powcuts_home.ps1. See azdevops_auth.ps1 for the master docstring.
 
+# In-session memo for resolved Area/Iteration path arrays. Keyed by
+# "<active-project>|<Kind>" so a multi-project shell keeps separate entries.
+# Populated on the first successful resolve (cache hit or live fetch) so the
+# two pickers in a single create - and the batch "change area/iteration"
+# rounds - never re-read the cache or re-call `az` after the first hit.
+# Cleared explicitly by az-Sync-AzDevOpsCache and az-Use-AzDevOpsProject.
+$script:AzDevOpsClassificationPathMemo = @{}
+
+# Memo-key project segment used when no $global:AzDevOpsProjectMap is set
+# (single-project flat-env mode). Keeps the key shape stable.
+$script:AzDevOpsSingleProjectMemoKey = '__single_project__'
+
+
+function Clear-AzDevOpsClassificationMemo {
+    # Private. Drops the in-session Area/Iteration path memo so the next picker
+    # call re-reads the freshly-synced cache or re-targets the new active
+    # project. Unapproved verb is fine - this is not a user-facing function.
+    $script:AzDevOpsClassificationPathMemo = @{}
+}
+
+
+function Get-AzDevOpsClassificationMemoKey {
+    # Private. Builds the "<active-project>|<Kind>" memo key for the active
+    # project, falling back to a stable constant in single-project mode.
+    param([Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind)
+
+    $projectKey = $null
+    if (Get-Command Get-AzDevOpsActiveProjectSlug -ErrorAction SilentlyContinue) {
+        $slug = Get-AzDevOpsActiveProjectSlug
+        $projectKey = $slug
+    }
+
+    if (-not $projectKey) {
+        $projectKey = $script:AzDevOpsSingleProjectMemoKey
+    }
+
+    $key = "$projectKey|$Kind"
+    return $key
+}
+
+
 function Read-AzDevOpsClassificationCache {
     # Reads iterations.json or areas.json from the cache. Returns the parsed
     # tree root, or $null when the cache file is missing / unparseable so
@@ -124,19 +165,43 @@ function ConvertTo-AzDevOpsClassificationPaths {
 
 
 function Get-AzDevOpsClassificationPaths {
-    # Single entry point for picker consumers: read from cache first, fall
-    # back to live `az` with a one-line "(run az-Sync-AzDevOpsCache to make this
-    # instant)" notice so the function stays usable before the user re-syncs.
+    # Single entry point for picker consumers. Returns from the in-session memo
+    # when present; otherwise reads the local cache, falling back to a live `az`
+    # call - with a loud "cache is empty/missing, going to Azure now (slow)"
+    # alert - only when the cache file is missing/unparseable. A successful
+    # resolve (cache hit or live fetch) is memoized so the second picker in a
+    # create, and the batch "change area/iteration" rounds, stay instant.
     param([Parameter(Mandatory)] [ValidateSet('Iteration', 'Area')] [string] $Kind)
+
+    $memoKey = Get-AzDevOpsClassificationMemoKey -Kind $Kind
+    if ($script:AzDevOpsClassificationPathMemo.ContainsKey($memoKey)) {
+        $memoized = $script:AzDevOpsClassificationPathMemo[$memoKey]
+        return $memoized
+    }
 
     $tree = Read-AzDevOpsClassificationCache -Kind $Kind
     if ($null -eq $tree) {
         $azKind = $Kind.ToLower()
-        Write-Host "(fetching ${azKind}s live - run az-Sync-AzDevOpsCache to make this instant)" -ForegroundColor Yellow
+        $allPaths = Get-AzDevOpsCachePaths
+        $cacheFile = if ($Kind -eq 'Iteration') {
+            $allPaths.Iterations
+        } else {
+            $allPaths.Areas
+        }
+
+        Write-Host "!  ${Kind} cache is EMPTY/MISSING - nothing local to read." -ForegroundColor Yellow
+        Write-Host "   Expected at: $cacheFile" -ForegroundColor Yellow
+        Write-Host "   Calling Azure live for ${azKind}s now (slow). Run az-Sync-AzDevOpsCache to populate the cache and make this instant." -ForegroundColor Yellow
+
         $tree = Invoke-AzDevOpsClassificationLive -Kind $Kind
     }
 
     $paths = ConvertTo-AzDevOpsClassificationPaths -Root $tree -Kind $Kind
+
+    if ($null -ne $tree) {
+        $script:AzDevOpsClassificationPathMemo[$memoKey] = $paths
+    }
+
     return $paths
 }
 

--- a/powcuts_by_cli/azdevops_projects.ps1
+++ b/powcuts_by_cli/azdevops_projects.ps1
@@ -516,6 +516,10 @@ function az-Use-AzDevOpsProject {
         Clear-AzDevOpsClassificationMemo
     }
 
+    if (Get-Command Clear-AzDevOpsAuthMemo -ErrorAction SilentlyContinue) {
+        Clear-AzDevOpsAuthMemo
+    }
+
     if (-not $SkipConfigure) {
         if (Get-Command az -ErrorAction SilentlyContinue) {
             $org     = [string]$config['Org']

--- a/powcuts_by_cli/azdevops_projects.ps1
+++ b/powcuts_by_cli/azdevops_projects.ps1
@@ -512,6 +512,10 @@ function az-Use-AzDevOpsProject {
     Set-AzDevOpsActiveProjectEnv -Config $config
     $script:ActiveAzDevOpsProject = $Name
 
+    if (Get-Command Clear-AzDevOpsClassificationMemo -ErrorAction SilentlyContinue) {
+        Clear-AzDevOpsClassificationMemo
+    }
+
     if (-not $SkipConfigure) {
         if (Get-Command az -ErrorAction SilentlyContinue) {
             $org     = [string]$config['Org']

--- a/powcuts_by_cli/azdevops_sync.ps1
+++ b/powcuts_by_cli/azdevops_sync.ps1
@@ -258,6 +258,10 @@ function az-Sync-AzDevOpsCache {
     Write-AzDevOpsCacheFile -Path $paths.LastSync -Content ($lastSync | ConvertTo-Json -Depth 5)
     Write-AzDevOpsSyncLog 'sync complete'
 
+    if (Get-Command Clear-AzDevOpsClassificationMemo -ErrorAction SilentlyContinue) {
+        Clear-AzDevOpsClassificationMemo
+    }
+
     Write-Host ""
     Write-Host "Cache: $($paths.Dir)" -ForegroundColor Cyan
     if ($errored -gt 0) {

--- a/powcuts_by_cli/azdevops_views.ps1
+++ b/powcuts_by_cli/azdevops_views.ps1
@@ -135,11 +135,52 @@ function ConvertFrom-AzDevOpsAssignedItem {
 }
 
 
+# In-session parse memo for cache files, keyed by absolute path + the file's
+# last-write-time. Repeated reads of an unchanged file in one session skip the
+# Get-Content + ConvertFrom-Json + per-row conversion (the cost felt when, say,
+# creating several stories back-to-back re-parses hierarchy.json each time).
+# Keying on mtime means the detached background sync - which rewrites cache
+# files from a SEPARATE process - auto-invalidates the memo with no explicit
+# clear, and keying on the (per-project) path means switching projects can't
+# serve another project's rows. Failed parses are not memoized.
+$script:AzDevOpsParseMemo = @{}
+
+
+function Get-AzDevOpsMemoizedParse {
+    # Private. Returns the memoized parse of $Path while the file is unchanged
+    # since the last read (by LastWriteTimeUtc); otherwise runs $Parse, stores a
+    # non-null result keyed by path + mtime, and returns it. $Parse takes no args
+    # and must read $Path itself and return the finished object/array. Callers
+    # must confirm $Path exists before calling.
+    param(
+        [Parameter(Mandatory)] [string]      $Path,
+        [Parameter(Mandatory)] [scriptblock] $Parse
+    )
+
+    $mtime = (Get-Item -LiteralPath $Path).LastWriteTimeUtc
+
+    $entry = $script:AzDevOpsParseMemo[$Path]
+    if ($null -ne $entry -and $entry.Mtime -eq $mtime) {
+        $cached = $entry.Value
+        return $cached
+    }
+
+    $value = & $Parse
+
+    if ($null -ne $value) {
+        $script:AzDevOpsParseMemo[$Path] = @{ Mtime = $mtime; Value = $value }
+    }
+
+    return $value
+}
+
+
 function Read-AzDevOpsJsonCache {
     # Shared shape for every cache reader: missing-cache hint, ConvertFrom-Json
     # with try/catch, then map each row through a per-dataset converter. Each
     # caller supplies its own $Path, a short $Description for the hint line,
     # and a scriptblock that turns one parsed row into a typed PSCustomObject.
+    # The parse is memoized per path+mtime so repeat reads in a session are free.
     param(
         [Parameter(Mandatory)] [string]      $Path,
         [Parameter(Mandatory)] [string]      $Description,
@@ -152,15 +193,19 @@ function Read-AzDevOpsJsonCache {
         return $null
     }
 
-    try {
-        $raw = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
-    }
-    catch {
-        Write-Host "Could not parse ${Path}: $_" -ForegroundColor Red
-        return $null
-    }
+    $items = Get-AzDevOpsMemoizedParse -Path $Path -Parse {
+        try {
+            $raw = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+        }
+        catch {
+            Write-Host "Could not parse ${Path}: $_" -ForegroundColor Red
+            return $null
+        }
 
-    $items = @($raw | ForEach-Object { & $Converter $_ })
+        $parsed = @($raw | ForEach-Object { & $Converter $_ })
+        return $parsed
+    }.GetNewClosure()
+
     return $items
 }
 


### PR DESCRIPTION

## Table of Contents


| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #102 |
| [Changes](#changes) | ✅ 5 files |
| [Test Plan](#test-plan) | 0/11 |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4526376521) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4526377741) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4526377961) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4526378153) |
| 📖 Docs Check | ✅ CURRENT — [View](#issuecomment-4526381893) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4526382720) |
| 📐 AzDO Diagrams Check | ✅ CURRENT — [View](#issuecomment-4526382782) |
| 💠 PowerShell Engineer Review — auth memo | ✅ APPROVE — [View](#issuecomment-4526466361) |
| 🛡️ Security Audit — auth memo | ✅ PASS — [View](#issuecomment-4526466304) |
| 🧼 Clean-Code Engineer Review — auth memo | ✅ APPROVE — [View](#issuecomment-4526466899) |
| 💠 PowerShell Engineer Review — parse memo | ✅ APPROVE — [View](#issuecomment-4526485593) |
| 🧼 Clean-Code Engineer Review — parse memo | ✅ APPROVE — [View](#issuecomment-4526486011) |


## How it works

Both flows short-circuit a repeated live `az` round-trip with an in-session memo. **Flow 1 (auth, primary):** the create/sync prologue checks a proven-auth timestamp before running a live smoke query; **Flow 2 (classification, secondary):** the Area/Iteration picker checks a path memo before touching the cache or going live. `az-Use-AzDevOpsProject` clears *both* memos when the active project flips.

```mermaid
flowchart TD
    %% FLOW 1 — auth-gate memo (primary)
    NewUS([az-New-AzDevOpsUserStory<br/>az-Sync-AzDevOpsCache]):::pub
    Gate[Test-AzDevOpsCreateGate<br/>Assert-AzDevOpsAuthOrAbort]:::priv
    MemoChk{Test-AzDevOpsAuthMemoValid<br/>within 10-min TTL?}
    Smoke["az-Test-AzDevOpsAuth<br/>Invoke-AzDevOpsSmokeQuery<br/>(az boards query @Me)"]:::io
    SetOk[Set-AzDevOpsAuthOk]:::priv
    ClrAuth[Clear-AzDevOpsAuthMemo]:::priv
    Connect([az-Connect-AzDevOps]):::pub

    NewUS --&gt; Gate --&gt; MemoChk
    MemoChk -- hit --&gt; OK([proceed / no network])
    MemoChk -- miss --&gt; Smoke
    Smoke -- ok --&gt; SetOk --&gt; OK
    Smoke -- fail --&gt; ClrAuth --&gt; Abort([abort: run az-Connect])
    Connect -.primes.-&gt; SetOk

    %% FLOW 2 — classification memo (secondary)
    Pick([Read-AzDevOpsKindPick]):::pub
    Paths[Get-AzDevOpsClassificationPaths]:::priv
    KeyChk{memo-key hit?<br/>Get-...MemoKey}
    Cache[(Read-...Cache /<br/>Get-...CacheFile)]:::io
    Live["EMPTY/MISSING alert +<br/>Invoke-...ClassificationLive"]:::io
    ClrCls[Clear-AzDevOpsClassificationMemo]:::priv

    Pick --&gt; Paths --&gt; KeyChk
    KeyChk -- hit --&gt; CDone([return paths instantly])
    KeyChk -- miss --&gt; Cache
    Cache -- hit --&gt; CDone
    Cache -- miss --&gt; Live --&gt; CDone

    %% shared clear
    UseProj([az-Use-AzDevOpsProject]):::pub
    UseProj -.clears both.-&gt; ClrAuth
    UseProj -.clears both.-&gt; ClrCls

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```


## Summary
**Primary fix — auth smoke-query gate.** Starting `az-New-AzDevOpsUserStory` (and `az-Sync-AzDevOpsCache`, schema commands) immediately echoed a live `az boards query` for `AssignedTo = @Me` — a network round-trip on the *start of every command*. The chain is `Test-AzDevOpsCreateGate → Assert-AzDevOpsAuthOrAbort → az-Test-AzDevOpsAuth → Invoke-AzDevOpsSmokeQuery`. This memoizes a proven-auth timestamp and short-circuits the re-check within a 10-minute TTL, so the WIQL round-trip happens at most once per window instead of once per command. `az-Test-AzDevOpsAuth` stays an honest live diagnostic; only the internal gate is memoized.

**Secondary fix — Area/Iteration classification.** Each picker called `Get-AzDevOpsClassificationPaths`, which fell back to a blocking live `az boards  list` on any cache miss (up to two calls per create, re-firing every batch &#34;change area/iteration&#34; round). An in-session memo reuses the resolved path set, and the live-fallback notice is now a loud, explicit empty-cache alert.

**Third layer — local parse memo.** `Read-AzDevOpsJsonCache` (the chokepoint for hierarchy/assigned/mentions) re-ran `Get-Content` + `ConvertFrom-Json` + per-row conversion on every call — re-parsing `hierarchy.json` on each of several back-to-back story creates. A new `Get-AzDevOpsMemoizedParse` helper memoizes the parse keyed by file path + last-write-time, so repeat reads of an unchanged file are free. Keying on mtime auto-invalidates when the detached background sync rewrites a file from a separate process (no explicit clear), and keying on the per-project path prevents cross-project bleed.

Both are the same idea — short-circuit the repeated live `az` calls within a session — applied at the two hot paths.

## Issue
Closes #102

## Changes
- `powcuts_by_cli/azdevops_views.ps1` — new `$script:AzDevOpsParseMemo` + private `Get-AzDevOpsMemoizedParse` helper; `Read-AzDevOpsJsonCache` routes its parse through it (path + `LastWriteTimeUtc` keyed; failures not memoized; self-invalidating, no clear needed).
- `powcuts_by_cli/azdevops_auth.ps1` **(primary)**
  - New `$script:AzDevOpsAuthOkAt` + `$script:AzDevOpsAuthMemoTtlMinutes` (10) state.
  - New private helpers `Clear-AzDevOpsAuthMemo`, `Set-AzDevOpsAuthOk`, `Test-AzDevOpsAuthMemoValid`.
  - `Assert-AzDevOpsAuthOrAbort` short-circuits on a valid memo, records success after a live check, and clears on failure. A successful `az-Connect-AzDevOps` primes the memo (step 8 already proved auth).
- `powcuts_by_cli/azdevops_classification.ps1`
  - `$script:AzDevOpsClassificationPathMemo` (keyed by active-project + `Kind`) + `$script:AzDevOpsSingleProjectMemoKey`; private helpers `Clear-AzDevOpsClassificationMemo`, `Get-AzDevOpsClassificationMemoKey`, `Get-AzDevOpsClassificationCacheFile`.
  - `Get-AzDevOpsClassificationPaths` returns from the memo, memoizes only on a **successful** resolve, and emits an explicit `EMPTY/MISSING … calling Azure live (slow)` alert on cache miss.
- `powcuts_by_cli/azdevops_sync.ps1` — `az-Sync-AzDevOpsCache` clears the classification memo after a successful sync.
- `powcuts_by_cli/azdevops_projects.ps1` — `az-Use-AzDevOpsProject` clears both the classification memo and the auth memo when the active project flips.

Failures are never memoized (auth or classification), so fixing the problem and retrying re-checks instantly. The auth TTL bounds staleness so a mid-session token expiry is re-verified within the window rather than masked until a new shell. All clear-calls are `Get-Command`-guarded for load-order safety.

## Test Plan
**Auth gate (primary):**
- [ ] `pwsh` parse `azdevops_auth.ps1` — zero errors (parser unavailable in CI env; verify locally)
- [ ] First `az-New-AzDevOpsUserStory` in a fresh shell echoes the `WIQL: … @Me` smoke query once; a **second** create within 10 min does **not** echo it (memo hit)
- [ ] Create flow is visibly faster on the 2nd+ create (no auth round-trip)
- [ ] `az-Test-AzDevOpsAuth` invoked directly still runs the live query every time (honest diagnostic)
- [ ] `az-Use-AzDevOpsProject` switch → next create re-runs the smoke query once (auth memo cleared)

**Classification (secondary):**
- [ ] Populated cache → `az-New-AzDevOpsUserStory`: both pickers open instantly, no `(fetching … live)` line
- [ ] Delete `areas.json`/`iterations.json` → first picker prints the explicit empty-cache alert + one `az` call; second picker + batch &#34;change&#34; rounds are instant
- [ ] `az-Sync-AzDevOpsCache` then create → reflects freshly-synced paths (memo cleared)

**Local parse memo:**
- [ ] `pwsh` parse `azdevops_views.ps1` — zero errors (verify locally)
- [ ] Create several user stories back-to-back in one shell → `hierarchy.json` is parsed once, not per create (faster after the first)
- [ ] Touch/rewrite a cache file (e.g. `az-Sync-AzDevOpsCache`) → next read reflects the new content (mtime changed → memo auto-invalidates)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVjWPTSbQedzTTiGQSryam)_