### PR TITLE
Morph timer countdown into a themed WPF debrief form with post spinner and loop-back

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,17 +467,23 @@ Start-TimerSession -Integration 'Azure DevOps - User Stories'
 Flow:
 1. Pick an integration (skipped when `-Integration` is supplied or only one is registered)
 2. Pick an item from the integration's grid
-3. Snake-animation countdown runs for `$Minutes`
-4. Debrief prompts (`debrief notes`, `what's next`) → comment posted on the picked item
+3. Countdown runs for `$Minutes` — WPF circular overlay on Windows, snake animation on macOS/Linux
+4. Capture your debrief (`debrief notes`, `what's next`) → comment posted on the picked item
+
+### The debrief
+
+On **Windows** the countdown morphs into a themed debrief form that shares the timer's dark/blue style: one window with a **Debrief** field and a **Next step** field plus a **Post Debrief** button. While the comment posts, the button is replaced by a spinner / `Posting...` state, and the **Start another session?** choice only appears once the comment posts successfully — so you always know the debrief landed before deciding whether to loop into a fresh timer. Choosing **Start another** reopens a new countdown; **Done** ends the session. Right-click the form to cancel without posting. A failed post keeps the form open with the error so you can retry.
+
+On **macOS/Linux** the debrief is collected with terminal `Read-Host` prompts after the snake animation, and a `Posting...` indicator shows while the comment is sent.
 
 ### Interrupting a session
 
-Press **Esc** during the countdown to end the session early and still go through the debrief prompts. The posted comment header reflects the outcome:
+Press **Esc** during the countdown (or use **Mark Complete Early** on the Windows overlay) to end the session early and still go through the debrief. The posted comment header reflects the outcome:
 
 - Completed: `Pomodoro complete — 25:00`
 - Interrupted: `Session interrupted at 04:30 of 25:00`
 
-After an interrupted session's comment posts, you're asked `Start a new session? [Y/n]` so you can pivot to a different story / integration without retyping the command. **Ctrl-C** is still a hard exit — no debrief, no comment.
+On Windows the debrief form's **Start another session?** prompt appears after every successful post (completed or interrupted). On macOS/Linux you're asked `Start a new session? [Y/n]` only after an *interrupted* session's comment posts, so you can pivot to a different story / integration without retyping the command. **Ctrl-C** is still a hard exit — no debrief, no comment.
 
 ### Registering your own integration
 

--- a/powcuts_by_cli/pow_common.ps1
+++ b/powcuts_by_cli/pow_common.ps1
@@ -224,3 +224,68 @@ function Set-WpfArcPoint {
     $ArcSegment.IsLargeArc = ($angle -gt 180)
     $ArcSegment.Point      = New-Object System.Windows.Point($x, $y)
 }
+
+
+$script:CommonSpinnerFrames = @('|', '/', '-', '\')
+
+
+function Invoke-WithSpinner {
+    # Runs $ScriptBlock while showing a console loading/posting indicator, then
+    # returns whatever the scriptblock returned. The work runs synchronously on
+    # the calling thread — a wrapped az call blocks until it returns — so this
+    # prints a single "working" line that stays on screen for the duration
+    # rather than a continuously spinning glyph (a true animation would need a
+    # second thread, and the wrapped call's own command echo would clash with
+    # it on the same console). It exists to give feedback that a slow call is
+    # in flight and to be the shared seam the repo-wide az spinner (#105) wraps.
+    param(
+        [Parameter(Mandatory)] [scriptblock] $ScriptBlock,
+        [string] $Message = 'Working'
+    )
+
+    $frame = $script:CommonSpinnerFrames[0]
+    Write-Host "$frame $Message..." -ForegroundColor Cyan
+
+    $result = & $ScriptBlock
+    return $result
+}
+
+
+function New-WpfSpinnerControl {
+    # Reusable WPF spinner: a TextBlock whose text cycles through the shared
+    # spinner frames on a DispatcherTimer tick. Caller adds .Text to its layout
+    # and starts/stops .Timer. Frames advance only while the dispatcher is free,
+    # so a long synchronous call on the UI thread stalls the animation until it
+    # returns — acceptable for the brief az posts this wraps. Returns the
+    # TextBlock + Timer so callers own placement and start/stop timing.
+    param(
+        [Parameter(Mandatory)] $Brushes,
+        [int] $FontSize = 22
+    )
+
+    $frames = $script:CommonSpinnerFrames
+
+    $textBlock = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text                = $frames[0]
+        FontSize            = $FontSize
+        FontFamily          = 'Consolas'
+        Foreground          = $Brushes.White
+        HorizontalAlignment = 'Center'
+    }
+
+    $timer = New-Object System.Windows.Threading.DispatcherTimer -Property @{
+        Interval = [TimeSpan]::FromMilliseconds(120)
+    }
+
+    $frameIndex = [ref] 0
+    $timer.Add_Tick({
+        $frameIndex.Value = ($frameIndex.Value + 1) % $frames.Count
+        $textBlock.Text   = $frames[$frameIndex.Value]
+    }.GetNewClosure())
+
+    $result = [PSCustomObject]@{
+        Text  = $textBlock
+        Timer = $timer
+    }
+    return $result
+}

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -3,9 +3,13 @@
 #
 # Public surface:
 #   Start-TimerSession         - pick integration -> pick item -> run timer ->
-#                                prompt for debrief -> post comment.
-#                                Press Esc during the countdown to end early
-#                                and still post a debrief.
+#                                collect debrief -> post comment. On Windows the
+#                                countdown morphs into a themed WPF debrief form
+#                                (Show-WpfTimerDebrief) that posts under a spinner
+#                                and loops back to a fresh timer; elsewhere the
+#                                debrief is collected via terminal Read-Host with
+#                                a console posting indicator. Press Esc during the
+#                                countdown to end early and still post a debrief.
 #   Register-TimerIntegration  - add an integration (Name, Description,
 #                                FetchItems, AddComment, optional ViewHint).
 #                                Registering with an existing Name replaces it.
@@ -675,6 +679,22 @@ function Format-TimerCommentBody {
 }
 
 
+function Get-TimerResultExitCode {
+    # Names the "missing ExitCode means success (0)" contract for an AddComment
+    # envelope ({ Json, Error, ExitCode }) in one place, so both the console
+    # verdict and the WPF post-gate read the outcome the same way.
+    param([Parameter(Mandatory)] $Result)
+
+    $exitCode = if ($Result -and $Result.PSObject.Properties['ExitCode']) {
+        $Result.ExitCode
+    } else {
+        0
+    }
+
+    return $exitCode
+}
+
+
 function Write-TimerPostVerdict {
     # Prints the post-comment verdict shared by both the WPF and terminal
     # debrief paths: a green check + optional ViewHint on success, a red warning
@@ -686,11 +706,7 @@ function Write-TimerPostVerdict {
         [Parameter(Mandatory)] $Integration
     )
 
-    $exitCode = if ($Result -and $Result.PSObject.Properties['ExitCode']) {
-        $Result.ExitCode
-    } else {
-        0
-    }
+    $exitCode = Get-TimerResultExitCode -Result $Result
 
     $checkIcon = $script:TimerIconCheck
     $warnIcon  = $script:TimerIconWarn
@@ -945,11 +961,7 @@ function Show-WpfTimerDebrief {
         $spinner.Timer.Stop()
         $spinner.Text.Visibility = [System.Windows.Visibility]::Collapsed
 
-        $exitCode = if ($postResult -and $postResult.PSObject.Properties['ExitCode']) {
-            $postResult.ExitCode
-        } else {
-            0
-        }
+        $exitCode = Get-TimerResultExitCode -Result $postResult
 
         if ($exitCode -eq 0) {
             $Script:WpfDebriefPostResult = $postResult

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -674,12 +674,339 @@ function Format-TimerCommentBody {
     return $body
 }
 
+
+function Write-TimerPostVerdict {
+    # Prints the post-comment verdict shared by both the WPF and terminal
+    # debrief paths: a green check + optional ViewHint on success, a red warning
+    # + error text on failure. $Result is the integration's AddComment envelope
+    # ({ Json, Error, ExitCode }); a missing ExitCode is treated as success (0).
+    param(
+        [Parameter(Mandatory)] $Result,
+        [Parameter(Mandatory)] $Item,
+        [Parameter(Mandatory)] $Integration
+    )
+
+    $exitCode = if ($Result -and $Result.PSObject.Properties['ExitCode']) {
+        $Result.ExitCode
+    } else {
+        0
+    }
+
+    $checkIcon = $script:TimerIconCheck
+    $warnIcon  = $script:TimerIconWarn
+
+    if ($exitCode -eq 0) {
+        Write-Host "$checkIcon Comment posted on item $($Item.Id)." -ForegroundColor Green
+
+        if ($Integration.ViewHint) {
+            $hint = & $Integration.ViewHint -Id $Item.Id
+            if ($hint) {
+                Write-Host "   $hint" -ForegroundColor DarkGray
+            }
+        }
+
+    } else {
+
+        Write-Host "$warnIcon Comment post failed (exit=$exitCode)." -ForegroundColor Red
+        if ($Result -and $Result.Error) {
+            Write-Host "   $($Result.Error)" -ForegroundColor Red
+        }
+    }
+}
+
+
+function Show-WpfTimerDebrief {
+    # Windows-only themed debrief form the countdown overlay morphs into. Two
+    # multiline fields (Debrief + Next) share the timer's dark/blue theme. On
+    # Post the form disables the button, shows a spinner, and runs -SubmitAction
+    # (which composes + posts the comment and returns the { Json, Error,
+    # ExitCode } envelope). The "Start another session?" choice is revealed ONLY
+    # after a successful post (ExitCode 0); a failed post keeps the form open
+    # with the error so the user can retry. Returns
+    # { Cancelled; StartAnother; PostResult } for the orchestrator.
+    #
+    # The az post is synchronous on the dispatcher thread, so the spinner can't
+    # truly animate during the call. The form forces a Render-priority dispatch
+    # before posting so the "Posting..." overlay paints, then blocks briefly on
+    # the call — feedback without spinning up a worker runspace.
+    param(
+        [Parameter(Mandatory)] [bool]        $Interrupted,
+        [Parameter(Mandatory)] [scriptblock] $SubmitAction
+    )
+
+    Add-Type -AssemblyName PresentationFramework, WindowsBase, PresentationCore
+
+    $formWidth = 360
+
+    $Script:WpfDebriefOutcome      = 'Cancelled'
+    $Script:WpfDebriefStartAnother = $false
+    $Script:WpfDebriefPostResult   = $null
+
+    $brushes = New-WpfBrushSet -ProgressColor $script:WpfColorProgress
+
+    # ---- Window + container ----
+
+    $mainWin = New-Object System.Windows.Window -Property @{
+        Title                 = 'Timer Debrief'
+        SizeToContent         = 'WidthAndHeight'
+        WindowStyle           = 'None'
+        AllowsTransparency    = $true
+        Background            = $brushes.Clear
+        Topmost               = $true
+        WindowStartupLocation = 'CenterScreen'
+    }
+
+    $border = New-Object System.Windows.Controls.Border -Property @{
+        Background      = $brushes.Bg
+        BorderBrush     = $brushes.Stroke
+        BorderThickness = 2
+        CornerRadius    = 10
+        Padding         = '16'
+        Width           = $formWidth
+    }
+
+    $vbox = New-Object System.Windows.Controls.StackPanel
+
+    # ---- Title (drag handle) ----
+
+    $headerText = if ($Interrupted) {
+        'Session interrupted — debrief'
+    } else {
+        'Session complete — debrief'
+    }
+
+    $titleLabel = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text                = $headerText
+        FontSize            = 15
+        FontWeight          = 'Bold'
+        Foreground          = $brushes.White
+        HorizontalAlignment = 'Center'
+        Margin              = '0,0,0,12'
+        Cursor              = [System.Windows.Input.Cursors]::SizeAll
+    }
+    $vbox.Children.Add($titleLabel) | Out-Null
+
+    # ---- Debrief field ----
+
+    $debriefLabel = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text       = 'Debrief — what did you accomplish?'
+        FontSize   = 11
+        Foreground = $brushes.Hint
+        Margin     = '0,0,0,3'
+    }
+    $vbox.Children.Add($debriefLabel) | Out-Null
+
+    $debriefBox = New-Object System.Windows.Controls.TextBox -Property @{
+        AcceptsReturn               = $true
+        TextWrapping                = 'Wrap'
+        Height                      = 64
+        Background                  = $brushes.Button
+        Foreground                  = $brushes.White
+        BorderBrush                 = $brushes.Stroke
+        Padding                     = '4'
+        VerticalScrollBarVisibility = 'Auto'
+        Margin                      = '0,0,0,10'
+    }
+    $vbox.Children.Add($debriefBox) | Out-Null
+
+    # ---- Next field ----
+
+    $nextLabel = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text       = 'Next — what''s the next step?'
+        FontSize   = 11
+        Foreground = $brushes.Hint
+        Margin     = '0,0,0,3'
+    }
+    $vbox.Children.Add($nextLabel) | Out-Null
+
+    $nextBox = New-Object System.Windows.Controls.TextBox -Property @{
+        AcceptsReturn               = $true
+        TextWrapping                = 'Wrap'
+        Height                      = 64
+        Background                  = $brushes.Button
+        Foreground                  = $brushes.White
+        BorderBrush                 = $brushes.Stroke
+        Padding                     = '4'
+        VerticalScrollBarVisibility = 'Auto'
+        Margin                      = '0,0,0,12'
+    }
+    $vbox.Children.Add($nextBox) | Out-Null
+
+    # ---- Post button row ----
+
+    $postPanel = New-Object System.Windows.Controls.StackPanel -Property @{
+        HorizontalAlignment = 'Center'
+    }
+    $btnPost = New-Object System.Windows.Controls.Button -Property @{
+        Content    = 'Post Debrief'
+        Width      = 120
+        Height     = 28
+        Background = $brushes.Button
+        Foreground = $brushes.White
+    }
+    $postPanel.Children.Add($btnPost) | Out-Null
+    $vbox.Children.Add($postPanel) | Out-Null
+
+    # ---- Spinner + status (hidden until Post) ----
+
+    $statusPanel = New-Object System.Windows.Controls.StackPanel -Property @{
+        Orientation         = 'Horizontal'
+        HorizontalAlignment = 'Center'
+        Margin              = '0,10,0,0'
+        Visibility          = [System.Windows.Visibility]::Collapsed
+    }
+    $spinner = New-WpfSpinnerControl -Brushes $brushes -FontSize 18
+    $spinner.Text.Margin = New-Object System.Windows.Thickness(0, 0, 8, 0)
+    $statusPanel.Children.Add($spinner.Text) | Out-Null
+
+    $statusText = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text              = ''
+        FontSize          = 12
+        Foreground        = $brushes.White
+        VerticalAlignment = 'Center'
+        TextWrapping      = 'Wrap'
+        MaxWidth          = 280
+    }
+    $statusPanel.Children.Add($statusText) | Out-Null
+    $vbox.Children.Add($statusPanel) | Out-Null
+
+    # ---- Start-another choice (hidden until a successful post) ----
+
+    $askPanel = New-Object System.Windows.Controls.StackPanel -Property @{
+        Orientation         = 'Horizontal'
+        HorizontalAlignment = 'Center'
+        Margin              = '0,12,0,0'
+        Visibility          = [System.Windows.Visibility]::Collapsed
+    }
+    $btnYes = New-Object System.Windows.Controls.Button -Property @{
+        Content    = 'Start another'
+        Width      = 100
+        Height     = 26
+        Background = $brushes.Button
+        Foreground = $brushes.White
+        Margin     = 3
+    }
+    $btnNo = New-Object System.Windows.Controls.Button -Property @{
+        Content    = 'Done'
+        Width      = 70
+        Height     = 26
+        Background = $brushes.Button
+        Foreground = $brushes.White
+        Margin     = 3
+    }
+    $askPanel.Children.Add($btnYes) | Out-Null
+    $askPanel.Children.Add($btnNo)  | Out-Null
+    $vbox.Children.Add($askPanel) | Out-Null
+
+    # ---- Exit hint ----
+
+    $exitHint = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text                = 'Right-click to cancel without posting'
+        FontSize            = 9
+        Foreground          = $brushes.Hint
+        HorizontalAlignment = 'Center'
+        Margin              = '0,12,0,0'
+    }
+    $vbox.Children.Add($exitHint) | Out-Null
+
+    $border.Child    = $vbox
+    $mainWin.Content = $border
+
+    # ---- Event handlers ----
+
+    $titleLabel.Add_MouseLeftButtonDown({ $mainWin.DragMove() })
+
+    $mainWin.Add_MouseRightButtonDown({
+        if ($Script:WpfDebriefOutcome -ne 'Posted') {
+            $Script:WpfDebriefOutcome = 'Cancelled'
+        }
+        $mainWin.Close()
+    })
+
+    $btnPost.Add_Click({
+        $debriefText = $debriefBox.Text
+        $nextText    = $nextBox.Text
+
+        $btnPost.IsEnabled      = $false
+        $statusText.Foreground  = $brushes.White
+        $statusText.Text        = 'Posting debrief...'
+        $statusPanel.Visibility = [System.Windows.Visibility]::Visible
+        $spinner.Timer.Start()
+
+        # Flush the dispatcher to Render priority so the "Posting..." overlay
+        # paints before the synchronous az call blocks this (UI) thread.
+        $mainWin.Dispatcher.Invoke(
+            [action]{},
+            [System.Windows.Threading.DispatcherPriority]::Render
+        )
+
+        $postResult = & $SubmitAction $debriefText $nextText
+
+        $spinner.Timer.Stop()
+        $spinner.Text.Visibility = [System.Windows.Visibility]::Collapsed
+
+        $exitCode = if ($postResult -and $postResult.PSObject.Properties['ExitCode']) {
+            $postResult.ExitCode
+        } else {
+            0
+        }
+
+        if ($exitCode -eq 0) {
+            $Script:WpfDebriefPostResult = $postResult
+            $Script:WpfDebriefOutcome    = 'Posted'
+
+            $statusText.Text      = 'Posted. Start another session?'
+            $postPanel.Visibility = [System.Windows.Visibility]::Collapsed
+            $askPanel.Visibility  = [System.Windows.Visibility]::Visible
+        } else {
+            $errText = if ($postResult -and $postResult.Error) {
+                $postResult.Error
+            } else {
+                "exit $exitCode"
+            }
+
+            $statusText.Foreground = $brushes.DarkRed
+            $statusText.Text       = "Post failed: $errText"
+            $btnPost.IsEnabled     = $true
+        }
+    })
+
+    $btnYes.Add_Click({
+        $Script:WpfDebriefStartAnother = $true
+        $mainWin.Close()
+    })
+
+    $btnNo.Add_Click({
+        $Script:WpfDebriefStartAnother = $false
+        $mainWin.Close()
+    })
+
+    # ---- Show ----
+
+    $debriefBox.Focus() | Out-Null
+    $mainWin.ShowDialog() | Out-Null
+
+    $cancelled = ($Script:WpfDebriefOutcome -ne 'Posted')
+
+    $result = [PSCustomObject]@{
+        Cancelled    = $cancelled
+        StartAnother = [bool]$Script:WpfDebriefStartAnother
+        PostResult   = $Script:WpfDebriefPostResult
+    }
+    return $result
+}
+
+
 function az-Start-TimerSession {
     # Orchestrator. Pick an integration (or use -Integration to skip),
     # fetch + pick an item, run the countdown (WPF overlay on Windows, snake
-    # animation elsewhere), prompt for debrief notes in the terminal, post
-    # the composed comment via the chosen integration's AddComment. On an
-    # interrupted session also prompt whether to start another session.
+    # animation elsewhere), then collect the debrief and post the composed
+    # comment via the chosen integration's AddComment. On Windows the countdown
+    # morphs into a themed WPF debrief form (Show-WpfTimerDebrief) that posts
+    # under a spinner and offers "Start another session?" only after a
+    # successful post; elsewhere the debrief is collected via terminal Read-Host
+    # with a console posting indicator, and only an interrupted session is asked
+    # whether to start another.
     #
     # UTF-8 encoding is applied so emoji glyphs render in terminals that
     # default to a non-UTF-8 codepage; restored on exit (including Ctrl-C).
@@ -729,65 +1056,87 @@ function az-Start-TimerSession {
             $seconds         = $Minutes * 60
             $countdownResult = Show-TimerCountdown -Seconds $seconds
 
-            Clear-Host
-            $finishIcon = $script:TimerIconFinish
-            Write-Host "$finishIcon SESSION COMPLETE! $finishIcon" -ForegroundColor Green
-            Write-Host ""
+            $onWindows = Test-WpfIsWindows
 
-            $iconMemo = $script:TimerIconMemo
-            $debrief  = Read-Host "$iconMemo Debrief — what did you accomplish?"
-            $next     = Read-Host "$iconMemo Next — what's the next step?"
+            if ($onWindows) {
 
-            $body = Format-TimerCommentBody `
-                -Interrupted    $countdownResult.Interrupted `
-                -ElapsedSeconds $countdownResult.ElapsedSeconds `
-                -TotalSeconds   $countdownResult.TotalSeconds `
-                -Debrief        $debrief `
-                -Next           $next
+                $submitAction = {
+                    param(
+                        [string] $DebriefText,
+                        [string] $NextText
+                    )
 
-            Write-Host ""
-            Write-Host "Posting debrief comment to item $($pickedItem.Id)..." -ForegroundColor Cyan
-            $commentResult = & $chosen.AddComment -Id $pickedItem.Id -Body $body
+                    $composed = Format-TimerCommentBody `
+                        -Interrupted    $countdownResult.Interrupted `
+                        -ElapsedSeconds $countdownResult.ElapsedSeconds `
+                        -TotalSeconds   $countdownResult.TotalSeconds `
+                        -Debrief        $DebriefText `
+                        -Next           $NextText
 
-            $exitCode = if ($commentResult -and $commentResult.PSObject.Properties['ExitCode']) {
-                $commentResult.ExitCode
-            } else {
-                0
-            }
+                    $posted = & $chosen.AddComment -Id $pickedItem.Id -Body $composed
+                    return $posted
+                }.GetNewClosure()
 
-            $checkIcon = $script:TimerIconCheck
-            $warnIcon  = $script:TimerIconWarn
+                $debriefResult = Show-WpfTimerDebrief -Interrupted $countdownResult.Interrupted -SubmitAction $submitAction
 
-            if ($exitCode -eq 0) {
-                Write-Host "$checkIcon Comment posted on item $($pickedItem.Id)." -ForegroundColor Green
-                if ($chosen.ViewHint) {
-                    $hint = & $chosen.ViewHint -Id $pickedItem.Id
-                    if ($hint) {
-                        Write-Host "   $hint" -ForegroundColor DarkGray
-                    }
+                if (-not $debriefResult.PostResult) {
+                    $waveIcon = $script:TimerIconWave
+                    Write-Host "No debrief posted - goodbye $waveIcon" -ForegroundColor DarkGray
+                    return
                 }
 
-            } else {
+                Write-TimerPostVerdict -Result $debriefResult.PostResult -Item $pickedItem -Integration $chosen
 
-                Write-Host "$warnIcon Comment post failed (exit=$exitCode)." -ForegroundColor Red
-                if ($commentResult -and $commentResult.Error) {
-                    Write-Host "   $($commentResult.Error)" -ForegroundColor Red
-                }
-
-            }
-
-            if ($countdownResult.Interrupted) {
-                $startAnother = Read-TimerYesNo -Prompt 'Start a new session?' -DefaultYes
-                if ($startAnother) {
+                if ($debriefResult.StartAnother) {
                     $shouldRestart = $true
-                    $Integration = $null
+                    $Integration   = $null
                 } else {
                     $waveIcon = $script:TimerIconWave
                     Write-Host "Goodbye $waveIcon" -ForegroundColor DarkGray
                 }
+
+            } else {
+
+                Clear-Host
+                $finishIcon = $script:TimerIconFinish
+                Write-Host "$finishIcon SESSION COMPLETE! $finishIcon" -ForegroundColor Green
+                Write-Host ""
+
+                $iconMemo = $script:TimerIconMemo
+                $debrief  = Read-Host "$iconMemo Debrief — what did you accomplish?"
+                $next     = Read-Host "$iconMemo Next — what's the next step?"
+
+                $body = Format-TimerCommentBody `
+                    -Interrupted    $countdownResult.Interrupted `
+                    -ElapsedSeconds $countdownResult.ElapsedSeconds `
+                    -TotalSeconds   $countdownResult.TotalSeconds `
+                    -Debrief        $debrief `
+                    -Next           $next
+
+                Write-Host ""
+                $postScript = {
+                    $posted = & $chosen.AddComment -Id $pickedItem.Id -Body $body
+                    return $posted
+                }.GetNewClosure()
+
+                $commentResult = Invoke-WithSpinner `
+                    -Message "Posting debrief to item $($pickedItem.Id)" `
+                    -ScriptBlock $postScript
+
+                Write-TimerPostVerdict -Result $commentResult -Item $pickedItem -Integration $chosen
+
+                if ($countdownResult.Interrupted) {
+                    $startAnother = Read-TimerYesNo -Prompt 'Start a new session?' -DefaultYes
+                    if ($startAnother) {
+                        $shouldRestart = $true
+                        $Integration   = $null
+                    } else {
+                        $waveIcon = $script:TimerIconWave
+                        Write-Host "Goodbye $waveIcon" -ForegroundColor DarkGray
+                    }
+                }
             }
 
-            
         } while ($shouldRestart)
     }
     finally {


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #104 |
| [Changes](#changes) | ✅ 3 files |
| [Notes](#notes) | ✅ |
| [Test Plan](#test-plan) | ✅ 5 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4527071953) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4527072965) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4527074004) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4527074045) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4527076919) |
| 📚 Docs Check | ✅ CURRENT — (inline, no source drift) |
<!-- toc:end -->
<!-- pr-diagram:start -->
## How it works

After the countdown, `az-Start-TimerSession` branches by platform: on Windows the overlay morphs into the new `Show-WpfTimerDebrief` form, which posts under a spinner (`New-WpfSpinnerControl`) and only offers "Start another" once the post succeeds; on macOS/Linux the terminal `Read-Host` debrief posts via the new `Invoke-WithSpinner` indicator. Both paths funnel the result through the extracted `Write-TimerPostVerdict`, and a "yes" loops back to a fresh countdown.

```mermaid
flowchart TD
    Entry([az-Start-TimerSession]):::pub
    Count["Show-TimerCountdown<br/>WPF overlay / snake"]
    Plat{Windows?}

    Debrief([Show-WpfTimerDebrief]):::pub
    Spin[New-WpfSpinnerControl]:::priv
    Submit["SubmitAction closure<br/>Format-TimerCommentBody"]:::priv

    Read["Read-Host debrief + next"]
    InvSpin([Invoke-WithSpinner]):::pub

    AzPost["AddComment<br/>az boards work-item update --discussion"]:::io
    Gate{ExitCode 0?}
    Ask["Start another session?"]
    Verdict([Write-TimerPostVerdict]):::pub
    Done([end session])

    Entry --> Count --> Plat
    Plat -- yes --> Debrief
    Debrief --> Spin
    Debrief --> Submit --> AzPost
    Plat -- no --> Read --> InvSpin --> AzPost

    AzPost --> Gate
    Gate -- ok --> Ask
    Gate -- fail --> Debrief
    Ask --> Verdict
    Verdict -. start another .-> Entry
    Ask -- done --> Done

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
On Windows, `az-Start-TimerSession` now morphs the WPF circular countdown into a themed debrief form instead of dropping to bare terminal `Read-Host` prompts. The form shares the timer's dark/blue theme, captures Debrief + Next in one window, posts under a spinner, and only reveals "Start another session?" once the comment posts successfully — looping back into a fresh countdown on yes. macOS/Linux keeps the terminal `Read-Host` debrief with a console posting indicator.

## Issue
Closes #104

## Changes
- **`powcuts_by_cli/pow_timer.ps1`**
  - `Show-WpfTimerDebrief` — Windows-only themed two-field debrief form; disables Post + shows a spinner during the post; reveals "Start another session?" only on `ExitCode 0`; a failed post keeps the form open to retry; returns `{ Cancelled; StartAnother; PostResult }`
  - `Write-TimerPostVerdict` — extracted success/failure verdict shared by both the WPF and terminal paths (removes the duplicated verdict block)
  - `az-Start-TimerSession` — post-countdown section reworked into a Windows (form) vs non-Windows (`Read-Host` + `Invoke-WithSpinner`) branch; on Windows the "ask then loop" now applies to both completed and interrupted sessions
- **`powcuts_by_cli/pow_common.ps1`**
  - `Invoke-WithSpinner` — console loading/posting indicator that returns the wrapped call's result (shared seam for the repo-wide az spinner, #105)
  - `New-WpfSpinnerControl` — reusable WPF spinner (TextBlock + DispatcherTimer)
  - `$script:CommonSpinnerFrames`
- **`README.md`** — Timer sessions flow rewritten + new "The debrief" subsection (themed form, spinner, loop-back; terminal fallback)

## Notes
- **PowerShell-only** by design — the WPF form/spinner are Windows-only (like the existing countdown overlay); macOS/Linux retains the `Read-Host` debrief. No `bashcuts_by_cli/` change.
- The az post is synchronous on the WPF dispatcher thread, so the spinner paints its "Posting…" state (via a forced Render-priority dispatch) then blocks briefly on the call — feedback without a worker runspace (documented in-code).
- The repo-wide spinner around every `az` call (wrapping `Invoke-AzDevOpsAzJson`) is the separate follow-up #105 and reuses the helpers added here.

## Test Plan
- [ ] `pwsh -NoProfile` parses `pow_timer.ps1` and `pow_common.ps1` with zero errors *(could not run locally — pwsh unavailable in the build container)*
- [ ] Windows: `az-Start-TimerSession -Minutes 1` → overlay → themed two-field debrief → Post shows spinner → "Start another?" appears only after the comment posts → **Start another** reopens a fresh overlay
- [ ] Windows interrupted (Esc / Mark Complete Early): same themed debrief + spinner + loop-back
- [ ] Post failure: form stays open with the error, no "start another?"
- [ ] macOS/Linux: snake animation → terminal `Read-Host` debrief → `Posting…` console indicator → interrupted-only "new session?" prompt