### PR TITLE
Auto-start the Pomodoro countdown when the timer overlay opens

### DIFF
--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -553,15 +553,31 @@ function Show-WpfTimerCountdown {
         })
 
         $btnPlus5.Add_Click({
+            $wasExpired = ($Script:WpfTimeRemaining -le 0)
+
             $Script:WpfTotalSeconds   += 300
             $Script:WpfTimeRemaining  += 300
             & $updateUi
+
+            if ($wasExpired) {
+                $flashTick.Stop()
+                $mainCircle.Fill = $brushes.Bg
+                $clockTick.Start()
+            }
         })
 
         $btnPlus10.Add_Click({
+            $wasExpired = ($Script:WpfTimeRemaining -le 0)
+
             $Script:WpfTotalSeconds   += 600
             $Script:WpfTimeRemaining  += 600
             & $updateUi
+
+            if ($wasExpired) {
+                $flashTick.Stop()
+                $mainCircle.Fill = $brushes.Bg
+                $clockTick.Start()
+            }
         })
 
         $btnNewPomo.Add_Click({

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -553,28 +553,25 @@ function Show-WpfTimerCountdown {
         })
 
         $btnPlus5.Add_Click({
-            if (-not $clockTick.IsEnabled) {
-                $Script:WpfTotalSeconds  += 300
-                $Script:WpfTimeRemaining  = $Script:WpfTotalSeconds
-                & $updateUi
-            }
+            $Script:WpfTotalSeconds   += 300
+            $Script:WpfTimeRemaining  += 300
+            & $updateUi
         })
 
         $btnPlus10.Add_Click({
-            if (-not $clockTick.IsEnabled) {
-                $Script:WpfTotalSeconds  += 600
-                $Script:WpfTimeRemaining  = $Script:WpfTotalSeconds
-                & $updateUi
-            }
+            $Script:WpfTotalSeconds   += 600
+            $Script:WpfTimeRemaining  += 600
+            & $updateUi
         })
 
         $btnNewPomo.Add_Click({
-            $clockTick.Stop()
             $flashTick.Stop()
             $mainCircle.Fill         = $brushes.Bg
             $Script:WpfTotalSeconds  = [double]$defaultSeconds
             $Script:WpfTimeRemaining = $Script:WpfTotalSeconds
             & $updateUi
+
+            $clockTick.Start()
         })
 
         $btnCapture.Add_Click({
@@ -605,6 +602,7 @@ function Show-WpfTimerCountdown {
         # ---- Show ----
 
         & $updateUi
+        $clockTick.Start()
         $mainWin.ShowDialog() | Out-Null
 
         if ($Script:WpfOutcome -eq 'CaptureStory') {


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #108 |
| [Changes](#changes) | ✅ 1 file |
| [Test Plan](#test-plan) | ✅ 7 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4535351137) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4535354227) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4535353925) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4535354909) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4535366287) |
| 📚 Docs Check | ✅ CURRENT — (no drift; no comment posted) |
<!-- toc:end -->

## Summary

The WPF Pomodoro countdown (`Show-WpfTimerCountdown` in `powcuts_by_cli/pow_timer.ps1`) used to open frozen — the clock sat at the starting time until the user clicked it to begin. The overlay's own hint already read *"Click time to pause"*, so a running clock was the intended behavior. This PR starts the countdown the moment the overlay opens.

## Issue

Closes #108

## Changes

- **Auto-start** — `$clockTick.Start()` now runs right before `ShowDialog`, so the countdown ticks immediately on open. Clicking the clock text now pauses/resumes (its existing toggle), matching the *"Click time to pause"* hint.
- **`+5 / +10 Min` while running** — dropped the `if (-not $clockTick.IsEnabled)` guard and switched to `+= 300 / 600` on `WpfTimeRemaining` (instead of resetting it to the full total), so adding time works while the countdown runs *and* while paused.
- **`+5 / +10 Min` after expiry** — if the timer already hit `00:00` (clock stopped, flashing), adding time stops the flash and resumes the countdown rather than leaving a frozen display; a paused-but-not-expired timer still stays paused.
- **`New Pomodoro`** — restarts the clock after resetting to the default duration, so the fresh countdown auto-runs without a click.

PowerShell / Windows-only — the console snake fallback (macOS/Linux) already auto-runs its countdown, and the unplanned stopwatch already auto-starts.

## Test Plan

- [ ] Fresh PowerShell terminal (Windows): `az-Start-TimerSession -Minutes 1` → pick item → countdown **starts ticking down immediately**, no click needed
- [ ] Click the clock text → **pauses**; click again → **resumes**
- [ ] While running, click **+5 Min** → remaining jumps up 5:00 and keeps ticking (doesn't snap back to full total)
- [ ] While **paused**, click **+5 Min** → remaining increases but the timer stays paused
- [ ] Let it reach `00:00` (flashing) → click **+5 Min** → flash stops and the countdown resumes from 5:00
- [ ] Click **New Pomodoro** → resets to default 25:00 **and starts running** with no click
- [ ] `pow_timer.ps1` dot-sources without parse errors on `reinit`