### PR TITLE
Add "continue with same work item" option to pomodoro debrief restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ Flow:
 
 ### The debrief
 
-On **Windows** the countdown morphs into a themed debrief form that shares the timer's dark/blue style: one window with a **Debrief** field and a **Next step** field plus a **Post Debrief** button. While the comment posts, the button is replaced by a spinner / `Posting...` state, and the **Start another session?** choice only appears once the comment posts successfully — so you always know the debrief landed before deciding whether to loop into a fresh timer. Choosing **Start another** reopens a new countdown; **Done** ends the session. Right-click the form to cancel without posting. A failed post keeps the form open with the error so you can retry.
+On **Windows** the countdown morphs into a themed debrief form that shares the timer's dark/blue style: one window with a **Debrief** field and a **Next step** field plus a **Post Debrief** button. While the comment posts, the button is replaced by a spinner / `Posting...` state, and the **Start another session?** choice only appears once the comment posts successfully — so you always know the debrief landed before deciding whether to loop into a fresh timer. The choice is three buttons: **Same item** reopens a new countdown on the work item you just debriefed (skipping both the integration and item pickers so you can keep grinding on the same ID), **Pick another** loops back to the picker, and **Done** ends the session. Right-click the form to cancel without posting. A failed post keeps the form open with the error so you can retry.
 
 On **macOS/Linux** the debrief is collected with terminal `Read-Host` prompts after the snake animation, and a `Posting...` indicator shows while the comment is sent.
 
@@ -483,7 +483,7 @@ Press **Esc** during the countdown (or use **Mark Complete Early** on the Window
 - Completed: `Pomodoro complete — 25:00`
 - Interrupted: `Session interrupted at 04:30 of 25:00`
 
-On Windows the debrief form's **Start another session?** prompt appears after every successful post (completed or interrupted). On macOS/Linux you're asked `Start a new session? [Y/n]` only after an *interrupted* session's comment posts, so you can pivot to a different story / integration without retyping the command. **Ctrl-C** is still a hard exit — no debrief, no comment.
+On both platforms the **Start another session?** choice appears after every successful post (completed or interrupted). On macOS/Linux it's a terminal prompt — `[s] Same item / [p] Pick another item / [d] Done` (blank or `d` ends the session) — mirroring the Windows buttons: **Same item** loops straight back to the countdown on the work item you just debriefed, **Pick another** returns to the picker so you can pivot to a different story / integration without retyping the command. **Ctrl-C** is still a hard exit — no debrief, no comment.
 
 ### Registering your own integration
 

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -119,6 +119,70 @@ function Read-TimerYesNo {
 }
 
 
+function Read-TimerNextAction {
+    # Console counterpart to the WPF debrief's restart buttons. Offers the same
+    # three-way choice and returns the shared action token: 'SameItem' reuses
+    # the work item just debriefed, 'NewItem' returns to the picker, 'Done'
+    # (also the blank/unrecognized default) ends the loop.
+    param(
+        [Parameter(Mandatory)] [string] $ItemLabel
+    )
+
+    Write-Host ""
+    Write-Host "Start another session?" -ForegroundColor Cyan
+    Write-Host "  [s] Same item — $ItemLabel"
+    Write-Host "  [p] Pick another item"
+    Write-Host "  [d] Done"
+
+    $raw = Read-Host "Choose [s/p/D]"
+    if (-not $raw) {
+        return 'Done'
+    }
+
+    $normalized = $raw.Trim().ToLowerInvariant()
+    switch ($normalized) {
+        's' {
+            return 'SameItem'
+        }
+
+        'same' {
+            return 'SameItem'
+        }
+
+        'p' {
+            return 'NewItem'
+        }
+
+        'pick' {
+            return 'NewItem'
+        }
+
+        default {
+            return 'Done'
+        }
+    }
+}
+
+
+function Resolve-TimerNextAction {
+    # Maps a debrief next-action token ('Done' / 'SameItem' / 'NewItem') to the
+    # restart-loop flags shared by the WPF and console paths, so both decide
+    # "restart? reuse the item?" through one branch instead of duplicating it.
+    param(
+        [Parameter(Mandatory)] [string] $Action
+    )
+
+    $shouldRestart = ($Action -eq 'SameItem' -or $Action -eq 'NewItem')
+    $reuseItem     = ($Action -eq 'SameItem')
+
+    $result = [PSCustomObject]@{
+        ShouldRestart = $shouldRestart
+        ReuseItem     = $reuseItem
+    }
+    return $result
+}
+
+
 function Read-TimerNumberedPick {
     # Fallback picker for terminals without Out-ConsoleGridView. Blank input
     # cancels (returns $null); out-of-range / non-numeric input also cancels
@@ -738,8 +802,10 @@ function Show-WpfTimerDebrief {
     # (which composes + posts the comment and returns the { Json, Error,
     # ExitCode } envelope). The "Start another session?" choice is revealed ONLY
     # after a successful post (ExitCode 0); a failed post keeps the form open
-    # with the error so the user can retry. Returns
-    # { Cancelled; StartAnother; PostResult } for the orchestrator.
+    # with the error so the user can retry. The "Start another?" choice offers
+    # "Same item" (reuse the work item just debriefed), "Pick another" (return
+    # to the picker), and "Done". Returns { Cancelled; NextAction; PostResult }
+    # for the orchestrator, where NextAction is 'Done' / 'SameItem' / 'NewItem'.
     #
     # The az post is synchronous on the dispatcher thread, so the spinner can't
     # truly animate during the call. The form forces a Render-priority dispatch
@@ -754,9 +820,9 @@ function Show-WpfTimerDebrief {
 
     $formWidth = 360
 
-    $Script:WpfDebriefOutcome      = 'Cancelled'
-    $Script:WpfDebriefStartAnother = $false
-    $Script:WpfDebriefPostResult   = $null
+    $Script:WpfDebriefOutcome    = 'Cancelled'
+    $Script:WpfDebriefNextAction = 'Done'
+    $Script:WpfDebriefPostResult = $null
 
     $brushes = New-WpfBrushSet -ProgressColor $script:WpfColorProgress
 
@@ -894,15 +960,23 @@ function Show-WpfTimerDebrief {
         Margin              = '0,12,0,0'
         Visibility          = [System.Windows.Visibility]::Collapsed
     }
-    $btnYes = New-Object System.Windows.Controls.Button -Property @{
-        Content    = 'Start another'
+    $btnSameItem = New-Object System.Windows.Controls.Button -Property @{
+        Content    = 'Same item'
+        Width      = 90
+        Height     = 26
+        Background = $brushes.Button
+        Foreground = $brushes.White
+        Margin     = 3
+    }
+    $btnNewItem = New-Object System.Windows.Controls.Button -Property @{
+        Content    = 'Pick another'
         Width      = 100
         Height     = 26
         Background = $brushes.Button
         Foreground = $brushes.White
         Margin     = 3
     }
-    $btnNo = New-Object System.Windows.Controls.Button -Property @{
+    $btnDone = New-Object System.Windows.Controls.Button -Property @{
         Content    = 'Done'
         Width      = 70
         Height     = 26
@@ -910,8 +984,9 @@ function Show-WpfTimerDebrief {
         Foreground = $brushes.White
         Margin     = 3
     }
-    $askPanel.Children.Add($btnYes) | Out-Null
-    $askPanel.Children.Add($btnNo)  | Out-Null
+    $askPanel.Children.Add($btnSameItem) | Out-Null
+    $askPanel.Children.Add($btnNewItem)  | Out-Null
+    $askPanel.Children.Add($btnDone)     | Out-Null
     $vbox.Children.Add($askPanel) | Out-Null
 
     # ---- Exit hint ----
@@ -983,13 +1058,18 @@ function Show-WpfTimerDebrief {
         }
     })
 
-    $btnYes.Add_Click({
-        $Script:WpfDebriefStartAnother = $true
+    $btnSameItem.Add_Click({
+        $Script:WpfDebriefNextAction = 'SameItem'
         $mainWin.Close()
     })
 
-    $btnNo.Add_Click({
-        $Script:WpfDebriefStartAnother = $false
+    $btnNewItem.Add_Click({
+        $Script:WpfDebriefNextAction = 'NewItem'
+        $mainWin.Close()
+    })
+
+    $btnDone.Add_Click({
+        $Script:WpfDebriefNextAction = 'Done'
         $mainWin.Close()
     })
 
@@ -1001,9 +1081,9 @@ function Show-WpfTimerDebrief {
     $cancelled = ($Script:WpfDebriefOutcome -ne 'Posted')
 
     $result = [PSCustomObject]@{
-        Cancelled    = $cancelled
-        StartAnother = [bool]$Script:WpfDebriefStartAnother
-        PostResult   = $Script:WpfDebriefPostResult
+        Cancelled  = $cancelled
+        NextAction = $Script:WpfDebriefNextAction
+        PostResult = $Script:WpfDebriefPostResult
     }
     return $result
 }
@@ -1015,10 +1095,12 @@ function az-Start-TimerSession {
     # animation elsewhere), then collect the debrief and post the composed
     # comment via the chosen integration's AddComment. On Windows the countdown
     # morphs into a themed WPF debrief form (Show-WpfTimerDebrief) that posts
-    # under a spinner and offers "Start another session?" only after a
-    # successful post; elsewhere the debrief is collected via terminal Read-Host
-    # with a console posting indicator, and only an interrupted session is asked
-    # whether to start another.
+    # under a spinner and, after a successful post, offers "Same item" (reuse
+    # the work item just debriefed), "Pick another", and "Done"; elsewhere the
+    # debrief is collected via terminal Read-Host with a console posting
+    # indicator and the same three-way choice via Read-TimerNextAction. A
+    # "Same item" choice loops back straight to the countdown, skipping both
+    # the integration and item pickers.
     #
     # UTF-8 encoding is applied so emoji glyphs render in terminals that
     # default to a non-UTF-8 codepage; restored on exit (including Ctrl-C).
@@ -1039,27 +1121,32 @@ function az-Start-TimerSession {
 
     try {
         $shouldRestart = $false
+        $reuseItem     = $false
         do {
             $shouldRestart = $false
 
-            $chosen = Get-TimerIntegrationPick -Name $Integration
-            if (-not $chosen) {
-                Write-Host "No integration selected — exiting." -ForegroundColor DarkGray
-                return
+            if (-not $reuseItem) {
+                $chosen = Get-TimerIntegrationPick -Name $Integration
+                if (-not $chosen) {
+                    Write-Host "No integration selected — exiting." -ForegroundColor DarkGray
+                    return
+                }
+
+                Write-Host "Fetching items from '$($chosen.Name)'..." -ForegroundColor Cyan
+                $items = & $chosen.FetchItems
+                if (-not $items -or @($items).Count -eq 0) {
+                    Write-Host "No items returned from '$($chosen.Name)'." -ForegroundColor Yellow
+                    return
+                }
+
+                $pickedItem = Get-TimerItemPick -Items $items -IntegrationName $chosen.Name
+                if (-not $pickedItem) {
+                    Write-Host "No item selected — exiting." -ForegroundColor DarkGray
+                    return
+                }
             }
 
-            Write-Host "Fetching items from '$($chosen.Name)'..." -ForegroundColor Cyan
-            $items = & $chosen.FetchItems
-            if (-not $items -or @($items).Count -eq 0) {
-                Write-Host "No items returned from '$($chosen.Name)'." -ForegroundColor Yellow
-                return
-            }
-
-            $pickedItem = Get-TimerItemPick -Items $items -IntegrationName $chosen.Name
-            if (-not $pickedItem) {
-                Write-Host "No item selected — exiting." -ForegroundColor DarkGray
-                return
-            }
+            $reuseItem = $false
 
             Write-Host ""
             Write-Host "Starting $Minutes-minute session on item $($pickedItem.Id): $($pickedItem.Title)" -ForegroundColor Green
@@ -1099,13 +1186,7 @@ function az-Start-TimerSession {
 
                 Write-TimerPostVerdict -Result $debriefResult.PostResult -Item $pickedItem -Integration $chosen
 
-                if ($debriefResult.StartAnother) {
-                    $shouldRestart = $true
-                    $Integration   = $null
-                } else {
-                    $waveIcon = $script:TimerIconWave
-                    Write-Host "Goodbye $waveIcon" -ForegroundColor DarkGray
-                }
+                $nextAction = $debriefResult.NextAction
 
             } else {
 
@@ -1137,16 +1218,19 @@ function az-Start-TimerSession {
 
                 Write-TimerPostVerdict -Result $commentResult -Item $pickedItem -Integration $chosen
 
-                if ($countdownResult.Interrupted) {
-                    $startAnother = Read-TimerYesNo -Prompt 'Start a new session?' -DefaultYes
-                    if ($startAnother) {
-                        $shouldRestart = $true
-                        $Integration   = $null
-                    } else {
-                        $waveIcon = $script:TimerIconWave
-                        Write-Host "Goodbye $waveIcon" -ForegroundColor DarkGray
-                    }
-                }
+                $itemLabel  = "$($pickedItem.Id): $($pickedItem.Title)"
+                $nextAction = Read-TimerNextAction -ItemLabel $itemLabel
+            }
+
+            $resolved      = Resolve-TimerNextAction -Action $nextAction
+            $shouldRestart = $resolved.ShouldRestart
+            $reuseItem     = $resolved.ReuseItem
+
+            if ($shouldRestart -and -not $reuseItem) {
+                $Integration = $null
+            } elseif (-not $shouldRestart) {
+                $waveIcon = $script:TimerIconWave
+                Write-Host "Goodbye $waveIcon" -ForegroundColor DarkGray
             }
 
         } while ($shouldRestart)


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #109 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | 0/3 (manual) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4535371519) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4535373646) |
| 🛡️ Security Audit | ✅ APPROVE — [View](#issuecomment-4535374206) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4535375372) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4535382077) |
| 📚 Docs Check | ✅ CURRENT — README updated in this PR |
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

`az-Start-TimerSession` runs a restart loop. After the countdown, the debrief (the Windows WPF form or the console `Read-TimerNextAction` prompt) returns one of three action tokens, which `Resolve-TimerNextAction` maps to restart/reuse flags. **SameItem** loops back skipping both pickers (the `reuseItem` guard), **NewItem** re-picks, **Done** exits.

```mermaid
flowchart TD
    Start([az-Start-TimerSession loop]):::pub
    PickGuard{reuseItem?}
    Pickers["pick integration<br/>+ pick item"]
    Banner["Starting N-min session<br/>on item X"]
    Countdown[Show-TimerCountdown]:::priv
    WinGate{Windows?}
    WpfForm["Show-WpfTimerDebrief<br/>Same item / Pick another / Done"]:::priv
    ConsolePrompt[Read-TimerNextAction]:::pub
    Resolve[Resolve-TimerNextAction]:::pub
    Decide{ShouldRestart?<br/>ReuseItem?}
    Done([Goodbye])

    Start --> PickGuard
    PickGuard -- no --> Pickers --> Banner
    PickGuard -- yes --> Banner
    Banner --> Countdown --> WinGate
    WinGate -- yes --> WpfForm --> Resolve
    WinGate -- no --> ConsolePrompt --> Resolve
    Resolve --> Decide
    Decide -- SameItem --> PickGuard
    Decide -- NewItem --> PickGuard
    Decide -- Done --> Done

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
The pomodoro debrief restart now offers a three-way next-action (`Done` / `SameItem` / `NewItem`) instead of a yes/no "start another". Choosing **Same item** loops straight back to the countdown on the work item just debriefed, skipping both the integration and item pickers — so you can chain focus sessions on the same work ID without walking back through the list picker.

## Issue
Closes #109

## Changes
- `powcuts_by_cli/pow_timer.ps1`:
  - **New** `Read-TimerNextAction` — console three-way restart prompt (`[s]` same item / `[p]` pick another / `[d]` done), blank/unrecognized defaults to done.
  - **New** `Resolve-TimerNextAction` — maps the action token to `{ ShouldRestart; ReuseItem }`, shared by the WPF and console paths so the restart decision lives in one place.
  - `Show-WpfTimerDebrief` — single "Start another" button replaced by **Same item** / **Pick another** / **Done**; return contract `StartAnother` (bool) → `NextAction` (token).
  - `az-Start-TimerSession` — restart loop guards the integration + item pickers behind a `reuseItem` flag; the console path now offers the restart choice after **every** session (not just interrupted ones). The "Starting N-minute session on item X" banner still prints on a reused item.
- `README.md` — "Timer sessions" debrief docs updated to describe the three-way Same item / Pick another / Done choice on both platforms.

## Test Plan
- [ ] **Windows/WPF:** `az-Start-TimerSession -Minutes 1` → finish → click **Same item**: a new countdown starts on the same ID with no picker. Click **Pick another**: the item picker returns. Click **Done**: exits.
- [ ] **Console (non-WPF):** finishing a session shows `[s] Same item / [p] Pick another / [d] Done`; `s` restarts on the same item, `p` re-picks, blank/`d` exits with the goodbye wave.
- [ ] Open a fresh PowerShell terminal — `pow_timer.ps1` dot-sources without parse errors and `az-Start-TimerSession` is defined.

---
_Generated by [Claude Code](https://claude.ai/code/session_014PpwSAaAeutvGYfFYHQc1J)_