### PR TITLE
Drop "AzDevOps" infix from az-Open-* names and add public az-Open-WorkItemById

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ o-sfdx   o-git   o-gh   o-az   o-cci
 │   ├── azdevops_create_pickers.ps1     # Field prompts + create-flow pickers
 │   ├── azdevops_create.ps1             # az-New-AzDevOps{UserStory,Feature,FeatureStories}
 │   ├── azdevops_schema.ps1             # Field-schema cache (per-org)
-│   ├── azdevops_openers.ps1            # az-Open-AzDevOps* file/folder openers
+│   ├── azdevops_openers.ps1            # az-Open-* file/folder openers
 │   ├── azdevops_projects.ps1           # Multi-project map + active-project switcher
 │   ├── azdevops_help.ps1               # az-help — guided walkthrough of az-AzDevOps* surface
 │   ├── pester.ps1                      # Pester test helpers

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For windows machines, the snippets are stored in an expected directory, so we ca
 
 > **Lost in the surface?** Run `az-help` (defined in `powcuts_by_cli/azdevops_help.ps1`) for an interactive `Out-ConsoleGridView` walkthrough that groups every `az-AzDevOps*` function by workflow phase (Onboarding → DailyRead → Create → MultiProject) and shows the order of operations + source / diagram / issue links for each function. `az-h<Tab>` lands directly on it.
 
-PowerShell shortcuts in `powcuts_by_cli/azdevops_*.ps1` (split across `azdevops_auth.ps1`, `azdevops_paths.ps1`, `azdevops_sync.ps1`, `azdevops_views.ps1`, `azdevops_find.ps1`, `azdevops_classification.ps1`, `azdevops_create_pickers.ps1`, `azdevops_create.ps1`, `azdevops_schema.ps1`, `azdevops_openers.ps1`) provide guided setup and work-item navigation against an Azure DevOps organization. Today this includes a guided `az-Connect-AzDevOps` first-run helper, a cached background sync (`az-Sync-AzDevOpsCache`, which also refreshes itself silently on shell open when the cache is stale), a list/open pair for items assigned to you (`az-Get-AzDevOpsAssigned`, `az-Open-AzDevOpsAssigned`), the matching pair for items where you've been @-mentioned in discussion (`az-Get-AzDevOpsMentions`, `az-Open-AzDevOpsMention`), an Epic→Feature→User Story tree view (`az-Show-Tree`, rendering the project's requirement-tier rows — `User Story` on Agile, `Product Backlog Item` on Scrum, `Requirement` on CMMI, `Issue` on Basic), a board-style group-by-State view of the same cached items (`az-Show-Board`), area- and iteration-path tree views (`az-Show-Areas`, `az-Show-Iterations`), an interactive Epic→Feature→Story drill-down picker (`az-Find-AzDevOpsWorkItem`), an interactive new-user-story creator with parent-feature, iteration, and area-path pickers (`az-New-AzDevOpsUserStory`), an interactive new-Feature creator one tier up (parent-Epic picker, area / iteration / priority / AC) with a hand-off prompt to spawn child stories (`az-New-AzDevOpsFeature`), a batch child-story creator that decomposes a Feature into 3-7 stories with a single area / iteration captured once and priority / story points carried forward across the loop (`az-New-AzDevOpsFeatureStories`), an interactive Task creator one tier down with a parent-User-Story picker (`az-New-Task`, also the child action when you select a Story in `az-Show-Tree` / `az-Show-Board`), and a per-org field-schema config (`az-Initialize-AzDevOpsSchema`, `az-Get-AzDevOpsSchema`, `az-Edit-AzDevOpsSchema`, `az-Test-AzDevOpsSchema`) that future schema-aware updates to the work-item commands consume.
+PowerShell shortcuts in `powcuts_by_cli/azdevops_*.ps1` (split across `azdevops_auth.ps1`, `azdevops_paths.ps1`, `azdevops_sync.ps1`, `azdevops_views.ps1`, `azdevops_find.ps1`, `azdevops_classification.ps1`, `azdevops_create_pickers.ps1`, `azdevops_create.ps1`, `azdevops_schema.ps1`, `azdevops_openers.ps1`) provide guided setup and work-item navigation against an Azure DevOps organization. Today this includes a guided `az-Connect-AzDevOps` first-run helper, a cached background sync (`az-Sync-AzDevOpsCache`, which also refreshes itself silently on shell open when the cache is stale), a list/open pair for items assigned to you (`az-Get-AzDevOpsAssigned`, `az-Open-Assigned`), the matching pair for items where you've been @-mentioned in discussion (`az-Get-AzDevOpsMentions`, `az-Open-Mention`), an open-any-item-by-id shortcut (`az-Open-WorkItemById`), an Epic→Feature→User Story tree view (`az-Show-Tree`, rendering the project's requirement-tier rows — `User Story` on Agile, `Product Backlog Item` on Scrum, `Requirement` on CMMI, `Issue` on Basic), a board-style group-by-State view of the same cached items (`az-Show-Board`), area- and iteration-path tree views (`az-Show-Areas`, `az-Show-Iterations`), an interactive Epic→Feature→Story drill-down picker (`az-Find-AzDevOpsWorkItem`), an interactive new-user-story creator with parent-feature, iteration, and area-path pickers (`az-New-AzDevOpsUserStory`), an interactive new-Feature creator one tier up (parent-Epic picker, area / iteration / priority / AC) with a hand-off prompt to spawn child stories (`az-New-AzDevOpsFeature`), a batch child-story creator that decomposes a Feature into 3-7 stories with a single area / iteration captured once and priority / story points carried forward across the loop (`az-New-AzDevOpsFeatureStories`), an interactive Task creator one tier down with a parent-User-Story picker (`az-New-Task`, also the child action when you select a Story in `az-Show-Tree` / `az-Show-Board`), and a per-org field-schema config (`az-Initialize-AzDevOpsSchema`, `az-Get-AzDevOpsSchema`, `az-Edit-AzDevOpsSchema`, `az-Test-AzDevOpsSchema`) that future schema-aware updates to the work-item commands consume.
 
 ### Prerequisites
 
@@ -216,7 +216,7 @@ Each sync fires one `az boards query` per file (epics, then features, then user 
 The fast way to open all three for editing is the dedicated shortcut:
 
 ```powershell
-az-Open-AzDevOpsHierarchyWiqls
+az-Open-HierarchyWiqls
 ```
 
 It seeds any missing defaults (so it works on a fresh machine even before `az-Connect-AzDevOps`) and then opens each path in your OS default editor.
@@ -225,41 +225,41 @@ If you delete a file, the next sync writes that default back. The placeholder `{
 
 ### Opening cache / config / schema files
 
-Every folder and file under `~/.bashcuts-az-devops-app/` has a dedicated `az-Open-AzDevOps*` shortcut. Tab-tab on `az-Open-AzDevOps` to see the full list. Each opener launches the path in your OS default handler (`Start-Process`); if the target doesn't exist yet it prints a one-line yellow hint pointing at the function that produces it (e.g. `az-Sync-AzDevOpsCache`) and returns without spawning anything.
+Every folder and file under `~/.bashcuts-az-devops-app/` has a dedicated opener — most under the `az-Open-*` prefix (tab-tab on `az-Open-` to see the full list), with the config-queries and schema directories under the `o-az-devops-*` open prefix. Each opener launches the path in your OS default handler (`Start-Process`); if the target doesn't exist yet it prints a one-line yellow hint pointing at the function that produces it (e.g. `az-Sync-AzDevOpsCache`) and returns without spawning anything.
 
 Folders:
 
 ```powershell
-az-Open-AzDevOpsAppRoot       # ~/.bashcuts-az-devops-app/
-az-Open-AzDevOpsCacheDir      # cache/  (or cache/<project-slug>/ when az-Use-AzDevOpsProject is active)
-az-Open-AzDevOpsConfigDir     # config/queries/
-az-Open-AzDevOpsSchemaDir     # schema/
+az-Open-AppRoot                 # ~/.bashcuts-az-devops-app/
+az-Open-CacheDir                # cache/  (or cache/<project-slug>/ when az-Use-AzDevOpsProject is active)
+o-az-devops-queries-config-dir  # config/queries/
+o-az-devops-schema-dir          # schema/
 ```
 
 Cache files (all resolved through the active project slice):
 
 ```powershell
-az-Open-AzDevOpsAssignedCache    # assigned.json
-az-Open-AzDevOpsMentionsCache    # mentions.json
-az-Open-AzDevOpsHierarchyCache   # hierarchy.json
-az-Open-AzDevOpsIterationsCache  # iterations.json
-az-Open-AzDevOpsAreasCache       # areas.json
-az-Open-AzDevOpsLastSync         # last-sync.json
-az-Open-AzDevOpsSyncLog          # sync.log
+az-Open-AssignedCache    # assigned.json
+az-Open-MentionsCache    # mentions.json
+az-Open-HierarchyCache   # hierarchy.json
+az-Open-IterationsCache  # iterations.json
+az-Open-AreasCache       # areas.json
+az-Open-LastSync         # last-sync.json
+az-Open-SyncLog          # sync.log
 ```
 
-Config WIQL files (per file; `az-Open-AzDevOpsHierarchyWiqls` above remains the "open all three" convenience):
+Config WIQL files (per file; `az-Open-HierarchyWiqls` above remains the "open all three" convenience):
 
 ```powershell
-az-Open-AzDevOpsEpicsWiql        # config/queries/epics.wiql
-az-Open-AzDevOpsFeaturesWiql     # config/queries/features.wiql
-az-Open-AzDevOpsUserStoriesWiql  # config/queries/user-stories.wiql
+az-Open-EpicsWiql        # config/queries/epics.wiql
+az-Open-FeaturesWiql     # config/queries/features.wiql
+az-Open-UserStoriesWiql  # config/queries/user-stories.wiql
 ```
 
 Schema file (per-org `schema-<slug>.json`, falling back to `schema.json` when `$env:AZ_DEVOPS_ORG` is unset):
 
 ```powershell
-az-Open-AzDevOpsSchema
+az-Open-Schema
 ```
 
 ### Day-to-day work-item shortcuts
@@ -272,7 +272,8 @@ az-Get-AzDevOpsAssigned -State Active         # filter to a single state
 az-Get-AzDevOpsAssigned -State Active,New     # filter to multiple states
 az-Get-AzDevOpsAssigned | Format-Table -AutoSize
 
-az-Open-AzDevOpsAssigned 12345                # open one of your assigned items in the browser
+az-Open-Assigned 12345                        # open one of your assigned items in the browser
+az-Open-WorkItemById 12345                    # open ANY work item by id in the browser (no cache lookup; works even if it isn't assigned to / mentioning you)
 
 az-Get-AzDevOpsMentions                                  # work items where you've been @-mentioned (excludes items you're already assigned to)
 az-Get-AzDevOpsMentions -State Active                    # filter to a single state
@@ -280,7 +281,7 @@ az-Get-AzDevOpsMentions -Since (Get-Date).AddDays(-7)    # only mentions whose l
 az-Get-AzDevOpsMentions -IncludeAssigned                 # also surface mentioned items already assigned to you
 az-Get-AzDevOpsMentions | Format-Table -AutoSize
 
-az-Open-AzDevOpsMention 12345                 # open one of your mentioned items in the browser
+az-Open-Mention 12345                         # open one of your mentioned items in the browser
 
 az-Show-Tree                          # Epic -> Feature -> User Story tree; select a row to open it or create a child work item
 az-Show-Board                         # board view: cached items grouped by State (click the State header in the grid to group)
@@ -315,7 +316,7 @@ If the cache is older than 6 hours, `az-Get-AzDevOpsAssigned`, `az-Get-AzDevOpsM
 
 After you select a row in `az-Show-Tree`, `az-Show-Board`, or `az-Show-Features`, you're prompted to either open the item in your browser or create the hierarchically-appropriate child work item — a Feature under an Epic, a User Story under a Feature, or a Task under a User Story (via `az-New-Task`) — with the selected row pre-filled as the new item's parent. Selecting a node in `az-Show-Areas` / `az-Show-Iterations` offers to open the project's Boards hub. (The post-selection prompt is PowerShell-only; the bash `az-show-features` shortcut prints a static query table.)
 
-Every list and picker (`az-Get-AzDevOpsAssigned`, `az-Get-AzDevOpsMentions`, `az-Get-AzDevOpsSchema`, `az-Get-AzDevOpsCacheStatus`, `az-Show-Tree`, `az-Show-Board`, `az-Show-Features`, `az-Show-Areas`, `az-Show-Iterations`, `az-Find-AzDevOpsWorkItem`, plus the parent-Feature / iteration / area pickers in `az-New-AzDevOpsUserStory`) renders through `Out-ConsoleGridView` — a sortable, filterable, click-to-select TUI grid that runs in your terminal on Windows, macOS, and Linux. Use the arrow keys to navigate, `Space` to select rows, `Enter` to confirm, `Esc` to cancel. Selected rows from the listing functions are emitted to the pipeline, so e.g. `az-Get-AzDevOpsAssigned | ForEach-Object { az-Open-AzDevOpsAssigned $_.Id }` opens every row you ticked. The grid ships in a separate module — install once with `Install-Module Microsoft.PowerShell.ConsoleGuiTools -Scope CurrentUser`. If the module isn't installed, every command falls back to the existing `Format-Table` / numbered-menu output — except `az-Find-AzDevOpsWorkItem`, which is grid-only by design and prints the install hint above instead of running.
+Every list and picker (`az-Get-AzDevOpsAssigned`, `az-Get-AzDevOpsMentions`, `az-Get-AzDevOpsSchema`, `az-Get-AzDevOpsCacheStatus`, `az-Show-Tree`, `az-Show-Board`, `az-Show-Features`, `az-Show-Areas`, `az-Show-Iterations`, `az-Find-AzDevOpsWorkItem`, plus the parent-Feature / iteration / area pickers in `az-New-AzDevOpsUserStory`) renders through `Out-ConsoleGridView` — a sortable, filterable, click-to-select TUI grid that runs in your terminal on Windows, macOS, and Linux. Use the arrow keys to navigate, `Space` to select rows, `Enter` to confirm, `Esc` to cancel. Selected rows from the listing functions are emitted to the pipeline, so e.g. `az-Get-AzDevOpsAssigned | ForEach-Object { az-Open-Assigned $_.Id }` opens every row you ticked. The grid ships in a separate module — install once with `Install-Module Microsoft.PowerShell.ConsoleGuiTools -Scope CurrentUser`. If the module isn't installed, every command falls back to the existing `Format-Table` / numbered-menu output — except `az-Find-AzDevOpsWorkItem`, which is grid-only by design and prints the install hint above instead of running.
 
 `az-Sync-AzDevOpsCache` populates two more cache files alongside the existing `assigned.json` / `mentions.json` / `hierarchy.json`: `iterations.json` and `areas.json`. The new-user-story command below uses these for instant iteration / area-path pickers; if you've upgraded but haven't re-synced yet, the picker fetches them live with a one-line "(run az-Sync-AzDevOpsCache to make this instant)" notice.
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -6,7 +6,7 @@ Visual reference for the Azure DevOps work-item shortcuts in `powcuts_by_cli/azd
 - [2. `az-Connect-AzDevOps` — 8-step orchestrator](#2-az-connect-azdevops--8-step-orchestrator)
 - [3. `az-Test-AzDevOpsAuth` — silent diagnostic chain](#3-az-test-azdevopsauth--silent-diagnostic-chain)
 - [4. `az-Sync-AzDevOpsCache` — dataset fan-out](#4-az-sync-azdevopscache--dataset-fan-out)
-- [5. Cache consumers (`az-Get-/az-Open-AzDevOps{Assigned,Mentions}`)](#5-cache-consumers-az-get-az-open-azdevopsassignedmentions)
+- [5. Cache consumers (`az-Get-AzDevOpsAssigned/Mentions` and `az-Open-Assigned/Mention`)](#5-cache-consumers-az-get-azdevopsassignedmentions-and-az-open-assignedmention)
 - [6. `az-Show-Tree` — Epic → Feature → requirement-tier render](#6-az-show-tree--epic--feature--requirement-tier-render)
 - [7. `az-New-AzDevOpsUserStory` — interactive create flow](#7-az-new-azdevopsuserstory--interactive-create-flow)
 - [8. `az-New-AzDevOpsFeature` — interactive Feature create + child-story hand-off](#8-az-new-azdevopsfeature--interactive-feature-create--child-story-hand-off)
@@ -35,9 +35,9 @@ flowchart LR
         Status["az-Get-AzDevOpsCacheStatus"]
         BgSync["Start-AzDevOpsBackgroundSync<br/>(on-open, internal)"]
         GetA["az-Get-AzDevOpsAssigned"]
-        OpenA["az-Open-AzDevOpsAssigned"]
+        OpenA["az-Open-Assigned"]
         GetM["az-Get-AzDevOpsMentions"]
-        OpenM["az-Open-AzDevOpsMention"]
+        OpenM["az-Open-Mention"]
         Tree["az-Show-Tree"]
         Board["az-Show-Board"]
         ShowAreas["az-Show-Areas"]
@@ -56,11 +56,11 @@ flowchart LR
         Help["az-help"]
     end
 
-    subgraph PathOpeners["Path inspectors (az-Open-AzDevOps*)"]
+    subgraph PathOpeners["Path inspectors (az-Open-*)"]
         OpensFolders["Folder openers:<br/>AppRoot, CacheDir, ConfigDir, SchemaDir"]
         OpensCache["Cache file openers:<br/>AssignedCache, MentionsCache, HierarchyCache,<br/>IterationsCache, AreasCache, LastSync, SyncLog"]
         OpensWiql["WIQL openers:<br/>EpicsWiql, FeaturesWiql, UserStoriesWiql"]
-        OpensSchema["az-Open-AzDevOpsSchema"]
+        OpensSchema["az-Open-Schema"]
     end
 
     subgraph Cache["$HOME/.bashcuts-az-devops-app/cache/"]
@@ -285,7 +285,7 @@ Atomic write pattern (`Write-AzDevOpsCacheFile`): `Set-Content` to `<path>.tmp`,
 
 ---
 
-## 5. Cache consumers (`az-Get-/az-Open-AzDevOps{Assigned,Mentions}`)
+## 5. Cache consumers (`az-Get-AzDevOpsAssigned/Mentions` and `az-Open-Assigned/Mention`)
 
 The two parallel pairs share private helpers (extracted under "Shared scaffolding" per CLAUDE.md). They never call `az` — purely cache reads.
 
@@ -329,14 +329,14 @@ Open-by-id flow re-uses the same cache + a different last-mile helper:
 
 ```mermaid
 flowchart LR
-    A([az-Open-AzDevOpsAssigned 12345]) --> RC[Read-AzDevOpsAssignedCache]
+    A([az-Open-Assigned 12345]) --> RC[Read-AzDevOpsAssignedCache]
     RC --> Find["Find-AzDevOpsCachedWorkItem<br/>(id lookup + miss-hint)"]
     Find -- miss --> Hint([print 'run az-Get-AzDevOpsAssigned' + LASTEXITCODE=1])
-    Find -- hit --> Open["Open-AzDevOpsWorkItemUrl<br/>(env-var guard + URL build)"]
+    Find -- hit --> Open["az-Open-WorkItemById<br/>(env-var guard + URL build)"]
     Open --> SP["Start-Process<br/>$env:AZ_DEVOPS_ORG/$env:AZ_PROJECT/_workitems/edit/12345"]
 ```
 
-`az-Open-AzDevOpsMention` is structurally identical, just swaps `Read-AzDevOpsMentionsCache` and the `-Description 'mentions'` label.
+`az-Open-Mention` is structurally identical, just swaps `Read-AzDevOpsMentionsCache` and the `-Description 'mentions'` label.
 
 ---
 
@@ -358,7 +358,7 @@ flowchart TD
     RowsFn --> Show["Show-AzDevOpsRows<br/>→ Out-ConsoleGridView"]
     Show --> Action["Invoke-AzDevOpsRowAction<br/>(per selected row)"]
     Action --> Choice{Read-AzDevOpsRowActionChoice}
-    Choice -- open --> OpenSel["Open-AzDevOpsWorkItemUrl"]
+    Choice -- open --> OpenSel["az-Open-WorkItemById"]
     Choice -- create --> Child["New-AzDevOpsChildForRow<br/>(Get-AzDevOpsChildTypeFor →<br/>az-New-AzDevOpsFeature / UserStory / az-New-Task)"]
     Choice -- skip --> NoOp([skip])
     Grid -- no --> ForEpic{foreach epic}
@@ -649,9 +649,9 @@ graph LR
     Status(["az-Get-AzDevOpsCacheStatus"]):::pub
     BgSync["Start-AzDevOpsBackgroundSync"]:::priv
     GetA(["az-Get-AzDevOpsAssigned"]):::pub
-    OpenA(["az-Open-AzDevOpsAssigned"]):::pub
+    OpenA(["az-Open-Assigned"]):::pub
     GetM(["az-Get-AzDevOpsMentions"]):::pub
-    OpenM(["az-Open-AzDevOpsMention"]):::pub
+    OpenM(["az-Open-Mention"]):::pub
     Tree(["az-Show-Tree"]):::pub
     Board(["az-Show-Board"]):::pub
     ShowAreas(["az-Show-Areas"]):::pub
@@ -665,7 +665,7 @@ graph LR
     NewSB(["az-New-AzDevOpsFeatureStories"]):::pub
     NewTask(["az-New-Task"]):::pub
     Find(["az-Find-AzDevOpsWorkItem"]):::pub
-    OpenHWiql(["az-Open-AzDevOpsHierarchyWiqls"]):::pub
+    OpenHWiql(["az-Open-HierarchyWiqls"]):::pub
     ShowFeats(["az-Show-Features"]):::pub
 
     %% Multi-project switcher (azdevops_projects.ps1)
@@ -773,7 +773,7 @@ graph LR
     Trunc[Format-AzDevOpsTruncatedTitle]:::priv
     TitleCol[Get-AzDevOpsTitleColumn]:::priv
     Find[Find-AzDevOpsCachedWorkItem]:::priv
-    OpenUrl[Open-AzDevOpsWorkItemUrl]:::priv
+    OpenUrl[az-Open-WorkItemById]:::pub
     WiUrl[Get-AzDevOpsWorkItemUrl]:::priv
     WiPfx[Get-AzDevOpsWorkItemUrlPrefix]:::priv
     MentDN[Get-AzDevOpsMentionedByDisplayName]:::priv
@@ -1237,21 +1237,21 @@ graph LR
     %% thin wrapper that resolves a path via one of the Get-AzDevOps*Paths
     %% helpers and delegates to Open-AzDevOpsPathIfExists, which Test-Paths the
     %% target and calls Start-Process when it exists.
-    OpenAppRoot(["az-Open-AzDevOpsAppRoot"]):::pub
-    OpenCacheDir(["az-Open-AzDevOpsCacheDir"]):::pub
-    OpenConfigDir(["az-Open-AzDevOpsConfigDir"]):::pub
-    OpenSchemaDir(["az-Open-AzDevOpsSchemaDir"]):::pub
-    OpenAsg(["az-Open-AzDevOpsAssignedCache"]):::pub
-    OpenMen(["az-Open-AzDevOpsMentionsCache"]):::pub
-    OpenHier(["az-Open-AzDevOpsHierarchyCache"]):::pub
-    OpenIter(["az-Open-AzDevOpsIterationsCache"]):::pub
-    OpenAreas(["az-Open-AzDevOpsAreasCache"]):::pub
-    OpenLast(["az-Open-AzDevOpsLastSync"]):::pub
-    OpenLog(["az-Open-AzDevOpsSyncLog"]):::pub
-    OpenEpics(["az-Open-AzDevOpsEpicsWiql"]):::pub
-    OpenFeats(["az-Open-AzDevOpsFeaturesWiql"]):::pub
-    OpenStories(["az-Open-AzDevOpsUserStoriesWiql"]):::pub
-    OpenSchema(["az-Open-AzDevOpsSchema"]):::pub
+    OpenAppRoot(["az-Open-AppRoot"]):::pub
+    OpenCacheDir(["az-Open-CacheDir"]):::pub
+    OpenConfigDir(["o-az-devops-queries-config-dir"]):::pub
+    OpenSchemaDir(["o-az-devops-schema-dir"]):::pub
+    OpenAsg(["az-Open-AssignedCache"]):::pub
+    OpenMen(["az-Open-MentionsCache"]):::pub
+    OpenHier(["az-Open-HierarchyCache"]):::pub
+    OpenIter(["az-Open-IterationsCache"]):::pub
+    OpenAreas(["az-Open-AreasCache"]):::pub
+    OpenLast(["az-Open-LastSync"]):::pub
+    OpenLog(["az-Open-SyncLog"]):::pub
+    OpenEpics(["az-Open-EpicsWiql"]):::pub
+    OpenFeats(["az-Open-FeaturesWiql"]):::pub
+    OpenStories(["az-Open-UserStoriesWiql"]):::pub
+    OpenSchema(["az-Open-Schema"]):::pub
 
     %% Path-inspector helper + path-discovery helpers used by the openers above
     OpenPath[Open-AzDevOpsPathIfExists]:::priv

--- a/powcuts_by_cli/azdevops_auth.ps1
+++ b/powcuts_by_cli/azdevops_auth.ps1
@@ -11,7 +11,7 @@
 #   az-Test-AzDevOpsAuth           - silent yes/no auth assertion intended for
 #                                    callers in later AzDevOps commands;
 #                                    returns $true / $false
-#   az-Open-AzDevOpsHierarchyWiqls - open each ~/.bashcuts-az-devops-app/config/
+#   az-Open-HierarchyWiqls - open each ~/.bashcuts-az-devops-app/config/
 #                                    queries/{epics,features,user-stories}.wiql
 #                                    in the default editor (seeds the defaults
 #                                    on first run)
@@ -400,7 +400,7 @@ function az-Confirm-AzDevOpsQueryFiles {
 }
 
 
-function az-Open-AzDevOpsHierarchyWiqls {
+function az-Open-HierarchyWiqls {
     # Opens all user-machine WIQL files (epics, features, user-stories,
     # assigned, mentions) in the OS default editor. Defensively seeds the
     # defaults via Initialize-AzDevOpsQueryFiles so a fresh machine that

--- a/powcuts_by_cli/azdevops_find.ps1
+++ b/powcuts_by_cli/azdevops_find.ps1
@@ -129,7 +129,7 @@ function az-Find-AzDevOpsWorkItem {
             }
 
             if ($picked.Title -eq $openEpicLabel) {
-                Open-AzDevOpsWorkItemUrl -Id $currentEpic.Id
+                az-Open-WorkItemById -Id $currentEpic.Id
                 Write-Output $currentEpic.Id
                 continue
             }
@@ -152,7 +152,7 @@ function az-Find-AzDevOpsWorkItem {
             }
 
             if ($picked.Title -eq $openFeatureLabel) {
-                Open-AzDevOpsWorkItemUrl -Id $currentFeature.Id
+                az-Open-WorkItemById -Id $currentFeature.Id
                 Write-Output $currentFeature.Id
                 continue
             }
@@ -176,7 +176,7 @@ function az-Find-AzDevOpsWorkItem {
                 continue
             }
 
-            Open-AzDevOpsWorkItemUrl -Id $currentStory.Id
+            az-Open-WorkItemById -Id $currentStory.Id
             Write-Output $currentStory.Id
 
             $tier = 1

--- a/powcuts_by_cli/azdevops_help.ps1
+++ b/powcuts_by_cli/azdevops_help.ps1
@@ -122,23 +122,23 @@ $script:AzDevOpsHelpCatalog = @(
         Purpose       = 'Grid of work items assigned to you (from cache)'
         Args          = '(none)'
         Example       = 'az-Get-AzDevOpsAssigned'
-        RunsBefore    = 'az-Open-AzDevOpsAssigned'
+        RunsBefore    = 'az-Open-Assigned'
         RequiresSync  = 'Yes'
-        DiagramAnchor = '#5-cache-consumers-az-get-az-open-azdevopsassignedmentions'
+        DiagramAnchor = '#5-cache-consumers-az-get-azdevopsassignedmentions-and-az-open-assignedmention'
         Issues        = @()
     },
 
     [PSCustomObject]@{
-        Name          = 'az-Open-AzDevOpsAssigned'
+        Name          = 'az-Open-Assigned'
         File          = 'powcuts_by_cli/azdevops_views.ps1'
         Phase         = 'DailyRead'
         Order         = 2
         Purpose       = 'Pick an assigned work item from the grid; open it in your browser'
         Args          = '(none)'
-        Example       = 'az-Open-AzDevOpsAssigned'
+        Example       = 'az-Open-Assigned'
         RunsBefore    = ''
         RequiresSync  = 'Yes'
-        DiagramAnchor = '#5-cache-consumers-az-get-az-open-azdevopsassignedmentions'
+        DiagramAnchor = '#5-cache-consumers-az-get-azdevopsassignedmentions-and-az-open-assignedmention'
         Issues        = @()
     },
 
@@ -150,23 +150,37 @@ $script:AzDevOpsHelpCatalog = @(
         Purpose       = 'Grid of work items where you have been @-mentioned in discussion'
         Args          = '(none) - reads $env:AZ_USER_EMAIL for the WIQL filter'
         Example       = 'az-Get-AzDevOpsMentions'
-        RunsBefore    = 'az-Open-AzDevOpsMention'
+        RunsBefore    = 'az-Open-Mention'
         RequiresSync  = 'Yes'
-        DiagramAnchor = '#5-cache-consumers-az-get-az-open-azdevopsassignedmentions'
+        DiagramAnchor = '#5-cache-consumers-az-get-azdevopsassignedmentions-and-az-open-assignedmention'
         Issues        = @()
     },
 
     [PSCustomObject]@{
-        Name          = 'az-Open-AzDevOpsMention'
+        Name          = 'az-Open-Mention'
         File          = 'powcuts_by_cli/azdevops_views.ps1'
         Phase         = 'DailyRead'
         Order         = 4
         Purpose       = 'Pick a mentioned work item from the grid; open it in your browser'
         Args          = '(none)'
-        Example       = 'az-Open-AzDevOpsMention'
+        Example       = 'az-Open-Mention'
         RunsBefore    = ''
         RequiresSync  = 'Yes'
-        DiagramAnchor = '#5-cache-consumers-az-get-az-open-azdevopsassignedmentions'
+        DiagramAnchor = '#5-cache-consumers-az-get-azdevopsassignedmentions-and-az-open-assignedmention'
+        Issues        = @()
+    },
+
+    [PSCustomObject]@{
+        Name          = 'az-Open-WorkItemById'
+        File          = 'powcuts_by_cli/azdevops_views.ps1'
+        Phase         = 'DailyRead'
+        Order         = 5
+        Purpose       = 'Open any work item in the browser by raw ID - no cache lookup, works for items not assigned to or mentioning you'
+        Args          = '<id>'
+        Example       = 'az-Open-WorkItemById 12345'
+        RunsBefore    = ''
+        RequiresSync  = 'No'
+        DiagramAnchor = ''
         Issues        = @()
     },
 
@@ -174,7 +188,7 @@ $script:AzDevOpsHelpCatalog = @(
         Name          = 'az-Show-Tree'
         File          = 'powcuts_by_cli/azdevops_views.ps1'
         Phase         = 'DailyRead'
-        Order         = 5
+        Order         = 6
         Purpose       = 'Epic -> Feature -> requirement-tier indented tree; select a row to open it or create a child work item'
         Args          = '[-IncludeClosed]'
         Example       = 'az-Show-Tree'
@@ -188,7 +202,7 @@ $script:AzDevOpsHelpCatalog = @(
         Name          = 'az-Show-Board'
         File          = 'powcuts_by_cli/azdevops_views.ps1'
         Phase         = 'DailyRead'
-        Order         = 6
+        Order         = 7
         Purpose       = 'Group-by-State board view of the cached items; select a row to open it or create a child work item'
         Args          = '[-IncludeClosed]'
         Example       = 'az-Show-Board'
@@ -202,7 +216,7 @@ $script:AzDevOpsHelpCatalog = @(
         Name          = 'az-Show-Features'
         File          = 'powcuts_by_cli/azdevops_views.ps1'
         Phase         = 'DailyRead'
-        Order         = 7
+        Order         = 8
         Purpose       = 'Features across the project map from the hierarchy cache; select a row to open it or create a child story'
         Args          = '[-Project <name>] [-State <states>]'
         Example       = 'az-Show-Features'

--- a/powcuts_by_cli/azdevops_openers.ps1
+++ b/powcuts_by_cli/azdevops_openers.ps1
@@ -6,7 +6,7 @@
 # path through the existing Get-AzDevOps* helpers so cache openers auto-follow
 # the active project slice and the schema opener auto-follows $env:AZ_DEVOPS_ORG.
 #
-# Discovery: tab-tab on `az-Open-AzDevOps` in any pwsh session.
+# Discovery: tab-tab on `az-Open-` in any pwsh session.
 #
 # Loaded by powcuts_home.ps1. See azdevops_auth.ps1 for the master docstring.
 
@@ -16,7 +16,7 @@ function o-az-devops-openers {
 
 
 function Open-AzDevOpsPathIfExists {
-    # Private helper used by every public az-Open-AzDevOps* function in this
+    # Private helper used by every public az-Open-* function in this
     # section. Centralizes the "exists? -> Start-Process, missing? -> yellow
     # hint + return" branch so the 15 public openers stay one-liners. Uses an
     # unapproved verb on purpose - it isn't user-facing, so it doesn't need to
@@ -39,14 +39,14 @@ function Open-AzDevOpsPathIfExists {
 
 # --- Folder openers (4) ----------------------------------------------------
 
-function az-Open-AzDevOpsAppRoot {
+function az-Open-AppRoot {
     $root = Get-AzDevOpsAppRoot
     Open-AzDevOpsPathIfExists -Path $root `
         -HintMessage "Run az-Connect-AzDevOps to scaffold the app root."
 }
 
 
-function az-Open-AzDevOpsCacheDir {
+function az-Open-CacheDir {
     $paths = Get-AzDevOpsCachePaths
     Open-AzDevOpsPathIfExists -Path $paths.Dir `
         -HintMessage "Run az-Sync-AzDevOpsCache to populate the active project's cache slice."
@@ -56,7 +56,7 @@ function az-Open-AzDevOpsCacheDir {
 function o-az-devops-queries-config-dir {
     $paths = Get-AzDevOpsConfigPaths
     Open-AzDevOpsPathIfExists -Path $paths.QueriesDir `
-        -HintMessage "Run az-Connect-AzDevOps (or az-Open-AzDevOpsHierarchyWiqls) to seed the default WIQL files."
+        -HintMessage "Run az-Connect-AzDevOps (or az-Open-HierarchyWiqls) to seed the default WIQL files."
 }
 
 
@@ -69,49 +69,49 @@ function o-az-devops-schema-dir {
 
 # --- Cache file openers (7) ------------------------------------------------
 
-function az-Open-AzDevOpsAssignedCache {
+function az-Open-AssignedCache {
     $paths = Get-AzDevOpsCachePaths
     Open-AzDevOpsPathIfExists -Path $paths.Assigned `
         -HintMessage "Run az-Sync-AzDevOpsCache to populate assigned.json."
 }
 
 
-function az-Open-AzDevOpsMentionsCache {
+function az-Open-MentionsCache {
     $paths = Get-AzDevOpsCachePaths
     Open-AzDevOpsPathIfExists -Path $paths.Mentions `
         -HintMessage "Run az-Sync-AzDevOpsCache to populate mentions.json."
 }
 
 
-function az-Open-AzDevOpsHierarchyCache {
+function az-Open-HierarchyCache {
     $paths = Get-AzDevOpsCachePaths
     Open-AzDevOpsPathIfExists -Path $paths.Hierarchy `
         -HintMessage "Run az-Sync-AzDevOpsCache to populate hierarchy.json."
 }
 
 
-function az-Open-AzDevOpsIterationsCache {
+function az-Open-IterationsCache {
     $paths = Get-AzDevOpsCachePaths
     Open-AzDevOpsPathIfExists -Path $paths.Iterations `
         -HintMessage "Run az-Sync-AzDevOpsCache to populate iterations.json."
 }
 
 
-function az-Open-AzDevOpsAreasCache {
+function az-Open-AreasCache {
     $paths = Get-AzDevOpsCachePaths
     Open-AzDevOpsPathIfExists -Path $paths.Areas `
         -HintMessage "Run az-Sync-AzDevOpsCache to populate areas.json."
 }
 
 
-function az-Open-AzDevOpsLastSync {
+function az-Open-LastSync {
     $paths = Get-AzDevOpsCachePaths
     Open-AzDevOpsPathIfExists -Path $paths.LastSync `
         -HintMessage "Run az-Sync-AzDevOpsCache to write the first last-sync.json."
 }
 
 
-function az-Open-AzDevOpsSyncLog {
+function az-Open-SyncLog {
     $paths = Get-AzDevOpsCachePaths
     Open-AzDevOpsPathIfExists -Path $paths.Log `
         -HintMessage "Run az-Sync-AzDevOpsCache - the log is appended only when a sync runs."
@@ -120,30 +120,30 @@ function az-Open-AzDevOpsSyncLog {
 
 # --- Config file openers (3) -----------------------------------------------
 
-function az-Open-AzDevOpsEpicsWiql {
+function az-Open-EpicsWiql {
     $paths = Get-AzDevOpsConfigPaths
     Open-AzDevOpsPathIfExists -Path $paths.EpicsQuery `
-        -HintMessage "Run az-Open-AzDevOpsHierarchyWiqls (or az-Connect-AzDevOps) to seed epics.wiql with the default."
+        -HintMessage "Run az-Open-HierarchyWiqls (or az-Connect-AzDevOps) to seed epics.wiql with the default."
 }
 
 
-function az-Open-AzDevOpsFeaturesWiql {
+function az-Open-FeaturesWiql {
     $paths = Get-AzDevOpsConfigPaths
     Open-AzDevOpsPathIfExists -Path $paths.FeaturesQuery `
-        -HintMessage "Run az-Open-AzDevOpsHierarchyWiqls (or az-Connect-AzDevOps) to seed features.wiql with the default."
+        -HintMessage "Run az-Open-HierarchyWiqls (or az-Connect-AzDevOps) to seed features.wiql with the default."
 }
 
 
-function az-Open-AzDevOpsUserStoriesWiql {
+function az-Open-UserStoriesWiql {
     $paths = Get-AzDevOpsConfigPaths
     Open-AzDevOpsPathIfExists -Path $paths.UserStoriesQuery `
-        -HintMessage "Run az-Open-AzDevOpsHierarchyWiqls (or az-Connect-AzDevOps) to seed user-stories.wiql with the default."
+        -HintMessage "Run az-Open-HierarchyWiqls (or az-Connect-AzDevOps) to seed user-stories.wiql with the default."
 }
 
 
 # --- Schema file opener (1) ------------------------------------------------
 
-function az-Open-AzDevOpsSchema {
+function az-Open-Schema {
     $paths = Get-AzDevOpsSchemaPaths
     Open-AzDevOpsPathIfExists -Path $paths.File `
         -HintMessage "Run az-Initialize-AzDevOpsSchema to introspect your org, or az-Edit-AzDevOpsSchema to scaffold a stub."

--- a/powcuts_by_cli/azdevops_paths.ps1
+++ b/powcuts_by_cli/azdevops_paths.ps1
@@ -215,7 +215,7 @@ function Initialize-AzDevOpsQueryFiles {
     # Idempotent: creates the queries directory if absent and seeds each
     # default .wiql file only when the file does not already exist. Returns
     # the resolved paths plus per-file Seeded flags so callers (the
-    # az-Connect-AzDevOps step and az-Open-AzDevOpsHierarchyWiqls) can print
+    # az-Connect-AzDevOps step and az-Open-HierarchyWiqls) can print
     # consistent status lines.
     $paths = Get-AzDevOpsConfigPaths
     New-AzDevOpsDirectoryIfMissing -Path $paths.QueriesDir

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -538,7 +538,7 @@ function Invoke-UnplannedDebrief {
     $commentResult = Add-AzDevOpsDiscussionComment -Id $TaskId -Body $commentBody
     if ($commentResult.ExitCode -eq 0) {
         Write-Host "$iconCheck Debrief posted on Task #$TaskId." -ForegroundColor Green
-        Write-Host "   View: az-Open-AzDevOpsAssigned $TaskId" -ForegroundColor DarkGray
+        Write-Host "   View: az-Open-WorkItemById $TaskId" -ForegroundColor DarkGray
     } else {
         Write-Host "Debrief comment failed: $($commentResult.Error)" -ForegroundColor Red
     }

--- a/powcuts_by_cli/azdevops_views.ps1
+++ b/powcuts_by_cli/azdevops_views.ps1
@@ -87,9 +87,9 @@ function Read-AzDevOpsGridPick {
 #
 # Public functions:
 #   az-Get-AzDevOpsAssigned   - table of work items assigned to me
-#   az-Open-AzDevOpsAssigned  - open a single assigned item in the browser
+#   az-Open-Assigned  - open a single assigned item in the browser
 #   az-Get-AzDevOpsMentions   - table of work items where I've been @-mentioned
-#   az-Open-AzDevOpsMention   - open a single mentioned item in the browser
+#   az-Open-Mention   - open a single mentioned item in the browser
 #
 # All four read $HOME/.bashcuts-az-devops-app/cache/{assigned,mentions}.json
 # (built by az-Sync-AzDevOpsCache). They never call `az` directly - if the cache
@@ -221,10 +221,11 @@ function Read-AzDevOpsJsonCache {
 #   - Title truncation projection - Format-AzDevOpsTruncatedTitle
 #   - id lookup w/ standard miss-hint + LASTEXITCODE=1
 #                                  - Find-AzDevOpsCachedWorkItem
-#   - env-var guard + URL build + Start-Process
-#                                  - Open-AzDevOpsWorkItemUrl
 #   - newest-first sort with $null dates pushed to the bottom
 #                                  - Sort-AzDevOpsByDateDesc
+#
+# az-Open-WorkItemById (public: open any item by raw ID, no cache check) is the
+# shared open primitive the Open-Assigned/Open-Mention pairs delegate to.
 # ---------------------------------------------------------------------------
 
 function Get-AzDevOpsClosedStates {
@@ -406,10 +407,11 @@ function Get-AzDevOpsBoardsUrl {
 }
 
 
-function Open-AzDevOpsWorkItemUrl {
-    # env-var guard + URL build + Start-Process. Sets $LASTEXITCODE = 1 and
-    # returns when env-vars are missing; otherwise launches the OS browser.
-    param([Parameter(Mandatory)] [int] $Id)
+function az-Open-WorkItemById {
+    # Open any work item in the browser by raw ID - no assigned/mentions cache
+    # membership check. Sets $LASTEXITCODE = 1 and returns when the az devops
+    # defaults are missing; otherwise launches the OS browser.
+    param([Parameter(Mandatory, Position = 0)] [int] $Id)
 
     $url = Get-AzDevOpsWorkItemUrl -Id $Id
     if ($null -eq $url) {
@@ -455,7 +457,7 @@ function az-Get-AzDevOpsAssigned {
 }
 
 
-function az-Open-AzDevOpsAssigned {
+function az-Open-Assigned {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, Position = 0)] [int] $Id
@@ -472,7 +474,7 @@ function az-Open-AzDevOpsAssigned {
         -IncludeUrlFallback
     if (-not $match) { return }
 
-    Open-AzDevOpsWorkItemUrl -Id $Id
+    az-Open-WorkItemById -Id $Id
 }
 
 
@@ -591,7 +593,7 @@ function az-Get-AzDevOpsMentions {
 }
 
 
-function az-Open-AzDevOpsMention {
+function az-Open-Mention {
     # Plain /_workitems/edit/<id> URL only - Azure DevOps' #comment-NNNN
     # anchor is an ephemeral comment id that isn't stable across syncs, so
     # there's no reliable way to deep-link into the discussion thread; the
@@ -612,7 +614,7 @@ function az-Open-AzDevOpsMention {
         -IncludeUrlFallback
     if (-not $match) { return }
 
-    Open-AzDevOpsWorkItemUrl -Id $Id
+    az-Open-WorkItemById -Id $Id
 }
 
 
@@ -1017,7 +1019,7 @@ function Invoke-AzDevOpsRowAction {
         $choice = Read-AzDevOpsRowActionChoice -Label $label -ChildType $childType
 
         if ($choice -eq 'open') {
-            Open-AzDevOpsWorkItemUrl -Id $id
+            az-Open-WorkItemById -Id $id
         }
         elseif ($choice -eq 'create') {
             New-AzDevOpsChildForRow -ParentType $type -ParentId $id | Out-Null

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -23,7 +23,7 @@
 #                               composed debrief comment on the chosen item
 #   ViewHint    [scriptblock] - param([int]$Id); returns a one-line string
 #                               printed after a successful comment post
-#                               (e.g. "View discussion: az-Open-AzDevOpsAssigned 1234")
+#                               (e.g. "View discussion: az-Open-WorkItemById 1234")
 #
 # Azure DevOps integration is registered at the bottom of this file; reads
 # $HOME/.bashcuts-cache/azure-devops/assigned.json (populated by
@@ -1204,6 +1204,6 @@ az-Register-TimerIntegration `
     } `
     -ViewHint    {
         param([Parameter(Mandatory)] [int] $Id)
-        $hint = "View discussion: az-Open-AzDevOpsAssigned $Id"
+        $hint = "View discussion: az-Open-WorkItemById $Id"
         return $hint
     }


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #107 |
| [Changes](#changes) | ✅ 11 files |
| [Scope notes](#scope-notes) | ✅ |
| [Test Plan](#test-plan) | 0/5 (manual) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4535401629) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4535409378) |
| 🛡️ Security Audit | ✅ APPROVE — [View](#issuecomment-4535409045) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4535407357) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4535420370) |
<!-- toc:end -->
<!-- pr-diagram:start -->
## How it works

This PR adds one new public primitive, `az-Open-WorkItemById`, which builds a work-item URL from a raw `[int]` id and launches it — guarding the unconfigured-defaults case. The renamed cache-gated openers (`az-Open-Assigned`, `az-Open-Mention`) and the grid row-action now delegate their "open" step to it after their own cache-membership check, so opening is one shared primitive instead of three copies.

```mermaid
flowchart TD
    OpenAsg([az-Open-Assigned]):::pub
    OpenMen([az-Open-Mention]):::pub
    RowAct[Invoke-AzDevOpsRowAction<br/>find / tree / board 'open']:::priv

    AsgCache[(assigned.json)]:::io
    MenCache[(mentions.json)]:::io
    Find[Find-AzDevOpsCachedWorkItem<br/>membership + miss-hint]:::priv
    Miss([miss: list-hint<br/>$LASTEXITCODE=1]):::io

    OpenById([az-Open-WorkItemById<br/>-Id int]):::pub
    UrlBuild[Get-AzDevOpsWorkItemUrl]:::priv
    Gate{URL resolved?}
    NoCfg([config hint<br/>$LASTEXITCODE=1]):::io
    Launch["Start-Process url<br/>OS browser"]:::io

    OpenAsg --> AsgCache --> Find
    OpenMen --> MenCache --> Find
    Find -- miss --> Miss
    Find -. hit .-> OpenById
    RowAct -. open .-> OpenById

    OpenById --> UrlBuild --> Gate
    Gate -- no --> NoCfg
    Gate -- yes --> Launch

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
- Hard-renames every `az-Open-AzDevOps*` PowerShell function to `az-Open-*` (drops the redundant `AzDevOps` infix), mirroring the precedent set for the `az-Show-*` views in #98.
- Promotes the private `Open-AzDevOpsWorkItemUrl` helper to a public, tab-discoverable `az-Open-WorkItemById -Id <n>` that opens any work item by raw ID with no assigned/mentions cache-membership check.
- Repoints all internal callers, hint strings, the `az-help` catalog, README, and the diagrams doc.

## Issue
Closes #107

## Changes
- `azdevops_openers.ps1` — 13 openers renamed (`AppRoot`, `CacheDir`, `AssignedCache`, `MentionsCache`, `HierarchyCache`, `IterationsCache`, `AreasCache`, `LastSync`, `SyncLog`, `EpicsWiql`, `FeaturesWiql`, `UserStoriesWiql`, `Schema`) + hints + header
- `azdevops_views.ps1` — `az-Open-Assigned` / `az-Open-Mention`; new public `az-Open-WorkItemById`; updated shared-helper docstring + callers
- `azdevops_find.ps1` — 3 callers repointed to `az-Open-WorkItemById`
- `azdevops_auth.ps1` — `az-Open-HierarchyWiqls` (+ docstring)
- `azdevops_help.ps1` — renamed refs, new `az-Open-WorkItemById` catalog entry, section-5 anchor normalized
- `azdevops_paths.ps1`, `azdevops_unplanned.ps1`, `pow_timer.ps1` — comment/hint refs; "view by id" hints now point at `az-Open-WorkItemById`
- `README.md`, `docs/azure-devops-diagrams.md`, `CLAUDE.md` — docs

## Scope notes
- **PowerShell only** by request — bash `az-open-*` openers untouched.
- **No backward-compat aliases** for the old names (per CLAUDE.md: no compat shims) — this is a hard rename.
- The `o-az-devops-queries-config-dir` / `o-az-devops-schema-dir` openers were intentionally left under their existing `o-` prefix; README/diagram labels that previously mislabeled them as `az-Open-AzDevOpsConfigDir/SchemaDir` are corrected to the real names.

## Test Plan
- [ ] Open a fresh PowerShell terminal — every changed `.ps1` dot-sources with no parse errors (`pwsh` was unavailable in CI; brace/paren balance verified manually)
- [ ] Tab-tab on `az-Open-` lists the new short names; no `az-Open-AzDevOps*` remain (`Get-Command az-Open-*`)
- [ ] `az-Open-WorkItemById 12345` opens the item in the browser with no cache lookup; with az defaults unset it prints the red configure-defaults hint and sets `$LASTEXITCODE = 1`
- [ ] `az-Open-Assigned <id>` / `az-Open-Mention <id>` still open from their caches
- [ ] `az-help` renders the new `az-Open-WorkItemById` row under DailyRead