### PR TITLE
Show a UX spinner around every az CLI call via Invoke-AzDevOpsAzJson

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,10 @@ Add any of these to your PowerShell `$profile` to enable additional features:
 $env:AZ_USER_EMAIL = 'user@example.com'   # enables accurate mentions WIQL
 $env:AZ_AREA       = 'My Project\My Team' # default area path for hierarchy queries
 $env:AZ_ITERATION  = 'My Project\Sprint 42' # default iteration for work item creation
+$env:BASHCUTS_NO_SPINNER = '1'            # opt out of the az-call loading spinner
 ```
+
+Every AzDevOps command routes its underlying `az` call through one wrapper, which now shows a small terminal spinner while the call is in flight and clears it cleanly when the call returns — so a multi-second `az-Sync-AzDevOpsCache` or `az-New-AzDevOpsUserStory` always signals that work is happening. The spinner suppresses itself when output is redirected or piped (CI, `> out.txt`, `| cmd`) so it never leaks into captured JSON; set `BASHCUTS_NO_SPINNER` to turn it off everywhere.
 
 ### First run
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -747,6 +747,9 @@ graph LR
     EchoLn[Write-AzDevOpsQueryEcho]:::priv
     ConvNative[ConvertTo-AzDevOpsNativeArgList]:::priv
 
+    %% Cross-cutting console spinner (pow_common.ps1)
+    Spinner[Invoke-WithSpinner]:::priv
+
     %% Platform + on-open background-sync helpers
     Plat[Get-AzDevOpsPlatform]:::priv
     AutoChild[Get-AzDevOpsAutoSyncChildVar]:::priv
@@ -939,7 +942,7 @@ graph LR
     AzJson --> CmdHead
     AzJson --> EchoLn
     AzJson --> ConvNative
-    AzJson --> Az
+    AzJson --> Spinner --> Az
     InvokeDS --> Stderr1
     InvokeDS --> DStatus
     InvokeDS --> StderrW --> LogFn

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -186,6 +186,8 @@ function Invoke-AzDevOpsAzJson {
     # Windows PowerShell 5.1 (already Legacy), where this is a harmless local.
     $PSNativeCommandArgumentPassing = 'Legacy'
 
+    $headline = Get-AzDevOpsCommandHeadline -ArgList $ArgList
+
     $stderrFile = [System.IO.Path]::GetTempFileName()
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     try {
@@ -196,13 +198,12 @@ function Invoke-AzDevOpsAzJson {
         # Invoke-WithSpinner's own scope; $LASTEXITCODE is the global az sets,
         # so it's still readable after the spinner stops (no native command
         # runs between the call and the read).
-        $spinnerMessage = Get-AzDevOpsCommandHeadline -ArgList $ArgList
         $azCall = {
             $output = & az @invokeArgs --output json 2>$stderrFile
             return $output
         }.GetNewClosure()
 
-        $json = Invoke-WithSpinner -ScriptBlock $azCall -Message $spinnerMessage
+        $json = Invoke-WithSpinner -ScriptBlock $azCall -Message $headline
         $exit = $LASTEXITCODE
 
         $stderr = if (Test-Path -LiteralPath $stderrFile) {
@@ -215,8 +216,7 @@ function Invoke-AzDevOpsAzJson {
     }
     $sw.Stop()
 
-    $elapsed  = '{0:N1}s' -f $sw.Elapsed.TotalSeconds
-    $headline = Get-AzDevOpsCommandHeadline -ArgList $ArgList
+    $elapsed = '{0:N1}s' -f $sw.Elapsed.TotalSeconds
 
     $summary      = "$headline ($elapsed, exit=$exit)"
     $summaryColor = if ($exit -eq 0) {

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -189,8 +189,22 @@ function Invoke-AzDevOpsAzJson {
     $stderrFile = [System.IO.Path]::GetTempFileName()
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     try {
-        $json = & az @invokeArgs --output json 2>$stderrFile
+        # Wrap the native az call in the shared console spinner so every query
+        # routed through here shows a "working" indicator while it's in flight.
+        # GetNewClosure() captures $invokeArgs, $stderrFile, and the Legacy
+        # $PSNativeCommandArgumentPassing pin so they survive the hand-off into
+        # Invoke-WithSpinner's own scope; $LASTEXITCODE is the global az sets,
+        # so it's still readable after the spinner stops (no native command
+        # runs between the call and the read).
+        $spinnerMessage = Get-AzDevOpsCommandHeadline -ArgList $ArgList
+        $azCall = {
+            $output = & az @invokeArgs --output json 2>$stderrFile
+            return $output
+        }.GetNewClosure()
+
+        $json = Invoke-WithSpinner -ScriptBlock $azCall -Message $spinnerMessage
         $exit = $LASTEXITCODE
+
         $stderr = if (Test-Path -LiteralPath $stderrFile) {
             (Get-Content -LiteralPath $stderrFile -Raw)
         } else {

--- a/powcuts_by_cli/pow_common.ps1
+++ b/powcuts_by_cli/pow_common.ps1
@@ -271,26 +271,44 @@ function Start-CommonConsoleSpinner {
         Active = $true
     })
 
-    $runspace = [runspacefactory]::CreateRunspace()
-    $runspace.Open()
-    $runspace.SessionStateProxy.SetVariable('State', $state)
-    $runspace.SessionStateProxy.SetVariable('Frames', $frames)
-    $runspace.SessionStateProxy.SetVariable('Message', $Message)
-    $runspace.SessionStateProxy.SetVariable('IntervalMs', $intervalMs)
+    $runspace = $null
+    $worker   = $null
 
-    $worker = [powershell]::Create()
-    $worker.Runspace = $runspace
-    $worker.AddScript({
-        $index = 0
-        while ($State.Active) {
-            $frame = $Frames[$index % $Frames.Count]
-            [Console]::Write("`r$frame $Message...")
-            $index++
-            Start-Sleep -Milliseconds $IntervalMs
+    try {
+        $runspace = [runspacefactory]::CreateRunspace()
+        $runspace.Open()
+        $runspace.SessionStateProxy.SetVariable('State', $state)
+        $runspace.SessionStateProxy.SetVariable('Frames', $frames)
+        $runspace.SessionStateProxy.SetVariable('Message', $Message)
+        $runspace.SessionStateProxy.SetVariable('IntervalMs', $intervalMs)
+
+        $worker = [powershell]::Create()
+        $worker.Runspace = $runspace
+        $worker.AddScript({
+            $index = 0
+            while ($State.Active) {
+                $frame = $Frames[$index % $Frames.Count]
+                [Console]::Write("`r$frame $Message...")
+                $index++
+                Start-Sleep -Milliseconds $IntervalMs
+            }
+        }) | Out-Null
+
+        $handle = $worker.BeginInvoke()
+    } catch {
+        # A spinner that fails to start must never break the wrapped call. Tear
+        # down whatever was created and return $null so the caller runs the work
+        # without a spinner (Stop-CommonConsoleSpinner treats $null as a no-op).
+        if ($null -ne $worker) {
+            $worker.Dispose()
         }
-    }) | Out-Null
 
-    $handle = $worker.BeginInvoke()
+        if ($null -ne $runspace) {
+            $runspace.Dispose()
+        }
+
+        return $null
+    }
 
     $result = [PSCustomObject]@{
         State    = $state
@@ -306,13 +324,27 @@ function Start-CommonConsoleSpinner {
 function Stop-CommonConsoleSpinner {
     # Private helper - signals the spinner runspace to stop, waits for the
     # in-flight frame to finish drawing, disposes the runspace, then blanks the
-    # spinner line so no glyph survives into whatever prints next. Width is the
+    # spinner line so no glyph survives into whatever prints next. A $null
+    # spinner (Start- failed to launch one) is a no-op. The whole teardown is
+    # best-effort: it runs from Invoke-WithSpinner's finally, so a worker that
+    # threw on an invalid console handle must not let EndInvoke resurface that
+    # exception and mask the wrapped call's real result. Width is the
     # spinner-line length captured at start, padded so the longest frame is
     # fully overwritten.
-    param([Parameter(Mandatory)] $Spinner)
+    param($Spinner)
+
+    if ($null -eq $Spinner) {
+        return
+    }
 
     $Spinner.State.Active = $false
-    $Spinner.Worker.EndInvoke($Spinner.Handle)
+
+    try {
+        $Spinner.Worker.EndInvoke($Spinner.Handle)
+    } catch {
+        # Cosmetic draw failure - swallow so it never masks the az outcome.
+    }
+
     $Spinner.Worker.Dispose()
     $Spinner.Runspace.Close()
     $Spinner.Runspace.Dispose()
@@ -343,9 +375,10 @@ function Invoke-WithSpinner {
         return $result
     }
 
-    $spinner = Start-CommonConsoleSpinner -Message $Message
+    $spinner = $null
     try {
-        $result = & $ScriptBlock
+        $spinner = Start-CommonConsoleSpinner -Message $Message
+        $result  = & $ScriptBlock
     } finally {
         Stop-CommonConsoleSpinner -Spinner $spinner
     }

--- a/powcuts_by_cli/pow_common.ps1
+++ b/powcuts_by_cli/pow_common.ps1
@@ -226,27 +226,130 @@ function Set-WpfArcPoint {
 }
 
 
-$script:CommonSpinnerFrames = @('|', '/', '-', '\')
+$script:CommonSpinnerFrames     = @('|', '/', '-', '\')
+$script:CommonSpinnerIntervalMs = 120
+$script:CommonSpinnerClearPad   = 8
+
+
+function Test-CommonSpinnerEnabled {
+    # Private guard - the console spinner is only safe to draw on an
+    # interactive terminal whose stdout isn't redirected. When output is piped
+    # or captured to a file (CI, `pwsh script.ps1 > out.txt`, `... | cmd`) the
+    # raw [Console]::Write frames would land in the redirected stream, so the
+    # spinner is suppressed and the caller runs the work silently — the
+    # { Json, Error, ExitCode } envelope a wrapper returns is never affected.
+    # BASHCUTS_NO_SPINNER is an explicit opt-out for users who want it off
+    # regardless of context. Unapproved-verb-free name (Test-* is approved);
+    # treated as private to pow_common.ps1.
+    if (-not [string]::IsNullOrEmpty($env:BASHCUTS_NO_SPINNER)) {
+        return $false
+    }
+
+    if ([Console]::IsOutputRedirected) {
+        return $false
+    }
+
+    return $true
+}
+
+
+function Start-CommonConsoleSpinner {
+    # Private helper - opens a background runspace that redraws the spinner
+    # frame in place on a "`r<frame> <Message>..." line every
+    # CommonSpinnerIntervalMs. The wrapped work runs synchronously on the
+    # calling thread, so the animation has to live on its own thread to keep
+    # ticking while a slow az call blocks. Shared state travels through a
+    # synchronized hashtable so the main thread can flip .Active to false;
+    # pair this with Stop-CommonConsoleSpinner to join the runspace and clear
+    # the line.
+    param([string] $Message = 'Working')
+
+    $frames     = $script:CommonSpinnerFrames
+    $intervalMs = $script:CommonSpinnerIntervalMs
+
+    $state = [hashtable]::Synchronized(@{
+        Active = $true
+    })
+
+    $runspace = [runspacefactory]::CreateRunspace()
+    $runspace.Open()
+    $runspace.SessionStateProxy.SetVariable('State', $state)
+    $runspace.SessionStateProxy.SetVariable('Frames', $frames)
+    $runspace.SessionStateProxy.SetVariable('Message', $Message)
+    $runspace.SessionStateProxy.SetVariable('IntervalMs', $intervalMs)
+
+    $worker = [powershell]::Create()
+    $worker.Runspace = $runspace
+    $worker.AddScript({
+        $index = 0
+        while ($State.Active) {
+            $frame = $Frames[$index % $Frames.Count]
+            [Console]::Write("`r$frame $Message...")
+            $index++
+            Start-Sleep -Milliseconds $IntervalMs
+        }
+    }) | Out-Null
+
+    $handle = $worker.BeginInvoke()
+
+    $result = [PSCustomObject]@{
+        State    = $state
+        Worker   = $worker
+        Handle   = $handle
+        Runspace = $runspace
+        Width    = ($Message.Length + $script:CommonSpinnerClearPad)
+    }
+    return $result
+}
+
+
+function Stop-CommonConsoleSpinner {
+    # Private helper - signals the spinner runspace to stop, waits for the
+    # in-flight frame to finish drawing, disposes the runspace, then blanks the
+    # spinner line so no glyph survives into whatever prints next. Width is the
+    # spinner-line length captured at start, padded so the longest frame is
+    # fully overwritten.
+    param([Parameter(Mandatory)] $Spinner)
+
+    $Spinner.State.Active = $false
+    $Spinner.Worker.EndInvoke($Spinner.Handle)
+    $Spinner.Worker.Dispose()
+    $Spinner.Runspace.Close()
+    $Spinner.Runspace.Dispose()
+
+    $blank = ' ' * $Spinner.Width
+    [Console]::Write("`r$blank`r")
+}
 
 
 function Invoke-WithSpinner {
-    # Runs $ScriptBlock while showing a console loading/posting indicator, then
-    # returns whatever the scriptblock returned. The work runs synchronously on
-    # the calling thread — a wrapped az call blocks until it returns — so this
-    # prints a single "working" line that stays on screen for the duration
-    # rather than a continuously spinning glyph (a true animation would need a
-    # second thread, and the wrapped call's own command echo would clash with
-    # it on the same console). It exists to give feedback that a slow call is
-    # in flight and to be the shared seam the repo-wide az spinner (#105) wraps.
+    # Runs $ScriptBlock while animating a single-line console spinner, then
+    # clears that line and returns whatever the scriptblock returned. The work
+    # runs synchronously on the calling thread — a wrapped az call blocks until
+    # it returns — so the animation is driven from a background runspace that
+    # redraws the frame in place; the main thread stops the runspace and blanks
+    # the line once the call completes, leaving no stray glyph behind. This is
+    # the shared seam the repo-wide az spinner wraps (Invoke-AzDevOpsAzJson).
+    # When stdout is redirected or BASHCUTS_NO_SPINNER is set the spinner is
+    # skipped and the work runs silently so captured/piped output is never
+    # corrupted.
     param(
         [Parameter(Mandatory)] [scriptblock] $ScriptBlock,
         [string] $Message = 'Working'
     )
 
-    $frame = $script:CommonSpinnerFrames[0]
-    Write-Host "$frame $Message..." -ForegroundColor Cyan
+    if (-not (Test-CommonSpinnerEnabled)) {
+        $result = & $ScriptBlock
+        return $result
+    }
 
-    $result = & $ScriptBlock
+    $spinner = Start-CommonConsoleSpinner -Message $Message
+    try {
+        $result = & $ScriptBlock
+    } finally {
+        Stop-CommonConsoleSpinner -Spinner $spinner
+    }
+
     return $result
 }
 


### PR DESCRIPTION
<!-- toc:start -->
## Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #105 |
| [Changes](#changes) | ✅ 4 files |
| [Test Plan](#test-plan) | ✅ 6 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4535606759) |
| 💠 PowerShell Engineer Review | ✅ REQUEST CHANGES → addressed in `ce47df0` — [View](#issuecomment-4535611947) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4535611743) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4535611169) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4535624928) |
<!-- toc:end -->
<!-- pr-diagram:start -->
## How it works

`Invoke-AzDevOpsAzJson` (the chokepoint every AzDO command's `az` call passes through) now hands its native call to `Invoke-WithSpinner`. `Test-CommonSpinnerEnabled` decides whether to animate: when stdout is redirected or `BASHCUTS_NO_SPINNER` is set, the work runs silently so captured JSON is never corrupted; otherwise `Start-/Stop-CommonConsoleSpinner` runs a background runspace that redraws a frame in place and blanks the line cleanly once the call returns. The command echo and the `{ Json, Error, ExitCode }` contract are unchanged.

```mermaid
flowchart TD
    AzJson[Invoke-AzDevOpsAzJson]:::priv
    Echo[Write-AzDevOpsQueryEcho<br/>command echo]:::priv
    Wrap([Invoke-WithSpinner]):::pub
    Gate{Test-CommonSpinnerEnabled?<br/>redirected / NO_SPINNER?}
    Start[Start-CommonConsoleSpinner<br/>background runspace]:::priv
    Worker((redraw frame<br/>every 120ms)):::priv
    AzCall["& az ... --output json"]:::io
    Stop[Stop-CommonConsoleSpinner<br/>blank the line]:::priv
    Done([return Json / Error / ExitCode])

    AzJson --> Echo --> Wrap --> Gate
    Gate -- redirected / opt-out --> AzCall
    Gate -- interactive --> Start --> AzCall
    Start --> Worker
    Worker -.animates during call.-> AzCall
    AzCall --> Stop --> Done

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
Every Azure DevOps command routes its `az` invocation through `Invoke-AzDevOpsAzJson`. These calls can take several seconds with no feedback. This wires the reusable `Invoke-WithSpinner` helper (from #104) into that wrapper so **every** az call routed through it shows a console spinner while in flight, cleared cleanly on completion.

## Issue
Closes #105

## Changes
- **`powcuts_by_cli/pow_common.ps1`** — upgraded `Invoke-WithSpinner` from a static one-line print into an animated background-runspace console spinner that redraws in place and blanks its line cleanly on completion. Added:
  - `Test-CommonSpinnerEnabled` — guard that suppresses the spinner when `[Console]::IsOutputRedirected` (CI / `> out.txt` / `| cmd`) or `BASHCUTS_NO_SPINNER` is set, so captured/piped output is never corrupted.
  - `Start-CommonConsoleSpinner` / `Stop-CommonConsoleSpinner` — runspace animator + clean (best-effort, $null-safe) teardown.
- **`powcuts_by_cli/azdevops_db.ps1`** — wrapped the native `& az` call inside `Invoke-AzDevOpsAzJson` with `Invoke-WithSpinner` (message = command headline). `.GetNewClosure()` carries `$invokeArgs`/`$stderrFile`/the `Legacy` pin into the helper scope; `$LASTEXITCODE` is read after the spinner stops. The `{ Json, Error, ExitCode }` contract and the always-on command echo are unchanged.
- **`docs/azure-devops-diagrams.md`** — Diagram 9 now shows the interposed node: `Invoke-AzDevOpsAzJson --> Invoke-WithSpinner --> az CLI`.
- **`README.md`** — documented the spinner behavior and the `BASHCUTS_NO_SPINNER` opt-out.

> Review fixes (commit `ce47df0`) hardened the spinner teardown: `Stop-` is `$null`-safe and wraps `EndInvoke` in `try/catch` so a worker draw failure can never mask the real az result; `Start-` disposes a partial runspace on failure; the headline is computed once.

PowerShell-only by design (per the issue).

## Test Plan
- [ ] `pwsh -NoProfile` parses `pow_common.ps1` and `azdevops_db.ps1` with zero errors *(could not run in the build container — pwsh not on PATH)*.
- [ ] Fresh PowerShell terminal: `az-Sync-AzDevOpsCache` shows the spinner during each underlying `az boards query` and clears it cleanly (no stray glyph); command echo + elapsed/exit summary still print.
- [ ] `az-New-AzDevOpsUserStory ...` visibly spins during its az call.
- [ ] `$r = Invoke-AzDevOpsAzJson -ArgList @('boards','query','--wiql','...')` — inspect `$r.Json`: no spinner characters leak into the captured value.
- [ ] `pwsh -c "az-Sync-AzDevOpsCache" > out.txt` — no spinner output in the file (redirected → suppressed).
- [ ] `$env:BASHCUTS_NO_SPINNER='1'; az-Sync-AzDevOpsCache` — no spinner shown.