### PR TITLE
Fix: separate As-a / I-want / So-that clauses with line breaks in the User Story description body

### DIFF
--- a/powcuts_by_cli/azdevops_create_pickers.ps1
+++ b/powcuts_by_cli/azdevops_create_pickers.ps1
@@ -106,8 +106,9 @@ function Read-AzDevOpsAcceptanceCriteria {
 function Read-AzDevOpsUserStoryDescription {
     # Builds the User Story description from the canonical three-clause
     # template. Each clause is required - re-prompts until a non-empty value
-    # is entered - then joins them single-spaced into one prose sentence:
-    # "As a <persona> I want <outcome> so that <benefit>".
+    # is entered - then joins them with HTML line breaks so each clause
+    # renders on its own line in the AzDO Description field (which stores
+    # HTML): "As a <persona>" / "I want <outcome>" / "so that <benefit>".
     $persona = ''
     while (-not $persona) {
         $persona = (Read-Host 'As a ...').Trim()
@@ -123,7 +124,15 @@ function Read-AzDevOpsUserStoryDescription {
         $benefit = (Read-Host 'so that ...').Trim()
     }
 
-    $description = "As a $persona I want $outcome so that $benefit"
+    $clauseBreak = '<br/><br/>'
+
+    $clauses = @(
+        "As a $persona"
+        "I want $outcome"
+        "so that $benefit"
+    )
+
+    $description = $clauses -join $clauseBreak
 
     return $description
 }


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #114 |
| [Changes](#changes) | ✅ 1 file |
| [Shell Parity](#shell-parity) | ✅ PowerShell-only |
| [Test Plan](#test-plan) | 0/3 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4535645663) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4535648598) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4535649369) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4535648968) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4535653985) |
<!-- toc:end -->

## Summary
`Read-AzDevOpsUserStoryDescription` joined the three template clauses with single spaces, so they collapsed into one run-together line in the Azure DevOps HTML Description field. This joins them with `<br/><br/>` so each clause renders on its own line with a blank line between.

## Issue
Closes #114

## Changes
- `powcuts_by_cli/azdevops_create_pickers.ps1` — build the description from a `$clauses` array joined by a named `$clauseBreak = &#39;<br/><br/>&#39;` separator instead of an inline single-spaced string.

## Shell Parity
PowerShell-only by design. The bash `az-create-userstory` flow takes a single free-form description and has no three-clause template, so no parity change is needed (called out as Out of Scope in #114).

## Test Plan
- [ ] `pwsh` parses `powcuts_by_cli/azdevops_create_pickers.ps1` with zero errors
- [ ] Open a fresh PowerShell terminal, run the User Story create flow, fill the three prompts
- [ ] Confirm the created work item&#39;s Description renders **As a… / I want… / so that…** on separate lines (blank line between) in Azure DevOps

---
_Generated by [Claude Code](https://claude.ai/code/session_01EP2QnA1sAmTwdjC5RjJeGZ)_