### PR TITLE
Fix: Resolved/Done/Completed work items appear in the timer task picker

### DIFF
--- a/powcuts_by_cli/azdevops_views.ps1
+++ b/powcuts_by_cli/azdevops_views.ps1
@@ -251,7 +251,7 @@ function Read-AzDevOpsJsonCache {
 # ---------------------------------------------------------------------------
 
 function Get-AzDevOpsClosedStates {
-    return @('Closed', 'Removed')
+    return @('Closed', 'Removed', 'Resolved', 'Done', 'Completed')
 }
 
 


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #113 |
| [Changes](#changes) | ✅ 1 file |
| [Test Plan](#test-plan) | ✅ 4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4535679596) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4535680953) |
| 🛡️ Security Audit | ✅ APPROVE — [View](#issuecomment-4535680851) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4535682302) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4535687263) |
| 📚 Docs Check | ✅ CURRENT — run inline (no new files/CLI/setup drift) |
| 📊 AzDO Diagrams Check | ✅ CURRENT — no function/subcommand delta in this PR |
<!-- toc:end -->

## Summary
The timer task picker (`Start-TimerSession` → "Azure DevOps - User Stories") was listing finished work items. The shared `Get-AzDevOpsClosedStates` helper only excluded `Closed` and `Removed`, so items in `Resolved` (Agile/CMMI), `Done` (Scrum), and `Completed` states leaked through `Select-AzDevOpsActiveItems` into the picker — and into every other active-items view that shares the helper.

## Issue
Closes #113

## Changes
- `powcuts_by_cli/azdevops_views.ps1` — `Get-AzDevOpsClosedStates` now returns `Closed`, `Removed`, `Resolved`, `Done`, `Completed`.

One-line change at the single filtering chokepoint fixes the timer picker plus `az-Find-AzDevOpsWorkItem`, the create-flow pickers, and the assigned/board/feature views consistently. The explicit `-State` override path is unaffected — it matches `$_.State -in $State` directly and never consults the closed list.

## Test Plan
- [ ] Open a fresh PowerShell terminal (or re-dot-source `powcuts_home.ps1`)
- [ ] Ensure `assigned.json` has at least one `Resolved` and one `Done` item (`az-Sync-AzDevOpsCache`)
- [ ] Run `Start-TimerSession`, choose "Azure DevOps - User Stories" — confirm no Resolved/Done/Completed items appear
- [ ] Confirm the archive/override path still works: `az-Get-AzDevOpsAssigned -State Resolved` still lists them

_PowerShell-only: the timer has no bash counterpart, so no `bashcuts_by_cli/` change applies._