### PR TITLE
Add resolve-this-story checkbox + prompt to the timer debrief (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,18 @@ On **Windows** the countdown morphs into a themed debrief form that shares the t
 
 On **macOS/Linux** the debrief is collected with terminal `Read-Host` prompts after the snake animation, and a `Posting...` indicator shows while the comment is sent.
 
+### Closing the story when a session finishes the task
+
+When the chosen integration supplies a `CloseItem` capability, the debrief surface adds a one-click way to transition the work item to its done state right after the comment lands — so a session that actually finished the task doesn't leave the item lingering in **Active**. On **Windows** the debrief form renders a **Work complete — resolve this story** checkbox above **Post Debrief**; ticking it makes the post sequence run the comment, then the state transition, and reports both outcomes before the **Start another session?** choice appears. On **macOS/Linux** the same trigger is a `Resolve this item now? [y/N]` prompt that follows a successful comment post (default **No** — your work item is never resolved without an explicit yes).
+
+The built-in **Azure DevOps** integration maps `CloseItem` to `System.State=Resolved` (Agile process: New → Active → Resolved → Closed). Override with a single line in your `$profile` if your process template uses a different done-state:
+
+```powershell
+$script:TimerCloseState = 'Done'   # Scrum / Basic process
+```
+
+A failed state transition (e.g. an invalid workflow move) is reported distinctly — the comment still lands; the resolve verdict tells you the state update didn't, so you can fix it in the AzDO UI without losing the debrief.
+
 ### Interrupting a session
 
 Press **Esc** during the countdown (or use **Mark Complete Early** on the Windows overlay) to end the session early and still go through the debrief. The posted comment header reflects the outcome:
@@ -506,6 +518,13 @@ Register-TimerIntegration `
     -ViewHint    {
         param([Parameter(Mandatory)] [int] $Id)
         "View: my-tracker open $Id"
+    } `
+    -CloseItem   {
+        # Optional. When present, the debrief shows a resolve checkbox
+        # (Windows) / `Resolve this item now? [y/N]` prompt (terminal) that
+        # fires after a successful comment post.
+        param([Parameter(Mandatory)] [int] $Id)
+        Set-MyTrackerItemDone -Id $Id
     }
 ```
 

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -852,6 +852,26 @@ function Write-TimerResolveVerdict {
 }
 
 
+function New-TimerCloseScript {
+    # Builds the closure that invokes the chosen integration's CloseItem against
+    # the picked item's Id. Both orchestrator branches (WPF debrief CloseAction +
+    # terminal Invoke-WithSpinner) need the same { & $chosen.CloseItem -Id
+    # $pickedItem.Id; return $closed }.GetNewClosure() shape, so they share this
+    # helper instead of inlining it twice.
+    param(
+        [Parameter(Mandatory)] $Integration,
+        [Parameter(Mandatory)] $Item
+    )
+
+    $closeScript = {
+        $closed = & $Integration.CloseItem -Id $Item.Id
+        return $closed
+    }.GetNewClosure()
+
+    return $closeScript
+}
+
+
 function Show-WpfTimerDebrief {
     # Windows-only themed debrief form the countdown overlay morphs into. Two
     # multiline fields (Debrief + Next) share the timer's dark/blue theme. On
@@ -1127,7 +1147,7 @@ function Show-WpfTimerDebrief {
             $Script:WpfDebriefPostResult = $postResult
             $Script:WpfDebriefOutcome    = 'Posted'
 
-            $wantsResolve = ($closeEnabled -and $chkResolve.IsChecked -eq $true)
+            $wantsResolve = ($closeEnabled -and ($chkResolve.IsChecked -eq $true))
 
             if ($wantsResolve) {
                 $Script:WpfDebriefCloseRequested = $true
@@ -1300,10 +1320,7 @@ function az-Start-TimerSession {
 
                 $closeAction = $null
                 if ($null -ne $chosen.CloseItem) {
-                    $closeAction = {
-                        $closed = & $chosen.CloseItem -Id $pickedItem.Id
-                        return $closed
-                    }.GetNewClosure()
+                    $closeAction = New-TimerCloseScript -Integration $chosen -Item $pickedItem
                 }
 
                 $debriefResult = Show-WpfTimerDebrief `
@@ -1362,10 +1379,7 @@ function az-Start-TimerSession {
                 if ($postExitCode -eq 0 -and $null -ne $chosen.CloseItem) {
                     $wantsResolve = Read-TimerYesNo -Prompt "Resolve this item now? (sets State=$script:TimerCloseState)"
                     if ($wantsResolve) {
-                        $closeScript = {
-                            $closed = & $chosen.CloseItem -Id $pickedItem.Id
-                            return $closed
-                        }.GetNewClosure()
+                        $closeScript = New-TimerCloseScript -Integration $chosen -Item $pickedItem
 
                         $closeResult = Invoke-WithSpinner `
                             -Message "Resolving item $($pickedItem.Id)" `

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -11,8 +11,9 @@
 #                                a console posting indicator. Press Esc during the
 #                                countdown to end early and still post a debrief.
 #   Register-TimerIntegration  - add an integration (Name, Description,
-#                                FetchItems, AddComment, optional ViewHint).
-#                                Registering with an existing Name replaces it.
+#                                FetchItems, AddComment, optional ViewHint,
+#                                optional CloseItem). Registering with an
+#                                existing Name replaces it.
 #
 # Integration contract (each entry of $script:TimerIntegrations):
 #   Name        [string]      - display name shown in the picker
@@ -24,6 +25,14 @@
 #   ViewHint    [scriptblock] - param([int]$Id); returns a one-line string
 #                               printed after a successful comment post
 #                               (e.g. "View discussion: az-Open-WorkItemById 1234")
+#   CloseItem   [scriptblock] - optional; param([int]$Id); transitions the work
+#                               item to its done state. Azure DevOps maps this
+#                               to System.State=$script:TimerCloseState (default
+#                               'Resolved'). When provided, the debrief surfaces
+#                               a "Work complete — resolve this story" checkbox
+#                               (WPF) / "Resolve this item now? [y/N]" prompt
+#                               (terminal) that fires only after a successful
+#                               AddComment.
 #
 # Azure DevOps integration is registered at the bottom of this file; reads
 # $HOME/.bashcuts-cache/azure-devops/assigned.json (populated by
@@ -47,6 +56,8 @@ $script:TimerPollIntervalMs = 100
 $script:TimerPollsPerSecond = 10
 
 $script:TimerIntegrations = @()
+
+$script:TimerCloseState = 'Resolved'
 
 $script:WpfColorBackground = '#2D2D30'
 $script:WpfColorStroke     = '#444444'
@@ -263,7 +274,8 @@ function az-Register-TimerIntegration {
         [Parameter(Mandatory)] [string]      $Description,
         [Parameter(Mandatory)] [scriptblock] $FetchItems,
         [Parameter(Mandatory)] [scriptblock] $AddComment,
-        [scriptblock] $ViewHint
+        [scriptblock] $ViewHint,
+        [scriptblock] $CloseItem
     )
 
     $entry = [PSCustomObject]@{
@@ -272,6 +284,7 @@ function az-Register-TimerIntegration {
         FetchItems  = $FetchItems
         AddComment  = $AddComment
         ViewHint    = $ViewHint
+        CloseItem   = $CloseItem
     }
 
     $existing = @($script:TimerIntegrations | Where-Object { $_.Name -eq $Name })
@@ -809,6 +822,36 @@ function Write-TimerPostVerdict {
 }
 
 
+function Write-TimerResolveVerdict {
+    # Prints the resolve-item verdict shared by both the WPF and terminal
+    # debrief paths after a successful comment post: a green check naming the
+    # target state on success, a red warning + error text on failure. $Result
+    # is the integration's CloseItem envelope ({ Json, Error, ExitCode }); a
+    # missing ExitCode is treated as success (0).
+    param(
+        [Parameter(Mandatory)] $Result,
+        [Parameter(Mandatory)] $Item,
+        [Parameter(Mandatory)] [string] $CloseState
+    )
+
+    $exitCode = Get-TimerResultExitCode -Result $Result
+
+    $checkIcon = $script:TimerIconCheck
+    $warnIcon  = $script:TimerIconWarn
+
+    if ($exitCode -eq 0) {
+        Write-Host "$checkIcon Item $($Item.Id) resolved (State=$CloseState)." -ForegroundColor Green
+
+    } else {
+
+        Write-Host "$warnIcon Resolve failed (exit=$exitCode). Comment was posted; state unchanged." -ForegroundColor Red
+        if ($Result -and $Result.Error) {
+            Write-Host "   $($Result.Error)" -ForegroundColor Red
+        }
+    }
+}
+
+
 function Show-WpfTimerDebrief {
     # Windows-only themed debrief form the countdown overlay morphs into. Two
     # multiline fields (Debrief + Next) share the timer's dark/blue theme. On
@@ -818,8 +861,12 @@ function Show-WpfTimerDebrief {
     # after a successful post (ExitCode 0); a failed post keeps the form open
     # with the error so the user can retry. The "Start another?" choice offers
     # "Same item" (reuse the work item just debriefed), "Pick another" (return
-    # to the picker), and "Done". Returns { Cancelled; NextAction; PostResult }
-    # for the orchestrator, where NextAction is 'Done' / 'SameItem' / 'NewItem'.
+    # to the picker), and "Done". When -CloseAction is supplied, a "Work
+    # complete — resolve this story" checkbox renders above the Post button;
+    # when ticked, a successful comment post is followed by an invocation of
+    # CloseAction and its outcome is reflected in the status line. Returns
+    # { Cancelled; NextAction; PostResult; CloseRequested; CloseResult } for the
+    # orchestrator, where NextAction is 'Done' / 'SameItem' / 'NewItem'.
     #
     # The az post is synchronous on the dispatcher thread, so the spinner can't
     # truly animate during the call. The form forces a Render-priority dispatch
@@ -827,16 +874,22 @@ function Show-WpfTimerDebrief {
     # the call — feedback without spinning up a worker runspace.
     param(
         [Parameter(Mandatory)] [bool]        $Interrupted,
-        [Parameter(Mandatory)] [scriptblock] $SubmitAction
+        [Parameter(Mandatory)] [scriptblock] $SubmitAction,
+        [scriptblock] $CloseAction
     )
 
     Add-Type -AssemblyName PresentationFramework, WindowsBase, PresentationCore
 
     $formWidth = 360
 
-    $Script:WpfDebriefOutcome    = 'Cancelled'
-    $Script:WpfDebriefNextAction = 'Done'
-    $Script:WpfDebriefPostResult = $null
+    $Script:WpfDebriefOutcome        = 'Cancelled'
+    $Script:WpfDebriefNextAction     = 'Done'
+    $Script:WpfDebriefPostResult     = $null
+    $Script:WpfDebriefCloseRequested = $false
+    $Script:WpfDebriefCloseResult    = $null
+
+    $closeEnabled  = ($null -ne $CloseAction)
+    $checkboxLabel = "Work complete — resolve this story (sets State=$script:TimerCloseState)"
 
     $brushes = New-WpfBrushSet -ProgressColor $script:WpfColorProgress
 
@@ -927,6 +980,24 @@ function Show-WpfTimerDebrief {
         Margin                      = '0,0,0,12'
     }
     $vbox.Children.Add($nextBox) | Out-Null
+
+    # ---- Resolve checkbox (only when integration supplies a CloseAction) ----
+
+    $chkResolve = New-Object System.Windows.Controls.CheckBox -Property @{
+        Content    = $checkboxLabel
+        Foreground = $brushes.White
+        Background = $brushes.Bg
+        FontSize   = 11
+        Margin     = '0,0,0,10'
+        IsChecked  = $false
+        Visibility = [System.Windows.Visibility]::Collapsed
+    }
+
+    if ($closeEnabled) {
+        $chkResolve.Visibility = [System.Windows.Visibility]::Visible
+    }
+
+    $vbox.Children.Add($chkResolve) | Out-Null
 
     # ---- Post button row ----
 
@@ -1056,8 +1127,40 @@ function Show-WpfTimerDebrief {
             $Script:WpfDebriefPostResult = $postResult
             $Script:WpfDebriefOutcome    = 'Posted'
 
-            $statusText.Text      = 'Posted. Start another session?'
+            $wantsResolve = ($closeEnabled -and $chkResolve.IsChecked -eq $true)
+
+            if ($wantsResolve) {
+                $Script:WpfDebriefCloseRequested = $true
+
+                $statusText.Text = 'Resolving item...'
+                $spinner.Text.Visibility = [System.Windows.Visibility]::Visible
+                $spinner.Timer.Start()
+
+                $mainWin.Dispatcher.Invoke(
+                    [action]{},
+                    [System.Windows.Threading.DispatcherPriority]::Render
+                )
+
+                $closeResult = & $CloseAction
+
+                $spinner.Timer.Stop()
+                $spinner.Text.Visibility = [System.Windows.Visibility]::Collapsed
+
+                $Script:WpfDebriefCloseResult = $closeResult
+
+                $closeExit = Get-TimerResultExitCode -Result $closeResult
+                if ($closeExit -eq 0) {
+                    $statusText.Text = "Posted + Resolved (State=$script:TimerCloseState). Start another session?"
+                } else {
+                    $statusText.Foreground = $brushes.DarkRed
+                    $statusText.Text       = "Posted; resolve failed. Start another session?"
+                }
+            } else {
+                $statusText.Text = 'Posted. Start another session?'
+            }
+
             $postPanel.Visibility = [System.Windows.Visibility]::Collapsed
+            $chkResolve.Visibility = [System.Windows.Visibility]::Collapsed
             $askPanel.Visibility  = [System.Windows.Visibility]::Visible
         } else {
             $errText = if ($postResult -and $postResult.Error) {
@@ -1095,9 +1198,11 @@ function Show-WpfTimerDebrief {
     $cancelled = ($Script:WpfDebriefOutcome -ne 'Posted')
 
     $result = [PSCustomObject]@{
-        Cancelled  = $cancelled
-        NextAction = $Script:WpfDebriefNextAction
-        PostResult = $Script:WpfDebriefPostResult
+        Cancelled      = $cancelled
+        NextAction     = $Script:WpfDebriefNextAction
+        PostResult     = $Script:WpfDebriefPostResult
+        CloseRequested = $Script:WpfDebriefCloseRequested
+        CloseResult    = $Script:WpfDebriefCloseResult
     }
     return $result
 }
@@ -1114,7 +1219,10 @@ function az-Start-TimerSession {
     # debrief is collected via terminal Read-Host with a console posting
     # indicator and the same three-way choice via Read-TimerNextAction. A
     # "Same item" choice loops back straight to the countdown, skipping both
-    # the integration and item pickers.
+    # the integration and item pickers. When the chosen integration supplies
+    # a CloseItem, the WPF form shows a resolve checkbox and the terminal path
+    # prompts "Resolve this item now?" after a successful comment post; either
+    # path fires the state transition only when explicitly requested.
     #
     # UTF-8 encoding is applied so emoji glyphs render in terminals that
     # default to a non-UTF-8 codepage; restored on exit (including Ctrl-C).
@@ -1190,7 +1298,18 @@ function az-Start-TimerSession {
                     return $posted
                 }.GetNewClosure()
 
-                $debriefResult = Show-WpfTimerDebrief -Interrupted $countdownResult.Interrupted -SubmitAction $submitAction
+                $closeAction = $null
+                if ($null -ne $chosen.CloseItem) {
+                    $closeAction = {
+                        $closed = & $chosen.CloseItem -Id $pickedItem.Id
+                        return $closed
+                    }.GetNewClosure()
+                }
+
+                $debriefResult = Show-WpfTimerDebrief `
+                    -Interrupted  $countdownResult.Interrupted `
+                    -SubmitAction $submitAction `
+                    -CloseAction  $closeAction
 
                 if (-not $debriefResult.PostResult) {
                     $waveIcon = $script:TimerIconWave
@@ -1199,6 +1318,13 @@ function az-Start-TimerSession {
                 }
 
                 Write-TimerPostVerdict -Result $debriefResult.PostResult -Item $pickedItem -Integration $chosen
+
+                if ($debriefResult.CloseRequested) {
+                    Write-TimerResolveVerdict `
+                        -Result     $debriefResult.CloseResult `
+                        -Item       $pickedItem `
+                        -CloseState $script:TimerCloseState
+                }
 
                 $nextAction = $debriefResult.NextAction
 
@@ -1231,6 +1357,26 @@ function az-Start-TimerSession {
                     -ScriptBlock $postScript
 
                 Write-TimerPostVerdict -Result $commentResult -Item $pickedItem -Integration $chosen
+
+                $postExitCode = Get-TimerResultExitCode -Result $commentResult
+                if ($postExitCode -eq 0 -and $null -ne $chosen.CloseItem) {
+                    $wantsResolve = Read-TimerYesNo -Prompt "Resolve this item now? (sets State=$script:TimerCloseState)"
+                    if ($wantsResolve) {
+                        $closeScript = {
+                            $closed = & $chosen.CloseItem -Id $pickedItem.Id
+                            return $closed
+                        }.GetNewClosure()
+
+                        $closeResult = Invoke-WithSpinner `
+                            -Message "Resolving item $($pickedItem.Id)" `
+                            -ScriptBlock $closeScript
+
+                        Write-TimerResolveVerdict `
+                            -Result     $closeResult `
+                            -Item       $pickedItem `
+                            -CloseState $script:TimerCloseState
+                    }
+                }
 
                 $itemLabel  = "$($pickedItem.Id): $($pickedItem.Title)"
                 $nextAction = Read-TimerNextAction -ItemLabel $itemLabel
@@ -1304,4 +1450,9 @@ az-Register-TimerIntegration `
         param([Parameter(Mandatory)] [int] $Id)
         $hint = "View discussion: az-Open-WorkItemById $Id"
         return $hint
+    } `
+    -CloseItem   {
+        param([Parameter(Mandatory)] [int] $Id)
+        $result = Set-AzDevOpsWorkItemField -Id $Id -Fields @("System.State=$script:TimerCloseState")
+        return $result
     }


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #117 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | 0/5 |
| [Shell Parity](#shell-parity) | ✅ PowerShell-only |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/121#issuecomment-4569071954) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/121#issuecomment-4569092850) |
| 🛡️ Security Audit | ✅ PASS — no findings posted |
| 🧼 Clean-Code Engineer Review | ❌ REQUEST CHANGES (HIGH addressed in `1eab434`) — [View](https://github.com/jdschleicher/bashcuts/pull/121#issuecomment-4569079812) |
| ✅ Criteria Check | ✅ PASS (12/12 automated, 5 manual) — [View](https://github.com/jdschleicher/bashcuts/pull/121#issuecomment-4569118786) |
| 📚 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/121#issuecomment-4569108470) |
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

After a successful comment post, the new resolve flow gates on the integration declaring a `CloseItem` capability and the user opting in (WPF checkbox on Windows, terminal `[y/N]` prompt elsewhere). When both are true, `New-TimerCloseScript` builds a closure that invokes the integration's `CloseItem` — the built-in Azure DevOps integration maps it to `Set-AzDevOpsWorkItemField System.State=$script:TimerCloseState` (default `'Resolved'`) — and `Write-TimerResolveVerdict` reports the outcome distinctly from the post verdict.

```mermaid
flowchart TD
    Start([az-Start-TimerSession<br/>pre-existing entry])
    Post[AddComment posts debrief]
    PostOK{exit == 0?}
    PostFail([existing post-failure path<br/>form stays open / error printed])
    HasClose{integration.CloseItem<br/>defined?}
    Skip([post-only finish<br/>state unchanged])
    Plat{Test-WpfIsWindows?}
    Cbx["WPF resolve checkbox<br/>Work complete — resolve this story"]:::priv
    Term["Terminal Read-TimerYesNo<br/>Resolve this item now? [y/N]"]:::priv
    OptIn{user opted in?}
    MakeScript([New-TimerCloseScript<br/>builds closure]):::pub
    RunClose["closure invokes<br/>integration.CloseItem -Id Id"]
    AzDOMap["AzDO mapping:<br/>Set-AzDevOpsWorkItemField<br/>System.State=$script:TimerCloseState"]:::io
    Verdict([Write-TimerResolveVerdict<br/>reports state transition]):::pub
    Done([resolve outcome reported<br/>success or distinct failure])

    Start --> Post --> PostOK
    PostOK -- no --> PostFail
    PostOK -- yes --> HasClose
    HasClose -- no --> Skip
    HasClose -- yes --> Plat
    Plat -- Windows --> Cbx --> OptIn
    Plat -- macOS/Linux --> Term --> OptIn
    OptIn -- no --> Skip
    OptIn -- yes --> MakeScript
    MakeScript -.closure.-> RunClose --> AzDOMap --> Verdict --> Done

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
- Adds an optional `CloseItem` capability to the timer integration contract.
- On Windows, the debrief form renders a **"Work complete — resolve this story"** checkbox (only when the integration supplies `CloseItem`) above **Post Debrief**; ticking it transitions the work item after the comment posts.
- On macOS/Linux, the same trigger is a `Resolve this item now? [y/N]` prompt after a successful comment post; default **No**.
- The built-in Azure DevOps integration wires `CloseItem` to `Set-AzDevOpsWorkItemField -Fields System.State=$script:TimerCloseState` (default `'Resolved'`).
- Failed resolves are reported distinctly so the comment-posted-but-state-not-changed case is unambiguous.

## Issue
Closes #117

## Changes
- `powcuts_by_cli/pow_timer.ps1` — header doc + integration-contract doc updated; `$script:TimerCloseState = 'Resolved'` constant; `az-Register-TimerIntegration` gains optional `CloseItem`; new `Write-TimerResolveVerdict`; new `New-TimerCloseScript` helper (dedupes WPF/terminal close-closure); `Show-WpfTimerDebrief` gains `$CloseAction` param + resolve checkbox + post-close wiring + extended return shape (`CloseRequested`/`CloseResult`); orchestrator WPF + terminal branches wire the resolve flow; AzDO integration registers `CloseItem`.
- `README.md` — new "Closing the story when a session finishes the task" subsection under "The debrief"; `Register-TimerIntegration` example extended with the optional `-CloseItem` block.

## Test Plan
- [ ] **Windows happy path:** `Start-TimerSession -Minutes 1` → form shows the resolve checkbox; tick + Post → AzDO shows the item in **Resolved**, status reads `Posted + Resolved (State=Resolved)`.
- [ ] **Windows unchecked:** same flow, leave the box unchecked → comment posts, state unchanged.
- [ ] **Windows resolve-failure:** manually flip an item to Closed first, then run a session targeting it and tick the box → comment posts; status reads `Posted; resolve failed`.
- [ ] **macOS/Linux:** snake animation → terminal `Read-Host` debrief → `Resolve this item now? [y/N]` → `y` resolves the item; blank/`n` leaves it active.
- [ ] **No CloseItem integration:** register a stub integration without `-CloseItem` → checkbox/prompt are absent; post still works.

## Shell Parity
PowerShell-only — the timer/debrief feature has no `bashcuts_by_cli/` counterpart. Both PowerShell paths (Windows WPF + macOS/Linux terminal) are covered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWZtrU2qYn1Ht9btFfU933)_