### PR TITLE
Offer to create a parent Feature/Epic when the orphan option is chosen in az-New-AzDevOps creators

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For windows machines, the snippets are stored in an expected directory, so we ca
 
 > **Lost in the surface?** Run `az-help` (defined in `powcuts_by_cli/azdevops_help.ps1`) for an interactive `Out-ConsoleGridView` walkthrough that groups every `az-AzDevOps*` function by workflow phase (Onboarding → DailyRead → Create → MultiProject) and shows the order of operations + source / diagram / issue links for each function. `az-h<Tab>` lands directly on it.
 
-PowerShell shortcuts in `powcuts_by_cli/azdevops_*.ps1` (split across `azdevops_auth.ps1`, `azdevops_paths.ps1`, `azdevops_sync.ps1`, `azdevops_views.ps1`, `azdevops_find.ps1`, `azdevops_classification.ps1`, `azdevops_create_pickers.ps1`, `azdevops_create.ps1`, `azdevops_schema.ps1`, `azdevops_openers.ps1`) provide guided setup and work-item navigation against an Azure DevOps organization. Today this includes a guided `az-Connect-AzDevOps` first-run helper, a cached background sync (`az-Sync-AzDevOpsCache`, which also refreshes itself silently on shell open when the cache is stale), a list/open pair for items assigned to you (`az-Get-AzDevOpsAssigned`, `az-Open-Assigned`), the matching pair for items where you've been @-mentioned in discussion (`az-Get-AzDevOpsMentions`, `az-Open-Mention`), an open-any-item-by-id shortcut (`az-Open-WorkItemById`), an Epic→Feature→User Story tree view (`az-Show-Tree`, rendering the project's requirement-tier rows — `User Story` on Agile, `Product Backlog Item` on Scrum, `Requirement` on CMMI, `Issue` on Basic), a board-style group-by-State view of the same cached items (`az-Show-Board`), area- and iteration-path tree views (`az-Show-Areas`, `az-Show-Iterations`), an interactive Epic→Feature→Story drill-down picker (`az-Find-AzDevOpsWorkItem`), an interactive new-user-story creator with parent-feature, iteration, and area-path pickers (`az-New-AzDevOpsUserStory`), an interactive new-Feature creator one tier up (parent-Epic picker, area / iteration / priority / AC) with a hand-off prompt to spawn child stories (`az-New-AzDevOpsFeature`), a batch child-story creator that decomposes a Feature into 3-7 stories with a single area / iteration captured once and priority / story points carried forward across the loop (`az-New-AzDevOpsFeatureStories`), an interactive Task creator one tier down with a parent-User-Story picker (`az-New-Task`, also the child action when you select a Story in `az-Show-Tree` / `az-Show-Board`), and a per-org field-schema config (`az-Initialize-AzDevOpsSchema`, `az-Get-AzDevOpsSchema`, `az-Edit-AzDevOpsSchema`, `az-Test-AzDevOpsSchema`) that future schema-aware updates to the work-item commands consume.
+PowerShell shortcuts in `powcuts_by_cli/azdevops_*.ps1` (split across `azdevops_auth.ps1`, `azdevops_paths.ps1`, `azdevops_sync.ps1`, `azdevops_views.ps1`, `azdevops_find.ps1`, `azdevops_classification.ps1`, `azdevops_create_pickers.ps1`, `azdevops_create.ps1`, `azdevops_schema.ps1`, `azdevops_openers.ps1`) provide guided setup and work-item navigation against an Azure DevOps organization. Today this includes a guided `az-Connect-AzDevOps` first-run helper, a cached background sync (`az-Sync-AzDevOpsCache`, which also refreshes itself silently on shell open when the cache is stale), a list/open pair for items assigned to you (`az-Get-AzDevOpsAssigned`, `az-Open-Assigned`), the matching pair for items where you've been @-mentioned in discussion (`az-Get-AzDevOpsMentions`, `az-Open-Mention`), an open-any-item-by-id shortcut (`az-Open-WorkItemById`), an Epic→Feature→User Story tree view (`az-Show-Tree`, rendering the project's requirement-tier rows — `User Story` on Agile, `Product Backlog Item` on Scrum, `Requirement` on CMMI, `Issue` on Basic), a board-style group-by-State view of the same cached items (`az-Show-Board`), area- and iteration-path tree views (`az-Show-Areas`, `az-Show-Iterations`), an interactive Epic→Feature→Story drill-down picker (`az-Find-AzDevOpsWorkItem`), an interactive new-user-story creator with parent-feature, iteration, and area-path pickers (`az-New-AzDevOpsUserStory`), an interactive new-Feature creator one tier up (parent-Epic picker, area / iteration / priority / AC) with a hand-off prompt to spawn child stories (`az-New-AzDevOpsFeature`), a top-tier Epic creator with no parent picker (`az-New-AzDevOpsEpic`) — which the Story and Feature creators can also spawn inline from their orphan path (pick "no parent" and they offer to create the missing Feature/Epic and link to it in one flow), a batch child-story creator that decomposes a Feature into 3-7 stories with a single area / iteration captured once and priority / story points carried forward across the loop (`az-New-AzDevOpsFeatureStories`), an interactive Task creator one tier down with a parent-User-Story picker (`az-New-Task`, also the child action when you select a Story in `az-Show-Tree` / `az-Show-Board`), and a per-org field-schema config (`az-Initialize-AzDevOpsSchema`, `az-Get-AzDevOpsSchema`, `az-Edit-AzDevOpsSchema`, `az-Test-AzDevOpsSchema`) that future schema-aware updates to the work-item commands consume.
 
 ### Prerequisites
 
@@ -363,7 +363,9 @@ az-New-AzDevOpsUserStory `
     -NoOpen
 ```
 
-`-FeatureId 0` creates an orphan (no parent link). `-NoOpen` skips the browser launch and just echoes the new work-item URL — handy in scripts.
+`-FeatureId 0` creates an orphan (no parent link) with no prompt. `-NoOpen` skips the browser launch and just echoes the new work-item URL — handy in scripts.
+
+When you reach the parent-Feature picker interactively and pick `0` / cancel (orphan), the creator asks `Create a new parent Feature now? [y/N]` first. On **yes** it runs the full `az-New-AzDevOpsFeature` walk-through (which can itself chain up to a new Epic), then links your new Story to the Feature it just created — so you can build a fresh Epic → Feature → Story slice in one command. On **no/Enter** it creates the orphan exactly as before. (Passing `-FeatureId 0` explicitly still means "force orphan" and skips this prompt.)
 
 ### Creating a new Feature
 
@@ -385,7 +387,25 @@ az-New-AzDevOpsFeature `
     -NoChildStoriesPrompt
 ```
 
-`-ParentEpicId 0` creates an orphan (no parent link).
+`-ParentEpicId 0` creates an orphan (no parent link) with no prompt.
+
+Just like the user-story creator, picking `0` / cancel at the interactive parent-Epic picker prompts `Create a new parent Epic now? [y/N]`. On **yes** it runs `az-New-AzDevOpsEpic` and links your new Feature to it; on **no/Enter** it creates the orphan as before. (Explicit `-ParentEpicId 0` skips the prompt.)
+
+### Creating a new Epic
+
+`az-New-AzDevOpsEpic` is the top tier of the Epic → Feature → Story hierarchy, so it has **no parent picker** — Epics are root items. It mirrors `az-New-AzDevOpsFeature`'s walk-through otherwise (title / description / priority / acceptance criteria / iteration / area / tags / required fields), then creates the Epic and opens it in your browser. It returns the new Epic's `[int]` id, which is what makes it usable as the inline "create a parent Epic" target from `az-New-AzDevOpsFeature`'s orphan path. Story points and the child-stories hand-off are intentionally skipped — those belong to the lower tiers.
+
+```powershell
+az-New-AzDevOpsEpic                                # full interactive walk-through
+az-New-AzDevOpsEpic `
+    -Title              "Customer-impact analytics" `
+    -Description        "All customer-impact reporting work for FY26." `
+    -Priority           2 `
+    -AcceptanceCriteria "- Exec dashboard ships`n- Per-team rollups available" `
+    -Iteration          "My Project\Sprint 42" `
+    -Area               "My Project\My Team" `
+    -NoOpen
+```
 
 ### Batch-creating child stories under a Feature
 

--- a/powcuts_by_cli/azdevops_auth.ps1
+++ b/powcuts_by_cli/azdevops_auth.ps1
@@ -211,10 +211,24 @@ function New-AzDevOpsStepResult {
 
 
 function Read-AzDevOpsYesNo {
-    # Default-yes Y/n prompt used by Confirm-* steps that offer a remediation
-    # action. Returns $true when the user accepts (empty input or anything
-    # other than n/no), $false on explicit refusal.
-    param([Parameter(Mandatory)] [string] $Prompt)
+    # Y/n prompt used by Confirm-* steps that offer a remediation action.
+    # Default-yes: returns $true on empty input or anything other than n/no,
+    # $false on explicit refusal.
+    #
+    # -DefaultNo flips the default for prompts where declining is the safe
+    # choice (e.g. the orphan path's "Create a new parent Feature now?"): the
+    # hint becomes [y/N], empty input (Enter) means "no", and only an explicit
+    # y/yes returns $true.
+    param(
+        [Parameter(Mandatory)] [string] $Prompt,
+        [switch] $DefaultNo
+    )
+
+    if ($DefaultNo) {
+        $resp = Read-Host "    $Prompt [y/N]"
+        return ($resp -match '^(y|yes)$')
+    }
+
     $resp = Read-Host "    $Prompt [Y/n]"
     return -not ($resp -match '^(n|no)$')
 }

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -352,6 +352,47 @@ function Invoke-AzDevOpsCreateAndLink {
 }
 
 
+function Resolve-AzDevOpsOrphanParent {
+    # Shared orphan -> create-parent branch for az-New-AzDevOpsUserStory and
+    # az-New-AzDevOpsFeature. Call this only when the interactive parent picker
+    # returned 0 (orphan). It offers to create the missing parent inline; on
+    # yes it runs the supplied -CreateParent creator and returns the new parent
+    # id, on no/Enter it returns 0 so the child stays an orphan exactly as
+    # before. A creator that fails or returns no id also falls back to 0 with a
+    # clear yellow note - the caller then takes its normal orphan path, with no
+    # link attempt against a bogus id.
+    #
+    # -CreateParent is a scriptblock (not a function name) so the full
+    # interactive creator runs verbatim - the spawned Feature runs its own Epic
+    # picker, the spawned Epic runs its own prompts. The recursion terminates
+    # naturally at az-New-AzDevOpsEpic, which has no parent.
+    param(
+        [Parameter(Mandatory)] [string]      $ParentLabel,
+        [Parameter(Mandatory)] [scriptblock] $CreateParent
+    )
+
+    Write-Host ""
+    if (-not (Read-AzDevOpsYesNo -Prompt "Create a new parent $ParentLabel now?" -DefaultNo)) {
+        return 0
+    }
+
+    $created = & $CreateParent
+    $candidate = $created | Select-Object -Last 1
+
+    $parentId = 0
+    if ($null -ne $candidate) {
+        [int]::TryParse("$candidate", [ref]$parentId) | Out-Null
+    }
+
+    if ($parentId -le 0) {
+        Write-Host "No parent $ParentLabel was created - continuing with an orphan." -ForegroundColor Yellow
+        return 0
+    }
+
+    return $parentId
+}
+
+
 function az-New-AzDevOpsUserStory {
     [CmdletBinding()]
     param(
@@ -401,6 +442,12 @@ function az-New-AzDevOpsUserStory {
 
     if ($FeatureId -lt 0) {
         $FeatureId = Read-AzDevOpsFeaturePick -Hierarchy $hierarchy -ChildType 'USER_STORY'
+
+        if ($FeatureId -eq 0) {
+            $FeatureId = Resolve-AzDevOpsOrphanParent -ParentLabel 'Feature' -CreateParent {
+                az-New-AzDevOpsFeature -NoChildStoriesPrompt -NoOpen
+            }
+        }
     }
 
     $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'USER_STORY'
@@ -587,6 +634,12 @@ function az-New-AzDevOpsFeature {
 
     if ($ParentEpicId -lt 0) {
         $ParentEpicId = Read-AzDevOpsEpicPick -Hierarchy $hierarchy -ChildType 'FEATURE'
+
+        if ($ParentEpicId -eq 0) {
+            $ParentEpicId = Resolve-AzDevOpsOrphanParent -ParentLabel 'Epic' -CreateParent {
+                az-New-AzDevOpsEpic -NoOpen
+            }
+        }
     }
 
     $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'FEATURE'
@@ -634,6 +687,91 @@ function az-New-AzDevOpsFeature {
         }
     }
 
+    return $newId
+}
+
+
+function az-New-AzDevOpsEpic {
+    # Interactive Epic creator - the top tier of the Epic -> Feature -> Story
+    # hierarchy, so there's no parent picker (Epics are root items). Mirrors
+    # az-New-AzDevOpsFeature's UX otherwise: title / description / priority /
+    # acceptance criteria / iteration / area / tags / required fields. Story
+    # points and the child-stories hand-off are intentionally skipped - those
+    # belong to the lower tiers.
+    #
+    # Used both stand-alone and as the chained parent target when
+    # az-New-AzDevOpsFeature's orphan path offers to create a new Epic inline.
+    # Returns the new Epic's [int] id.
+    [CmdletBinding()]
+    param(
+        [string] $Title,
+        [string] $Description,
+        [int]    $Priority = -1,
+        [string] $AcceptanceCriteria,
+        [string] $Iteration,
+        [string] $Area,
+        [switch] $NoOpen
+    )
+
+    if (-not (Test-AzDevOpsCreateGate -CommandName 'az-New-AzDevOpsEpic')) {
+        return
+    }
+
+    if (-not $Title) {
+        $Title = Read-Host 'What is the title of the Epic?'
+    }
+    if (-not $Title) {
+        Write-Host "Title is required - aborting." -ForegroundColor Red
+        return
+    }
+
+    if (-not $PSBoundParameters.ContainsKey('Description')) {
+        $Description = Read-Host 'What is the description?'
+    }
+
+    if ($Priority -lt 1 -or $Priority -gt 4) {
+        $Priority = Resolve-AzDevOpsTypePriorityOrPrompt -Type 'EPIC'
+    }
+
+    if (-not $PSBoundParameters.ContainsKey('AcceptanceCriteria')) {
+        $AcceptanceCriteria = Read-AzDevOpsAcceptanceCriteria
+    }
+
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'EPIC'
+    if (-not $resolved.Ok) {
+        return
+    }
+    $Iteration = $resolved.Iteration
+    $Area = $resolved.Area
+
+    $tags = Resolve-AzDevOpsTypeTagsOrEmpty -Type 'EPIC'
+    $extraFields = Read-AzDevOpsRequiredFields     -Type 'EPIC'
+
+    $createArgs = @{
+        Type               = 'Epic'
+        Title              = $Title
+        Description        = $Description
+        Priority           = $Priority
+        AcceptanceCriteria = $AcceptanceCriteria
+        Iteration          = $Iteration
+        Area               = $Area
+        Tags               = $tags
+        ExtraFields        = $extraFields
+    }
+
+    $outcome = Invoke-AzDevOpsCreateAndLink `
+        -ChildLabel    'Epic' `
+        -ParentLabel   'Epic' `
+        -OrphanLabel   'Epic (top-level - no parent)' `
+        -CreateArgs    $createArgs `
+        -ParentId      0 `
+        -OpenInBrowser:(-not $NoOpen)
+
+    if (-not $outcome.Ok) {
+        return
+    }
+
+    $newId = $outcome.Id
     return $newId
 }
 


### PR DESCRIPTION
<!-- toc:start -->
## Contents

| Section | Status |
|---------|--------|
| [How it works](#how-it-works) | 📐 diagram |
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #119 |
| [Changes](#changes) | ✅ 4 files |
| [Test Plan](#test-plan) | ✅ 6 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4569257740) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4569262624) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4569254619) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4569262053) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4569267774) |
| 📚 Docs Check | ✅ CURRENT (run inline) |
| 📐 AzDO Diagrams | ✅ SYNCED (Diagrams 1, 7, 8, 12) |
<!-- toc:end -->
<!-- pr-diagram:start -->
## How it works

The two existing creators (`az-New-AzDevOpsUserStory`, `az-New-AzDevOpsFeature`) now route their picker's orphan result (`0`) through the new shared `Resolve-AzDevOpsOrphanParent` helper, which offers a default-No `[y/N]` prompt to create the missing parent inline. On yes it spawns the full interactive parent creator — a Feature for the Story, the new top-tier `az-New-AzDevOpsEpic` for the Feature — and links the child to the returned id; the chain terminates at the parentless Epic, and any failure falls back to the orphan path.

```mermaid
flowchart TD
    NewS([az-New-AzDevOpsUserStory]):::pub
    NewF([az-New-AzDevOpsFeature]):::pub
    NewEpic([az-New-AzDevOpsEpic]):::pub

    PickF{Feature picker<br/>returns 0?}
    PickE{Epic picker<br/>returns 0?}
    Resolve[Resolve-AzDevOpsOrphanParent]:::priv
    YN{"Create parent now? [y/N]<br/>Read-AzDevOpsYesNo -DefaultNo"}:::priv
    CrLink[Invoke-AzDevOpsCreateAndLink]:::priv
    Az["az boards work-item create<br/>+ relation add"]:::io
    Done([return new id])

    NewS --> PickF
    NewF --> PickE
    PickF -- id &gt; 0 / explicit 0 --> CrLink
    PickE -- id &gt; 0 / explicit 0 --> CrLink
    PickF -- picked 0 --> Resolve
    PickE -- picked 0 --> Resolve

    Resolve --> YN
    YN -- no / Enter / fail --> CrLink
    YN -. yes: spawn parent .-> NewF
    YN -. yes: spawn parent .-> NewEpic
    NewEpic --> CrLink

    CrLink --> Az --> Done

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
When the interactive parent picker returns "orphan" (`0`) in `az-New-AzDevOpsUserStory` / `az-New-AzDevOpsFeature`, the creator now offers to create the missing parent inline and link the child to it — so you can build a fresh Epic → Feature → Story slice in one command instead of creating orphans and re-parenting later. Adds a new top-tier `az-New-AzDevOpsEpic` creator to terminate the chain.

## Issue
Closes #119

## Changes
- **`powcuts_by_cli/azdevops_create.ps1`**
  - New `az-New-AzDevOpsEpic` — top-tier creator (no parent picker), mirrors `az-New-AzDevOpsFeature`'s UX, returns the new Epic `[int]` id.
  - New private helper `Resolve-AzDevOpsOrphanParent` — extracts the shared orphan→create-parent branch (CLAUDE.md "extract repeated branches"). Runs the full interactive parent creator via a scriptblock so the chain recurses naturally (Story → Feature → Epic) and terminates at Epic. A failed/no-id parent create falls back to the orphan path with a yellow note and no bogus link attempt.
  - Wired the orphan→create-parent branch into `az-New-AzDevOpsUserStory` (Feature parent) and `az-New-AzDevOpsFeature` (Epic parent). The picker — and therefore the new prompt — is only reached when no parent id was passed; explicit `-FeatureId 0` / `-ParentEpicId 0` still forces an orphan with no prompt.
- **`powcuts_by_cli/azdevops_auth.ps1`**
  - `Read-AzDevOpsYesNo` gains a `-DefaultNo` switch (`[y/N]`, Enter = no) so the create-parent prompt defaults to declining and preserves today's orphan behavior on Enter, while still using the named helper the issue called for.
- **`README.md`** — documents `az-New-AzDevOpsEpic` and the inline create-parent flow (inventory line, Story/Feature orphan notes, new "Creating a new Epic" section).
- **`docs/azure-devops-diagrams.md`** — synced Diagrams 1, 7, 8, and 12 for the new creator, the shared helper, and the orphan→create-parent flow.

**PowerShell-only** by design — the Azure DevOps work-item create surface has no bash equivalent (per issue).

## Test Plan
- [ ] `pwsh -NoProfile` parses `powcuts_by_cli/azdevops_create.ps1` and `azdevops_auth.ps1` with zero errors *(pwsh unavailable in CI container — brace-balance verified; run locally)*
- [ ] Fresh pwsh: `az-New-AzDevOpsUserStory`, pick `0` at the Feature picker → prompt `Create a new parent Feature now? [y/N]`; `y` runs the full Feature walk-through (can chain to Epic) and links the Story to it
- [ ] Same prompt, Enter/`n` → Story created as orphan as before
- [ ] `az-New-AzDevOpsFeature`, pick `0` at Epic picker, `y` → `az-New-AzDevOpsEpic` runs and the Feature links to the new Epic
- [ ] `az-New-AzDevOpsEpic` stand-alone → no parent picker, creates a root Epic, returns its id
- [ ] `az-New-AzDevOpsUserStory -FeatureId 0 -NoOpen` → orphan, no create-parent prompt

https://claude.ai/code/session_019EVg12o28YieiiwuAsY6cA