### PR TITLE
Skip the live auth smoke query in the az-New-AzDevOps* create gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ az-Connect-AzDevOps
 
 This walks through seven checks (Azure CLI present, `azure-devops` extension installed, env vars set, `az login` session active, `az devops` defaults configured, user-machine WIQL query files seeded, smoke `az boards query` succeeds) and prints a clear `READY` or `NOT READY` verdict at the end. It will offer to install the extension and run `az login` for you if either is missing.
 
-After `az-Connect-AzDevOps` reports `READY` once, later commands in the AzDevOps batch use the silent `az-Test-AzDevOpsAuth` check at startup to confirm the environment is still good before they hit the cache.
+After `az-Connect-AzDevOps` reports `READY` once, the read/sync commands (`az-Sync-AzDevOpsCache`, the schema commands) use the silent `az-Test-AzDevOpsAuth` check at startup to confirm the environment is still good before they hit the cache. The result is cached in-session for a few minutes so the check isn't repeated on every command. The `az-New-AzDevOps*` creators skip that live check entirely — they only confirm the `az` CLI is on PATH and let the `az boards work-item create` call itself surface any auth problem, so creating a work item makes no extra `az` round-trip beyond the create and parent-link.
 
 ### Customizing WIQL queries
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -216,7 +216,7 @@ Helpers used by every step:
 
 ## 3. `az-Test-AzDevOpsAuth` — silent diagnostic chain
 
-Used by callers (`az-Sync-AzDevOpsCache`, `az-New-AzDevOpsUserStory`) at the top of every command to bail early if the environment regressed. No I/O — pure boolean.
+Used by the read/sync callers (`az-Sync-AzDevOpsCache`, `az-Initialize-AzDevOpsSchema`, `az-Test-AzDevOpsSchema`) at the top of every command to bail early if the environment regressed via `Assert-AzDevOpsAuthOrAbort`. No I/O — pure boolean. The `az-New-AzDevOps*` creators deliberately opt out (`Test-AzDevOpsCreateGate` → `Assert-AzDevOpsAuthOrAbort -SkipLiveProbe`): they skip this live smoke query because their own `az boards work-item create` call is the authoritative auth check, so an upfront probe would be a redundant `az` round-trip.
 
 ```mermaid
 flowchart TD
@@ -388,7 +388,7 @@ Interactive walk-through with all-optional parameters: every prompt is skipped i
 
 ```mermaid
 flowchart TD
-    Start([az-New-AzDevOpsUserStory]) --> Auth{az-Test-AzDevOpsAuth}
+    Start([az-New-AzDevOpsUserStory]) --> Auth{Test-AzDevOpsCreateGate<br/>auth memo or az-CLI-present<br/>no live smoke query}
     Auth -- false --> Abort1([abort: 'Run az-Connect-AzDevOps'])
     Auth -- true --> Email{$env:AZ_USER_EMAIL set?}
     Email -- no --> Abort2([abort])
@@ -438,6 +438,8 @@ flowchart TD
     SP2 --> Done([return $newId])
 ```
 
+Auth gate: the create commands route through `Test-AzDevOpsCreateGate`, which calls `Assert-AzDevOpsAuthOrAbort -SkipLiveProbe`. Unlike `az-Sync-AzDevOpsCache` / the schema commands, the creators do **not** fire the live `az boards query` @Me smoke test up front — the `az boards work-item create` call that follows is itself the authoritative auth check, so a separate probe would be a redundant `az` round-trip. A valid in-session auth memo still short-circuits the gate; a stale memo only re-confirms the `az` CLI is on PATH (a local `Get-Command` lookup, no `az` process), and a genuinely-unauthed session surfaces the failure through the create's own `STEP FAILED` path.
+
 Picker fallback: if `iterations.json` / `areas.json` aren't in the cache yet (user upgraded but hasn't synced), `Read-AzDevOpsKindPick` calls `Invoke-AzDevOpsClassificationLive` and prints a one-line "(run az-Sync-AzDevOpsCache to make this instant)" hint.
 
 ---
@@ -448,7 +450,7 @@ Tier-one-up counterpart to `az-New-AzDevOpsUserStory`. Picks a parent Epic from 
 
 ```mermaid
 flowchart TD
-    Start([az-New-AzDevOpsFeature]) --> Auth{az-Test-AzDevOpsAuth}
+    Start([az-New-AzDevOpsFeature]) --> Auth{Test-AzDevOpsCreateGate<br/>auth memo or az-CLI-present<br/>no live smoke query}
     Auth -- false --> Abort1([abort])
     Auth -- true --> Email{$env:AZ_USER_EMAIL set?}
     Email -- no --> Abort2([abort])
@@ -507,7 +509,7 @@ Batch counterpart to `az-New-AzDevOpsUserStory`. Captures parent / area / iterat
 
 ```mermaid
 flowchart TD
-    Start([az-New-AzDevOpsFeatureStories -ParentId N]) --> Auth{az-Test-AzDevOpsAuth}
+    Start([az-New-AzDevOpsFeatureStories -ParentId N]) --> Auth{Test-AzDevOpsCreateGate<br/>auth memo or az-CLI-present<br/>no live smoke query}
     Auth -- false --> Abort1([abort: 'Run az-Connect-AzDevOps'])
     Auth -- true --> Email{$env:AZ_USER_EMAIL set?}
     Email -- no --> Abort2([abort])

--- a/powcuts_by_cli/azdevops_auth.ps1
+++ b/powcuts_by_cli/azdevops_auth.ps1
@@ -123,13 +123,15 @@ function Invoke-AzDevOpsSmokeQuery {
 
 
 # In-session auth memo. Assert-AzDevOpsAuthOrAbort is the prologue for every
-# az-New-AzDevOps* / az-Sync / schema command, and az-Test-AzDevOpsAuth proves
-# auth with a live `az boards query` @Me smoke test - a network round-trip on
-# the start of EVERY command. Once auth is proven we record the time and
-# short-circuit the re-check for AzDevOpsAuthMemoTtlMinutes. Success only:
-# failures are never memoized, so fixing auth and retrying re-checks instantly.
-# Bounded by a TTL (not session-forever) so a token that expires mid-session is
-# re-verified within the window rather than masked until a new shell.
+# az-Sync / schema command, where az-Test-AzDevOpsAuth proves auth with a live
+# `az boards query` @Me smoke test - a network round-trip on the start of those
+# commands. The az-New-AzDevOps* creators call the gate with -SkipLiveProbe, so
+# they never fire that smoke query (the create call that follows is their own
+# auth check). Once auth is proven we record the time and short-circuit the
+# re-check for AzDevOpsAuthMemoTtlMinutes. Success only: failures are never
+# memoized, so fixing auth and retrying re-checks instantly. Bounded by a TTL
+# (not session-forever) so a token that expires mid-session is re-verified
+# within the window rather than masked until a new shell.
 $script:AzDevOpsAuthOkAt = $null
 $script:AzDevOpsAuthMemoTtlMinutes = 10
 
@@ -178,9 +180,30 @@ function Assert-AzDevOpsAuthOrAbort {
     # auth is good. On failure, prints the standard "<command> aborted -
     # az-Test-AzDevOpsAuth returned false. Run az-Connect-AzDevOps." line and
     # returns $false so callers `if (-not (Assert-...)) { return }`.
-    param([Parameter(Mandatory)] [string] $CommandName)
+    #
+    # -SkipLiveProbe suppresses the live `az boards query` @Me smoke test for
+    # write commands (the az-New-AzDevOps* creators) where the create call that
+    # immediately follows is itself the authoritative auth check - a separate
+    # upfront probe is a redundant network round-trip there. With the switch a
+    # valid auth memo still short-circuits to $true; when the memo is stale the
+    # gate only confirms the az CLI is on PATH (a local Get-Command lookup, no
+    # az process) and trusts the create to surface any auth error via its own
+    # STEP FAILED path. Read/sync commands omit the switch and keep failing fast.
+    param(
+        [Parameter(Mandatory)] [string] $CommandName,
+        [switch] $SkipLiveProbe
+    )
 
     if (Test-AzDevOpsAuthMemoValid) {
+        return $true
+    }
+
+    if ($SkipLiveProbe) {
+        if (-not (Test-AzDevOpsCliPresent)) {
+            Write-Host "$CommandName aborted - az CLI not found on PATH. Run az-Connect-AzDevOps." -ForegroundColor Red
+            return $false
+        }
+
         return $true
     }
 

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -134,9 +134,15 @@ function Test-AzDevOpsCreateGate {
     # Auth + AZ_USER_EMAIL gate shared by every az-New-AzDevOps* creator.
     # Prints the abort message and returns $false on miss so callers can
     # short-circuit with a single `if (-not (Test-AzDevOpsCreateGate ...))`.
+    #
+    # Passes -SkipLiveProbe so the gate never fires the live `az boards query`
+    # @Me smoke test: for a create command the `az boards work-item create`
+    # call that follows is the authoritative auth check, so an upfront probe is
+    # a redundant az round-trip. A valid auth memo still short-circuits; a stale
+    # memo only re-confirms the az CLI is on PATH.
     param([Parameter(Mandatory)] [string] $CommandName)
 
-    if (-not (Assert-AzDevOpsAuthOrAbort -CommandName $CommandName)) {
+    if (-not (Assert-AzDevOpsAuthOrAbort -CommandName $CommandName -SkipLiveProbe)) {
         return $false
     }
 


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #123 |
| [Changes](#changes) | ✅ 4 files |
| [Test Plan](#test-plan) | 4 items (manual) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE (N/A — no bash files) — [View](#issuecomment-4602321134) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4602325708) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4602329346) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4602327697) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4602340876) |
| 📚 Docs Check | ✅ CURRENT (run inline — no orphan/dead refs) |
| 📐 AzDO Diagrams Check | ✅ CURRENT (this branch's delta in sync) |
<!-- toc:end -->

## Summary
The `az-New-AzDevOps*` creators (and the unplanned-work creators) opened with `Test-AzDevOpsCreateGate` → `Assert-AzDevOpsAuthOrAbort`, which fired a live `az boards query` (`...WHERE [System.AssignedTo] = @Me`) smoke test before any prompts whenever the 10-minute in-session auth memo was stale. For a *write* command that's a redundant network round-trip — the `az boards work-item create` call that follows is itself the authoritative auth check. This adds a `-SkipLiveProbe` switch so the create gate trusts the auth memo and otherwise only confirms the `az` CLI is on PATH (local `Get-Command`, no `az` process). Read/sync and schema commands keep their fail-fast smoke query.

Sibling of #102, which removed the redundant *classification* live call from the same create flow.

## Issue
Closes #123

## Changes
- `powcuts_by_cli/azdevops_auth.ps1` — added `-SkipLiveProbe` switch to `Assert-AzDevOpsAuthOrAbort`; refreshed the auth-memo comment block
- `powcuts_by_cli/azdevops_create.ps1` — `Test-AzDevOpsCreateGate` now passes `-SkipLiveProbe`, so every `az-New-AzDevOps*` creator + the unplanned-work creators inherit the no-probe behavior
- `docs/azure-devops-diagrams.md` — updated create-flow diagrams (7/8/9), the section-3 note, and added an auth-gate explanation under diagram 7
- `README.md` — clarified that the creators skip the live auth check

PowerShell-only (the create flow and auth gate have no bash counterpart).

## Test Plan
- [ ] Parse: `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/azdevops_auth.ps1',[ref]$null,[ref]$null)"` (and `azdevops_create.ps1`) — zero errors
- [ ] Fresh PowerShell terminal: seed the auth memo (run any AzDevOps read), then `az-New-AzDevOpsUserStory` — the `↳ az ...` echoes show only `az boards work-item create` (+ `relation add` if a parent is picked), **no** `az boards query @Me`
- [ ] After memo expiry (>10 min), `az-New-AzDevOpsUserStory` still makes no smoke query
- [ ] `az-Sync-AzDevOpsCache` **still** shows the `az boards query @Me` smoke check (fail-fast preserved)

https://claude.ai/code/session_019UkSrS7LygS51ZN6sxncfP