### PR TITLE
Add Summary + Business Value description prompts to az-New-AzDevOpsFeature and drop the AC prompt for Features and Epics

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,20 +373,19 @@ When you reach the parent-Feature picker interactively and pick `0` / cancel (or
 
 ### Creating a new Feature
 
-`az-New-AzDevOpsFeature` is the tier-one-up counterpart to the user-story creator. It walks you through title / description / priority / acceptance criteria, then offers an interactive picker for the parent Epic (active Epics pulled from `hierarchy.json`), the iteration, and the area path. Same `Out-ConsoleGridView` / Read-Host fallback rules. Story points are intentionally skipped — Features don't carry story points in the default Agile / Scrum templates.
+`az-New-AzDevOpsFeature` is the tier-one-up counterpart to the user-story creator. It walks you through title / description / priority, then offers an interactive picker for the parent Epic (active Epics pulled from `hierarchy.json`), the iteration, and the area path. Same `Out-ConsoleGridView` / Read-Host fallback rules. The description is built from two guided prompts — **Summary** and **Business Value** — each rendered as a bold heading in the work-item Description field. Story points and acceptance criteria are intentionally skipped — Features don't carry story points in the default Agile / Scrum templates, and acceptance criteria belong on the child User Stories.
 
 After it creates the Feature and links the chosen Epic, it asks `Add child stories now? [Y/n]`; on yes it hands off to `az-New-AzDevOpsFeatureStories -ParentId <newFeatureId>` with the same area / iteration pre-seeded so you can decompose the Feature into its child stories in the same flow. Pass `-NoChildStoriesPrompt` to skip the hand-off (useful in scripts).
 
 ```powershell
 az-New-AzDevOpsFeature                                  # full interactive walk-through
 az-New-AzDevOpsFeature `
-    -Title              "Customer impact dashboard" `
-    -Description        "Surface customer-impact rollups on the team home page." `
-    -Priority           2 `
-    -AcceptanceCriteria "- Rollup widget renders for all team members`n- Updates within 60s of new deploy" `
-    -ParentEpicId       1180 `
-    -Iteration          "My Project\Sprint 42" `
-    -Area               "My Project\My Team" `
+    -Title        "Customer impact dashboard" `
+    -Description  "Surface customer-impact rollups on the team home page." `
+    -Priority     2 `
+    -ParentEpicId 1180 `
+    -Iteration    "My Project\Sprint 42" `
+    -Area         "My Project\My Team" `
     -NoOpen `
     -NoChildStoriesPrompt
 ```
@@ -397,17 +396,16 @@ Just like the user-story creator, picking `0` / cancel at the interactive parent
 
 ### Creating a new Epic
 
-`az-New-AzDevOpsEpic` is the top tier of the Epic → Feature → Story hierarchy, so it has **no parent picker** — Epics are root items. It mirrors `az-New-AzDevOpsFeature`'s walk-through otherwise (title / description / priority / acceptance criteria / iteration / area / tags / required fields), then creates the Epic and opens it in your browser. It returns the new Epic's `[int]` id, which is what makes it usable as the inline "create a parent Epic" target from `az-New-AzDevOpsFeature`'s orphan path. Story points and the child-stories hand-off are intentionally skipped — those belong to the lower tiers.
+`az-New-AzDevOpsEpic` is the top tier of the Epic → Feature → Story hierarchy, so it has **no parent picker** — Epics are root items. It mirrors `az-New-AzDevOpsFeature`'s walk-through otherwise (title / description / priority / iteration / area / tags / required fields), then creates the Epic and opens it in your browser. It returns the new Epic's `[int]` id, which is what makes it usable as the inline "create a parent Epic" target from `az-New-AzDevOpsFeature`'s orphan path. Story points and the child-stories hand-off are intentionally skipped — those belong to the lower tiers.
 
 ```powershell
 az-New-AzDevOpsEpic                                # full interactive walk-through
 az-New-AzDevOpsEpic `
-    -Title              "Customer-impact analytics" `
-    -Description        "All customer-impact reporting work for FY26." `
-    -Priority           2 `
-    -AcceptanceCriteria "- Exec dashboard ships`n- Per-team rollups available" `
-    -Iteration          "My Project\Sprint 42" `
-    -Area               "My Project\My Team" `
+    -Title       "Customer-impact analytics" `
+    -Description "All customer-impact reporting work for FY26." `
+    -Priority    2 `
+    -Iteration   "My Project\Sprint 42" `
+    -Area        "My Project\My Team" `
     -NoOpen
 ```
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -448,7 +448,7 @@ Picker fallback: if `iterations.json` / `areas.json` aren't in the cache yet (us
 
 ## 8. `az-New-AzDevOpsFeature` — interactive Feature create + child-story hand-off
 
-Tier-one-up counterpart to `az-New-AzDevOpsUserStory`. Picks a parent Epic from the cached hierarchy, fills `title / description / priority / area / iteration / AC`, creates the Feature, links to the Epic, then asks "Add child stories now?" — on yes hands off to `az-New-AzDevOpsFeatureStories -ParentId $newFeatureId` with the captured `area / iteration` pre-seeded. Story points are intentionally skipped (Features don't carry story points in default Agile / Scrum templates).
+Tier-one-up counterpart to `az-New-AzDevOpsUserStory`. Picks a parent Epic from the cached hierarchy, fills `title / description (Summary + Business Value) / priority / area / iteration`, creates the Feature, links to the Epic, then asks "Add child stories now?" — on yes hands off to `az-New-AzDevOpsFeatureStories -ParentId $newFeatureId` with the captured `area / iteration` pre-seeded. Story points are intentionally skipped (Features don't carry story points in default Agile / Scrum templates).
 
 ```mermaid
 flowchart TD
@@ -461,15 +461,12 @@ flowchart TD
     Title -- no --> ReadTitle["Read-Host 'title'"]
     Title -- yes --> Desc{Description param?}
     ReadTitle --> Desc
-    Desc -- no --> ReadDesc["Read-Host 'description'"]
+    Desc -- no --> ReadDesc["Read-AzDevOpsFeatureDescription<br/>(Summary + Business Value prompts)"]
     Desc -- yes --> Prio{Priority 1-4?}
     ReadDesc --> Prio
     Prio -- no --> ReadPrio[Read-AzDevOpsPriority]
-    Prio -- yes --> AC{AC param?}
-    ReadPrio --> AC
-    AC -- no --> ReadAC[Read-AzDevOpsAcceptanceCriteria]
-    AC -- yes --> Epic{ParentEpicId >= 0?}
-    ReadAC --> Epic
+    Prio -- yes --> Epic{ParentEpicId >= 0?}
+    ReadPrio --> Epic
     Epic -- no --> PickEpic["Read-AzDevOpsEpicPick<br/>-> Read-AzDevOpsParentPick<br/>(active Epics from hierarchy.json)"]
     Epic -- yes --> Iter{Iteration param?}
     PickEpic --> Iter
@@ -829,6 +826,7 @@ graph LR
     Pts[Read-AzDevOpsStoryPoints]:::priv
     AC[Read-AzDevOpsAcceptanceCriteria]:::priv
     USDesc[Read-AzDevOpsUserStoryDescription]:::priv
+    FeatDesc[Read-AzDevOpsFeatureDescription]:::priv
     PFeat[Read-AzDevOpsFeaturePick]:::priv
     PEpic[Read-AzDevOpsEpicPick]:::priv
     PParent[Read-AzDevOpsParentPick]:::priv
@@ -1110,7 +1108,7 @@ graph LR
     NewF --> CGate
     NewF --> ReadH
     NewF --> Pri
-    NewF --> AC
+    NewF --> FeatDesc
     NewF --> PEpic
     NewF --> ResIA
     NewF --> CrLink

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -586,10 +586,11 @@ function az-New-Task {
 function az-New-AzDevOpsFeature {
     # Interactive Feature creator. Mirrors az-New-AzDevOpsUserStory's UX one
     # tier up the tree: pick a parent Epic from the cached hierarchy, fill
-    # title / description / priority / area / iteration / acceptance criteria,
-    # create the Feature, link it to the Epic. Story points are intentionally
-    # skipped - Features don't carry story points in the default Agile / Scrum
-    # templates.
+    # title / description (Summary + Business Value) / priority / area /
+    # iteration, create the Feature, link it to the Epic. Story points and
+    # acceptance criteria are intentionally skipped - Features don't carry
+    # story points in the default Agile / Scrum templates, and AC belongs on
+    # User Stories.
     #
     # Ends with an "Add child stories now?" hand-off via Read-AzDevOpsYesNo;
     # on yes calls az-New-AzDevOpsFeatureStories -ParentId $newFeatureId with
@@ -601,7 +602,6 @@ function az-New-AzDevOpsFeature {
         [string] $Title,
         [string] $Description,
         [int]    $Priority = -1,
-        [string] $AcceptanceCriteria,
         [int]    $ParentEpicId = -1,
         [string] $Iteration,
         [string] $Area,
@@ -627,15 +627,11 @@ function az-New-AzDevOpsFeature {
     }
 
     if (-not $PSBoundParameters.ContainsKey('Description')) {
-        $Description = Read-Host 'What is the description?'
+        $Description = Read-AzDevOpsFeatureDescription
     }
 
     if ($Priority -lt 1 -or $Priority -gt 4) {
         $Priority = Resolve-AzDevOpsTypePriorityOrPrompt -Type 'FEATURE'
-    }
-
-    if (-not $PSBoundParameters.ContainsKey('AcceptanceCriteria')) {
-        $AcceptanceCriteria = Read-AzDevOpsAcceptanceCriteria
     }
 
     if ($ParentEpicId -lt 0) {
@@ -659,15 +655,14 @@ function az-New-AzDevOpsFeature {
     $extraFields = Read-AzDevOpsRequiredFields     -Type 'FEATURE'
 
     $createArgs = @{
-        Type               = 'Feature'
-        Title              = $Title
-        Description        = $Description
-        Priority           = $Priority
-        AcceptanceCriteria = $AcceptanceCriteria
-        Iteration          = $Iteration
-        Area               = $Area
-        Tags               = $tags
-        ExtraFields        = $extraFields
+        Type        = 'Feature'
+        Title       = $Title
+        Description = $Description
+        Priority    = $Priority
+        Iteration   = $Iteration
+        Area        = $Area
+        Tags        = $tags
+        ExtraFields = $extraFields
     }
 
     $outcome = Invoke-AzDevOpsCreateAndLink `
@@ -701,9 +696,9 @@ function az-New-AzDevOpsEpic {
     # Interactive Epic creator - the top tier of the Epic -> Feature -> Story
     # hierarchy, so there's no parent picker (Epics are root items). Mirrors
     # az-New-AzDevOpsFeature's UX otherwise: title / description / priority /
-    # acceptance criteria / iteration / area / tags / required fields. Story
-    # points and the child-stories hand-off are intentionally skipped - those
-    # belong to the lower tiers.
+    # iteration / area / tags / required fields. Story points, acceptance
+    # criteria, and the child-stories hand-off are intentionally skipped -
+    # those belong to the lower tiers.
     #
     # Used both stand-alone and as the chained parent target when
     # az-New-AzDevOpsFeature's orphan path offers to create a new Epic inline.
@@ -713,7 +708,6 @@ function az-New-AzDevOpsEpic {
         [string] $Title,
         [string] $Description,
         [int]    $Priority = -1,
-        [string] $AcceptanceCriteria,
         [string] $Iteration,
         [string] $Area,
         [switch] $NoOpen
@@ -739,10 +733,6 @@ function az-New-AzDevOpsEpic {
         $Priority = Resolve-AzDevOpsTypePriorityOrPrompt -Type 'EPIC'
     }
 
-    if (-not $PSBoundParameters.ContainsKey('AcceptanceCriteria')) {
-        $AcceptanceCriteria = Read-AzDevOpsAcceptanceCriteria
-    }
-
     $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'EPIC'
     if (-not $resolved.Ok) {
         return
@@ -754,15 +744,14 @@ function az-New-AzDevOpsEpic {
     $extraFields = Read-AzDevOpsRequiredFields     -Type 'EPIC'
 
     $createArgs = @{
-        Type               = 'Epic'
-        Title              = $Title
-        Description        = $Description
-        Priority           = $Priority
-        AcceptanceCriteria = $AcceptanceCriteria
-        Iteration          = $Iteration
-        Area               = $Area
-        Tags               = $tags
-        ExtraFields        = $extraFields
+        Type        = 'Epic'
+        Title       = $Title
+        Description = $Description
+        Priority    = $Priority
+        Iteration   = $Iteration
+        Area        = $Area
+        Tags        = $tags
+        ExtraFields = $extraFields
     }
 
     $outcome = Invoke-AzDevOpsCreateAndLink `

--- a/powcuts_by_cli/azdevops_create_pickers.ps1
+++ b/powcuts_by_cli/azdevops_create_pickers.ps1
@@ -138,6 +138,39 @@ function Read-AzDevOpsUserStoryDescription {
 }
 
 
+function Read-AzDevOpsFeatureDescription {
+    # Builds the Feature description from two required clauses - Summary and
+    # Business Value - each under a bold HTML heading so they render as bold
+    # headings in the AzDO Description field (which stores HTML). Mirrors
+    # Read-AzDevOpsUserStoryDescription: each clause is required (re-prompts
+    # until non-empty) and the two are joined with '<br/><br/>' so they render
+    # on separate lines: "<b>Summary</b> <text>" / "<b>Business Value</b> <text>".
+    $summaryHeading       = '<b>Summary</b>'
+    $businessValueHeading = '<b>Business Value</b>'
+
+    $summary = ''
+    while (-not $summary) {
+        $summary = (Read-Host 'Summary').Trim()
+    }
+
+    $businessValue = ''
+    while (-not $businessValue) {
+        $businessValue = (Read-Host 'Business Value').Trim()
+    }
+
+    $clauseBreak = '<br/><br/>'
+
+    $clauses = @(
+        "$summaryHeading $summary"
+        "$businessValueHeading $businessValue"
+    )
+
+    $description = $clauses -join $clauseBreak
+
+    return $description
+}
+
+
 function Test-AzDevOpsAreaPathMatch {
     # Returns $true when $CandidatePath equals any element of $AllowedPaths
     # exactly OR is a sub-path of one (matches at backslash boundary). Path


### PR DESCRIPTION

## Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #133 |
| [Changes](#changes) | ✅ 4 files |
| [Shell parity](#shell-parity) | ✅ PowerShell-only |
| [Test Plan](#test-plan) | ✅ 5 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4625644223) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4625649325) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4625653731) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4625654702) |
| ✅ Criteria Check | ✅ PASS (7/7, 2 deferred) — [View](#issuecomment-4625669146) |

<!-- pr-diagram:start -->
## How it works

This PR adds one new private helper, `Read-AzDevOpsFeatureDescription`, which replaces the freeform description `Read-Host` in `az-New-AzDevOpsFeature` with a guided two-clause prompt (Summary + Business Value, each required, joined under bold HTML headings). The same change drops the Acceptance-Criteria prompt from both `az-New-AzDevOpsFeature` and `az-New-AzDevOpsEpic` — AC now lives only on User Stories — so both creators feed a `$createArgs` table that no longer carries an `AcceptanceCriteria` field before handing off to the shared `Invoke-AzDevOpsCreateAndLink`.

```mermaid
flowchart TD
    Feature([az-New-AzDevOpsFeature]):::pub
    Epic([az-New-AzDevOpsEpic]):::pub

    ReadDesc[Read-AzDevOpsFeatureDescription]:::priv
    SummaryPrompt["prompt Summary<br/>(required, re-prompt)"]
    ValuePrompt["prompt Business Value<br/>(required, re-prompt)"]
    BuildHtml["join under bold headings<br/>&lt;b&gt;Summary&lt;/b&gt; ... &lt;br/&gt;&lt;br/&gt; &lt;b&gt;Business Value&lt;/b&gt; ..."]

    DroppedAC{{"AC prompt removed<br/>Read-AzDevOpsAcceptanceCriteria"}}:::dropped

    Args["build $createArgs<br/>(no AcceptanceCriteria field)"]
    CreateLink[Invoke-AzDevOpsCreateAndLink]:::io

    Feature --> ReadDesc
    ReadDesc --> SummaryPrompt --> ValuePrompt --> BuildHtml
    BuildHtml -. description .-> Args

    Feature -. AC step deleted .-> DroppedAC
    Epic -. AC step deleted .-> DroppedAC

    Epic --> Args
    Args --> CreateLink

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
    classDef dropped fill:#4a1f1f,stroke:#c06060,color:#fff,stroke-dasharray:4 3
```
<!-- pr-diagram:end -->

## Summary
Gives the Azure DevOps Feature creator a guided, structured description — a required **Summary** and **Business Value** prompt, each rendered under a bold HTML heading — mirroring how `Read-AzDevOpsUserStoryDescription` guides User Stories with `As a… / I want… / so that…`. Also removes the Acceptance Criteria prompt from Features and Epics, where it doesn&#39;t belong (AC stays on User Stories).

## Issue
Closes #133

## Changes
- **`powcuts_by_cli/azdevops_create_pickers.ps1`** — new `Read-AzDevOpsFeatureDescription`: prompts `Summary` then `Business Value` (both required, re-prompt until non-empty), joins them with `<br/><br/>` under named bold-heading locals so the result renders as:
  ```
  <b>Summary</b> <br/><br/><b>Business Value</b> 
  ```
- **`powcuts_by_cli/azdevops_create.ps1`**
  - `az-New-AzDevOpsFeature` — calls `Read-AzDevOpsFeatureDescription` instead of the freeform `Read-Host &#39;What is the description?&#39;`; removed the `-AcceptanceCriteria` param, its prompt, and its `$createArgs` field; docstring updated.
  - `az-New-AzDevOpsEpic` — removed the `-AcceptanceCriteria` param, its prompt, and its `$createArgs` field; docstring updated. Epic description prompt unchanged (plain `Read-Host`).
  - User Story and `az-New-AzDevOpsFeatureStories` batch flows keep their AC prompt unchanged.

## Shell parity
**PowerShell-only.** The Feature/Epic create flow lives only in `powcuts_by_cli/`; the bash `.az_bashcuts` has no Feature/Epic creator (only `az-create-userstory`), so there is no bash counterpart to update.

## Test Plan
- [ ] `pwsh` parses both changed `.ps1` files with zero errors
- [ ] `. ./powcuts_by_cli/azdevops_create_pickers.ps1; Read-AzDevOpsFeatureDescription` → entering a summary and a business value returns `<b>Summary</b> <br/><br/><b>Business Value</b> `; blank input re-prompts
- [ ] `az-New-AzDevOpsFeature` shows Summary + Business Value prompts and **no** Acceptance Criteria prompt; created Feature&#39;s Description renders both headings bold in the AzDO web UI
- [ ] `az-New-AzDevOpsEpic` shows **no** Acceptance Criteria prompt; description prompt unchanged
- [ ] `az-New-AzDevOpsUserStory` still prompts `As a / I want / so that` and Acceptance Criteria (unchanged)

https://claude.ai/code/session_01U5eY49Hx1ynyDzRyFmnL2Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5eY49Hx1ynyDzRyFmnL2Z)_