### PR TITLE
Add newly-created items to hierarchy.json immediately after az-New-AzDevOps* create

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -849,6 +849,7 @@ graph LR
     CGate[Test-AzDevOpsCreateGate]:::priv
     ResIA[Resolve-AzDevOpsIterationArea]:::priv
     CrLink[Invoke-AzDevOpsCreateAndLink]:::priv
+    AddHier[Add-AzDevOpsHierarchyCacheItem]:::priv
 
     %% Multi-project resolver layer (azdevops_projects.ps1)
     MapDef[Test-AzDevOpsProjectMapDefined]:::priv
@@ -1140,6 +1141,7 @@ graph LR
     ResIA --> PKind
     CrLink --> InvCreate --> NewWI --> AzJson
     CrLink --> InvLink --> AddRel --> AzJson
+    CrLink --> AddHier --> WriteFile
 
     %% Unplanned work sessions
     StartUW --> CGate

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -364,7 +364,13 @@ function Add-AzDevOpsHierarchyCacheItem {
         }
 
         $updated = @($existing) + $newRow
-        $json = ConvertTo-Json -InputObject @($updated) -Depth 10 -AsArray
+
+        # Match the hierarchy dataset's on-disk depth (Get-AzDevOpsSyncDatasets
+        # sets JsonDepth = 20) so an appended row serializes identically to a
+        # synced one - the flat id+fields shape needs far less, but aligning the
+        # value keeps the two writers from drifting.
+        $hierarchyJsonDepth = 20
+        $json = ConvertTo-Json -InputObject @($updated) -Depth $hierarchyJsonDepth -AsArray
 
         if (Get-Command New-AzDevOpsDirectoryIfMissing -ErrorAction SilentlyContinue) {
             New-AzDevOpsDirectoryIfMissing -Path $paths.Dir

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -365,11 +365,12 @@ function Add-AzDevOpsHierarchyCacheItem {
 
         $updated = @($existing) + $newRow
 
-        # Match the hierarchy dataset's on-disk depth (Get-AzDevOpsSyncDatasets
-        # sets JsonDepth = 20) so an appended row serializes identically to a
-        # synced one - the flat id+fields shape needs far less, but aligning the
-        # value keeps the two writers from drifting.
-        $hierarchyJsonDepth = 20
+        # Match the hierarchy dataset's on-disk depth. Its descriptor in
+        # Get-AzDevOpsSyncDatasets sets no JsonDepth, so the sync writes it at
+        # Invoke-AzDevOpsAzDataset's default of 10; an appended row therefore
+        # serializes identically to a synced one. The flat id+fields shape needs
+        # far less, but aligning the value keeps the two writers from drifting.
+        $hierarchyJsonDepth = 10
         $json = ConvertTo-Json -InputObject @($updated) -Depth $hierarchyJsonDepth -AsArray
 
         if (Get-Command New-AzDevOpsDirectoryIfMissing -ErrorAction SilentlyContinue) {

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -292,6 +292,94 @@ function Resolve-AzDevOpsIterationArea {
 }
 
 
+function Add-AzDevOpsHierarchyCacheItem {
+    # Append a freshly-created work item to the local hierarchy.json cache so
+    # follow-on commands in the same session (Test-AzDevOpsParentIsFeature, the
+    # Epic / Feature / Story parent pickers, az-Show-Tree) can see it without
+    # waiting for the next az-Sync-AzDevOpsCache. The row is written in the same
+    # raw `az boards query` shape the sync emits - a top-level `id` plus a
+    # `fields` object - so ConvertFrom-AzDevOpsHierarchyItem reads it back
+    # unchanged.
+    #
+    # Best-effort by design: a missing / empty / unparseable cache, or any write
+    # failure, is swallowed (logged when the sync logger is loaded) so it never
+    # aborts the create that just succeeded. The next full sync overwrites
+    # hierarchy.json wholesale, so a transient skip here self-heals. Re-adding an
+    # id that is already present is a no-op.
+    #
+    # State defaults to 'New' (the stock initial state across Agile / Scrum /
+    # CMMI); Basic projects open as 'To Do' but no cache consumer nests on state,
+    # so the next sync reconciles it harmlessly. ParentId of 0 writes a null
+    # System.Parent - the parentless shape the sync emits for top-level Epics.
+    param(
+        [Parameter(Mandatory)] [int]    $Id,
+        [Parameter(Mandatory)] [string] $Type,
+        [Parameter(Mandatory)] [string] $Title,
+        [string] $State = 'New',
+        [string] $Iteration,
+        [string] $AreaPath,
+        [int]    $ParentId = 0
+    )
+
+    try {
+        $paths = Get-AzDevOpsCachePaths
+        $path  = $paths.Hierarchy
+
+        $existing = @()
+        if (Test-Path -LiteralPath $path) {
+            $raw = Get-Content -LiteralPath $path -Raw
+            if ($raw -and $raw.Trim()) {
+                $parsed = $raw | ConvertFrom-Json
+                if ($null -ne $parsed) {
+                    $existing = @($parsed)
+                }
+            }
+        }
+
+        foreach ($row in $existing) {
+            if ([int]$row.id -eq $Id) {
+                return
+            }
+        }
+
+        $parentValue = if ($ParentId -gt 0) {
+            $ParentId
+        } else {
+            $null
+        }
+
+        $fields = [ordered]@{
+            'System.Id'            = $Id
+            'System.WorkItemType'  = $Type
+            'System.State'         = $State
+            'System.Title'         = $Title
+            'System.IterationPath' = $Iteration
+            'System.AreaPath'      = $AreaPath
+            'System.Parent'        = $parentValue
+        }
+
+        $newRow = [PSCustomObject]@{
+            id     = $Id
+            fields = [PSCustomObject]$fields
+        }
+
+        $updated = @($existing) + $newRow
+        $json = ConvertTo-Json -InputObject @($updated) -Depth 10 -AsArray
+
+        if (Get-Command New-AzDevOpsDirectoryIfMissing -ErrorAction SilentlyContinue) {
+            New-AzDevOpsDirectoryIfMissing -Path $paths.Dir
+        }
+
+        Write-AzDevOpsCacheFile -Path $path -Content $json
+    }
+    catch {
+        if (Get-Command Write-AzDevOpsSyncLog -ErrorAction SilentlyContinue) {
+            Write-AzDevOpsSyncLog "hierarchy cache append skipped for $Id : $($_.Exception.Message)"
+        }
+    }
+}
+
+
 function Invoke-AzDevOpsCreateAndLink {
     # Wraps the create -> parent-link -> echo URL tail shared by every
     # az-New-AzDevOps* creator: az-New-AzDevOpsUserStory, az-New-AzDevOpsFeature,
@@ -304,6 +392,14 @@ function Invoke-AzDevOpsCreateAndLink {
     # User Story...", "Linking story 5001 to parent Feature 1240..."), so the
     # existing UX is preserved verbatim - the helper only consolidates the
     # control flow.
+    #
+    # On success the new item is appended to hierarchy.json via
+    # Add-AzDevOpsHierarchyCacheItem so a chained child create (e.g. the Feature
+    # -> "Add child stories now?" hand-off, or a standalone
+    # az-New-AzDevOpsUserStory -FeatureId <newId>) finds the parent in the cache
+    # instead of failing the hierarchy lookup. The recorded System.Parent
+    # reflects the actual server link: the parent id only when the link
+    # succeeded, null otherwise.
     param(
         [Parameter(Mandatory)] [string]    $ChildLabel,
         [Parameter(Mandatory)] [string]    $ParentLabel,
@@ -331,6 +427,7 @@ function Invoke-AzDevOpsCreateAndLink {
     $newUrl = $createResult.Url
     Write-Host "OK Created $ChildLabel $newId" -ForegroundColor Green
 
+    $linkedParentId = 0
     if ($ParentId -gt 0) {
         Write-Host "Linking $OrphanLabel $newId to parent $ParentLabel $ParentId..." -ForegroundColor Cyan
         $linkResult = Invoke-AzDevOpsParentLink -Id $newId -ParentId $ParentId
@@ -340,11 +437,26 @@ function Invoke-AzDevOpsCreateAndLink {
         }
         else {
             Write-Host "OK Linked $newId -> $ParentLabel $ParentId" -ForegroundColor Green
+            $linkedParentId = $ParentId
         }
     }
     else {
         Write-Host "(no parent linked - orphan $OrphanLabel)" -ForegroundColor Yellow
     }
+
+    $createdType = if ($CreateArgs.ContainsKey('Type')) {
+        [string]$CreateArgs.Type
+    } else {
+        'User Story'
+    }
+
+    Add-AzDevOpsHierarchyCacheItem `
+        -Id        $newId `
+        -Type      $createdType `
+        -Title     ([string]$CreateArgs.Title) `
+        -Iteration ([string]$CreateArgs.Iteration) `
+        -AreaPath  ([string]$CreateArgs.Area) `
+        -ParentId  $linkedParentId
 
     if ($newUrl) {
         Write-Host "URL: $newUrl" -ForegroundColor Cyan


### PR DESCRIPTION
<!-- pr-diagram:start -->
## How it works

Every `az-New-AzDevOps*` creator funnels through the shared `Invoke-AzDevOpsCreateAndLink` tail. This PR adds a best-effort step at the end of that tail: after the work item is created (and parent-linked, if requested), the new private helper `Add-AzDevOpsHierarchyCacheItem` appends a raw `{ id, fields }` row to `hierarchy.json` via `Write-AzDevOpsCacheFile`. The cache mtime change invalidates the memoized parse, so a chained child-create (Feature -> "Add child stories now?" -> `az-New-AzDevOpsFeatureStories`, or a standalone `az-New-AzDevOpsUserStory -FeatureId <newId>`) re-reads the cache and finds the just-created parent instead of failing the hierarchy lookup.

```mermaid
flowchart TD
    Creators([az-New-AzDevOps Epic / Feature / UserStory / Task]):::pub
    Tail[Invoke-AzDevOpsCreateAndLink]:::priv

    Create["Invoke-AzDevOpsCreate<br/>(az boards work-item create)"]:::io
    LinkGate{ParentId &gt; 0?}
    Link["Invoke-AzDevOpsParentLink"]:::io
    LinkOk{link succeeded?}
    SetParent[linkedParentId = ParentId]:::priv
    NullParent[linkedParentId = 0 -> null]:::priv

    Append[Add-AzDevOpsHierarchyCacheItem]:::priv
    DupGate{id already<br/>in cache?}
    BuildRow["build raw id+fields row<br/>(System.Id/Type/State/Title/<br/>Iteration/Area/Parent)"]:::priv
    Cache[(hierarchy.json)]:::io
    Write["Write-AzDevOpsCacheFile<br/>(mtime bump -> parse invalidated)"]:::io

    Chained([chained child-create<br/>finds parent in cache]):::pub

    Creators --> Tail --> Create --> LinkGate
    LinkGate -- yes --> Link --> LinkOk
    LinkOk -- yes --> SetParent --> Append
    LinkOk -- no --> NullParent --> Append
    LinkGate -- no --> NullParent

    Append --> DupGate
    DupGate -- yes --> Append
    DupGate -- no --> BuildRow --> Write --> Cache
    Cache -.next read.-> Chained

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

`az-New-AzDevOps*` creators wrote the new work item to Azure DevOps but never updated the local `hierarchy.json` cache (only `az-Sync-AzDevOpsCache` does). A just-created item was therefore invisible to any follow-on command that reads the cache — most visibly the `az-New-AzDevOpsFeature` → &#34;Add child stories now?&#34; → `az-New-AzDevOpsFeatureStories -ParentId ` hand-off, which aborted with *&#34;ParentId X not found in hierarchy.json&#34;*.

This adds a best-effort `Add-AzDevOpsHierarchyCacheItem` helper that appends the new item to `hierarchy.json` in the same raw `az boards query` shape the sync emits, called from the shared `Invoke-AzDevOpsCreateAndLink` tail so all four creators (Epic, Feature, User Story, Task) seed the cache. The cache mtime change invalidates the memoized parse, so the chained child-create re-reads and finds the parent within the same session.

## Issue
Closes #131

## Changes
- `powcuts_by_cli/azdevops_create.ps1`:
  - New private helper `Add-AzDevOpsHierarchyCacheItem` — appends a raw `{ id, fields }` row (`System.Id/WorkItemType/State/Title/IterationPath/AreaPath/Parent`); idempotent; best-effort (missing/empty/corrupt cache or write failure is swallowed so the create never aborts).
  - `Invoke-AzDevOpsCreateAndLink` now calls the helper after a successful create, recording `System.Parent` from the **actual** server link (parent id only when the link succeeded, null otherwise).

PowerShell-only — bash `.az_bashcuts` has no hierarchy cache, so there is nothing to mirror.

## Test Plan
- [ ] `az-Sync-AzDevOpsCache` once to establish a baseline cache
- [ ] `az-New-AzDevOpsFeature` → create → answer **y** to &#34;Add child stories now?&#34; — batch loop starts instead of &#34;ParentId X not found in hierarchy.json&#34;
- [ ] In the same shell, `az-New-AzDevOpsUserStory -FeatureId ` links cleanly
- [ ] `az-Show-Tree` nests the new Feature/Story under the right parent before any re-sync
- [ ] Edge: remove `hierarchy.json`, run `az-New-AzDevOpsEpic` — create still succeeds, cache is seeded, no error
- [ ] PowerShell parse clean (pwsh was unavailable in the build environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_0144YTU9CR2WgsqX8Lpmih5h)_