### PR TITLE
Add team @-mention tagging to unplanned-work debriefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ Reads the day's local ledger (kept under the AzDO cache dir so total time can be
 
 ### Tagging teammates
 
-Set `$env:AZ_DEBRIEF_TEAM` to a `;`-separated list of teammate emails (names work too) to make people taggable from the debrief flow:
+Set `$env:AZ_DEBRIEF_TEAM` to a `;`-separated list of teammate emails (names work too) to make people taggable from the debrief flow. Commas also work as separators, so avoid them inside a value (use emails, which never contain a comma):
 
 ```powershell
 $env:AZ_DEBRIEF_TEAM = 'alice@example.com;bob@example.com'

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Add any of these to your PowerShell `$profile` to enable additional features:
 $env:AZ_USER_EMAIL = 'user@example.com'   # enables accurate mentions WIQL
 $env:AZ_AREA       = 'My Project\My Team' # default area path for hierarchy queries
 $env:AZ_ITERATION  = 'My Project\Sprint 42' # default iteration for work item creation
+$env:AZ_DEBRIEF_TEAM = 'alice@example.com;bob@example.com' # teammates taggable in unplanned-work debriefs
 $env:BASHCUTS_NO_SPINNER = '1'            # opt out of the az-call loading spinner
 ```
 
@@ -597,4 +598,15 @@ New-UnplannedWorkDebrief -Date 2026-05-19
 ```
 
 Reads the day's local ledger (kept under the AzDO cache dir so total time can be summed — AzDO doesn't store per-session minutes), prints the per-Task breakdown with total time, and on confirm posts a roll-up comment on the daily story.
+
+### Tagging teammates
+
+Set `$env:AZ_DEBRIEF_TEAM` to a `;`-separated list of teammate emails (names work too) to make people taggable from the debrief flow:
+
+```powershell
+$env:AZ_DEBRIEF_TEAM = 'alice@example.com;bob@example.com'
+az-Sync-UnplannedTeam   # resolve the roster to Azure DevOps identities and cache it
+```
+
+`az-Sync-UnplannedTeam` resolves each entry to an Azure DevOps identity (display name + email + identity id) via the identities API and caches it under the AzDO cache dir next to the per-day ledger — re-run it whenever you change the env var. Both debriefs (the per-firefight `Start-UnplannedWork` stop and the `New-UnplannedWorkDebrief` roll-up) then ask **"Tag teammate(s) on this debrief?"**. Answer yes and you get a type-to-filter picker showing each teammate's **name and email** so you can confirm the right person; the ones you pick are added to the posted comment as real Azure DevOps `@`-mentions, so they're notified. Tagging is always optional — pick nobody (or skip the prompt) and the debrief posts exactly as before.
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -25,7 +25,7 @@ How the public surface, the local cache, and the `az` CLI relate. Read-only cons
 flowchart LR
     subgraph User["User session ($profile)"]
         Profile["powcuts_home.ps1<br/>dot-sources azdevops_*.ps1"]
-        EnvVars["$env:AZ_USER_EMAIL<br/>$env:AZ_AREA<br/>$env:AZ_ITERATION<br/>(org/project come from<br/>az devops configure --defaults)"]
+        EnvVars["$env:AZ_USER_EMAIL<br/>$env:AZ_AREA<br/>$env:AZ_ITERATION<br/>$env:AZ_DEBRIEF_TEAM<br/>(org/project come from<br/>az devops configure --defaults)"]
     end
 
     subgraph Public["Public functions"]
@@ -620,21 +620,28 @@ flowchart TD
     Debrief --> FlushDesc["Format-UnplannedItemsDescription<br/>→ Set-AzDevOpsWorkItemField<br/>→ az boards work-item update (System.Description)"]
     FlushDesc --> AskFuture{future-feature opportunity?}
     AskFuture -- yes --> MaybeStory["(opt) az-New-AzDevOpsUserStory"]
-    AskFuture -- no --> PostComment
-    MaybeStory --> PostComment
-    PostComment["Format-UnplannedDebriefComment<br/>→ Add-AzDevOpsDiscussionComment<br/>→ az boards work-item update (--discussion)"]
+    AskFuture -- no --> Tag
+    MaybeStory --> Tag
+    Tag["Select-UnplannedDebriefMention<br/>type-to-filter roster picker (Name+Email)<br/>→ Format-UnplannedMentionAnchor (data-vss-mention)"]
+    Tag --> PostComment
+    PostComment["Format-UnplannedDebriefComment<br/>(+ @-mention anchors)<br/>→ Add-AzDevOpsDiscussionComment<br/>→ az boards work-item update (--discussion)"]
     PostComment --> Ledger["Add-UnplannedLedgerEntry<br/>unplanned-YYYY-MM-DD.json"]
     Ledger --> Done([end])
 
     DebriefDay([New-UnplannedWorkDebrief]) --> ReadLedger["read day ledger<br/>Measure-Object -Property Minutes"]
-    ReadLedger --> Rollup["Format-UnplannedDailyDebrief<br/>→ Add-AzDevOpsDiscussionComment on daily story"]
+    ReadLedger --> TagDay["Select-UnplannedDebriefMention<br/>(same roster picker)"]
+    TagDay --> Rollup["Format-UnplannedDailyDebrief<br/>(+ @-mention anchors)<br/>→ Add-AzDevOpsDiscussionComment on daily story"]
     Rollup --> Done2([end])
 
+    SyncTeam(["az-Sync-UnplannedTeam"]) --> ResolveTeam["Sync-UnplannedDebriefTeam<br/>read $env:AZ_DEBRIEF_TEAM (';'/','-split)<br/>→ Resolve-UnplannedTeamMember<br/>→ Get-AzDevOpsIdentity<br/>→ az devops invoke (ims/Identities)"]
+    ResolveTeam --> TeamCache["Save-UnplannedTeamCache<br/>debrief-team.json"]
+    TeamCache --> Done3([end])
+
     classDef io fill:#5a3a1a,stroke:#ffaa55,color:#fff
-    class Find,NewStory,Task,FlushDesc,PostComment,Ledger,Rollup io
+    class Find,NewStory,Task,FlushDesc,PostComment,Ledger,Rollup,ResolveTeam,TeamCache io
 ```
 
-Capture lands in two places per firefight: the accumulated bullet items flush to the Task **description** once at stop, and a single **discussion comment** carries the time spent, debrief notes, and any future-feature opportunity. Pure-UI helpers (`Show-UnplannedStatus`, `Format-UnplannedElapsed`, `Read-UnplannedYesNo`) are session-internal and omitted from the dependency map below.
+Capture lands in two places per firefight: the accumulated bullet items flush to the Task **description** once at stop, and a single **discussion comment** carries the time spent, debrief notes, and any future-feature opportunity. Before each comment posts, `Select-UnplannedDebriefMention` offers a type-to-filter picker over the cached team roster (`debrief-team.json`, seeded from `$env:AZ_DEBRIEF_TEAM` and resolved to identity GUIDs by `az-Sync-UnplannedTeam`); picked teammates are injected as real `data-vss-mention` anchors so they're notified. Tagging is optional — an empty pick posts the debrief unchanged. Pure-UI helpers (`Show-UnplannedStatus`, `Format-UnplannedElapsed`, `Read-UnplannedYesNo`) are session-internal and omitted from the dependency map below.
 
 ---
 
@@ -692,6 +699,22 @@ graph LR
     UWBalloon[New-UnplannedBalloon]:::priv
     WpfStopwatch[Show-WpfStopwatch]:::priv
     UWLedger[Add-UnplannedLedgerEntry]:::priv
+    SyncUWTeam(["az-Sync-UnplannedTeam"]):::pub
+    UWRosterSync[Sync-UnplannedDebriefTeam]:::priv
+    UWGetTeam[Get-UnplannedDebriefTeam]:::priv
+    UWRoster[Get-UnplannedTeamRoster]:::priv
+    UWResolve[Resolve-UnplannedTeamMember]:::priv
+    UWTeamSave[Save-UnplannedTeamCache]:::priv
+    UWTeamRead[Read-UnplannedTeamCache]:::priv
+    UWTeamPath[Get-UnplannedTeamCachePath]:::priv
+    UWMentionPick[Select-UnplannedDebriefMention]:::priv
+    UWMentionMenu[Select-UnplannedMentionFromMenu]:::priv
+    UWAnchor[Format-UnplannedMentionAnchor]:::priv
+    UWMentionLine[Format-UnplannedMentionLine]:::priv
+    UWCachePath[Get-UnplannedCacheFilePath]:::priv
+    UWJsonRead[Read-UnplannedJsonCache]:::priv
+    UWJsonSave[Save-UnplannedJsonCache]:::priv
+    UWLedgerPath[Get-UnplannedLedgerPath]:::priv
 
     %% Step helpers
     C1[az-Confirm-AzDevOpsCli]:::priv
@@ -746,6 +769,7 @@ graph LR
     SetField[Set-AzDevOpsWorkItemField]:::priv
     AssertTok[Assert-AzDevOpsFieldTokens]:::priv
     WITypeDef[Get-AzDevOpsWorkItemTypeDefinition]:::priv
+    Identity[Get-AzDevOpsIdentity]:::priv
     ConfDef[Get-AzDevOpsConfiguredDefaults]:::priv
 
     %% Query echo helpers (azdevops_db.ps1)
@@ -1178,6 +1202,32 @@ graph LR
     InvUWDebrief --> UWLedger
     NewUWDebrief --> AddDisc
     NewUWDebrief --> UWLedger
+
+    %% Debrief team tagging (azdevops_unplanned.ps1 + Get-AzDevOpsIdentity)
+    SyncUWTeam --> CGate
+    SyncUWTeam --> UWRosterSync
+    UWRosterSync --> UWRoster
+    UWRosterSync --> UWResolve --> Identity --> AzJson
+    UWRosterSync --> UWTeamSave
+    InvUWDebrief --> UWMentionPick
+    NewUWDebrief --> UWMentionPick
+    InvUWDebrief --> UWMentionLine
+    NewUWDebrief --> UWMentionLine
+    UWMentionPick --> UWGetTeam
+    UWMentionPick --> UWMentionMenu
+    UWGetTeam --> UWTeamRead
+    UWGetTeam --> UWRosterSync
+    UWMentionLine --> UWAnchor
+    UWTeamSave --> UWTeamPath
+    UWTeamSave --> UWJsonSave
+    UWTeamRead --> UWTeamPath
+    UWTeamRead --> UWJsonRead
+    UWTeamPath --> UWCachePath
+    UWLedger --> UWLedgerPath
+    UWLedger --> UWJsonRead
+    UWLedger --> UWJsonSave
+    UWLedgerPath --> UWCachePath
+    UWCachePath --> Paths
 
     %% Parent picker shared between Feature and Epic pickers
     PFeat --> PParent

--- a/powcuts_by_cli/azdevops_db.ps1
+++ b/powcuts_by_cli/azdevops_db.ps1
@@ -426,3 +426,31 @@ function Get-AzDevOpsWorkItemTypeDefinition {
     )
     return $result
 }
+
+
+function Get-AzDevOpsIdentity {
+    # `az devops invoke --area ims --resource Identities` wrapper. Resolves a
+    # display name, email, or alias to the org's identity records via the
+    # Identity Management Service search endpoint. Returns the canonical
+    # envelope; the parsed JSON is { count, value: [ { id, providerDisplayName,
+    # properties }, ... ] } where each value's `id` is the identity GUID
+    # (TeamFoundationId) that the work-item discussion control expects inside a
+    # data-vss-mention anchor.
+    #
+    # Like Get-AzDevOpsWorkItemTypeDefinition this routes through `az devops
+    # invoke` (REST passthrough) because the azure-devops extension exposes no
+    # first-class identity-search subcommand. searchFilter=General matches
+    # against name, email, and alias, so one query handles either input shape.
+    param([Parameter(Mandatory)] [string] $Query)
+
+    $apiVersion = '7.1-preview.1'
+
+    $result = Invoke-AzDevOpsAzJson -ArgList @(
+        'devops', 'invoke',
+        '--area',             'ims',
+        '--resource',         'Identities',
+        '--query-parameters', 'searchFilter=General', "filterValue=$Query",
+        '--api-version',      $apiVersion
+    )
+    return $result
+}

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -400,11 +400,11 @@ function Format-UnplannedDebriefComment {
 }
 
 
-function Get-UnplannedLedgerPath {
-    # Per-day ledger under the AzDO cache dir so New-UnplannedWorkDebrief can
-    # total time across firefights (AzDO doesn't store our per-session minutes).
-    # Returns $null when the cache layout isn't available.
-    param([datetime] $Date = (Get-Date))
+function Get-UnplannedCacheFilePath {
+    # Resolve <cacheDir>/<FileName> under the active AzDO cache layout, or $null
+    # when the cache dir isn't available. Single source of the cache-dir guard
+    # shared by the per-day ledger path and the debrief-team roster path.
+    param([Parameter(Mandatory)] [string] $FileName)
 
     if (-not (Get-Command Get-AzDevOpsCachePaths -ErrorAction SilentlyContinue)) {
         return $null
@@ -415,8 +415,60 @@ function Get-UnplannedLedgerPath {
         return $null
     }
 
+    $path = Join-Path $paths.Dir $FileName
+    return $path
+}
+
+
+function Read-UnplannedJsonCache {
+    # Read a JSON-array cache file written by Save-UnplannedJsonCache. Returns
+    # an empty array when the file is absent or unparseable. Shared by the
+    # ledger reader and the debrief-team roster reader.
+    param([Parameter(Mandatory)] [string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return @()
+    }
+
+    try {
+        $items = @(Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json)
+    }
+    catch {
+        return @()
+    }
+
+    return $items
+}
+
+
+function Save-UnplannedJsonCache {
+    # Ensure the parent dir exists, then write $Items as a JSON array (UTF-8).
+    # -AsArray keeps the single-element case an array on disk (PowerShell's
+    # ConvertTo-Json otherwise unwraps a one-item collection). Shared by the
+    # per-day ledger and the debrief-team roster cache.
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Items
+    )
+
+    $dir = Split-Path -Parent $Path
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    $json = ConvertTo-Json -InputObject @($Items) -Depth 5 -AsArray
+    Set-Content -LiteralPath $Path -Value $json -Encoding UTF8
+}
+
+
+function Get-UnplannedLedgerPath {
+    # Per-day ledger under the AzDO cache dir so New-UnplannedWorkDebrief can
+    # total time across firefights (AzDO doesn't store our per-session minutes).
+    # Returns $null when the cache layout isn't available.
+    param([datetime] $Date = (Get-Date))
+
     $stamp = $Date.ToString('yyyy-MM-dd')
-    $path  = Join-Path $paths.Dir "unplanned-$stamp.json"
+    $path  = Get-UnplannedCacheFilePath -FileName "unplanned-$stamp.json"
     return $path
 }
 
@@ -435,20 +487,7 @@ function Add-UnplannedLedgerEntry {
         return
     }
 
-    $dir = Split-Path -Parent $path
-    if (-not (Test-Path -LiteralPath $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
-    $existing = @()
-    if (Test-Path -LiteralPath $path) {
-        try {
-            $existing = @(Get-Content -LiteralPath $path -Raw | ConvertFrom-Json)
-        }
-        catch {
-            $existing = @()
-        }
-    }
+    $existing = Read-UnplannedJsonCache -Path $path
 
     $entry = [PSCustomObject]@{
         StoryId   = $StoryId
@@ -459,9 +498,9 @@ function Add-UnplannedLedgerEntry {
         EndedAt   = (Get-Date).ToString('o')
     }
 
-    $all  = @($existing) + $entry
-    $json = ConvertTo-Json -InputObject @($all) -Depth 5 -AsArray
-    Set-Content -LiteralPath $path -Value $json -Encoding UTF8
+    $all = @($existing) + $entry
+
+    Save-UnplannedJsonCache -Path $path -Items $all
 }
 
 
@@ -546,18 +585,9 @@ function Get-UnplannedTeamCachePath {
     # Resolved-roster cache (display name + email + identity GUID) under the
     # AzDO cache dir, so debriefs build mention anchors without re-hitting the
     # identities API every session. Returns $null when the cache layout isn't
-    # available (same guard as Get-UnplannedLedgerPath).
-    if (-not (Get-Command Get-AzDevOpsCachePaths -ErrorAction SilentlyContinue)) {
-        return $null
-    }
-
-    $paths = Get-AzDevOpsCachePaths
-    if (-not $paths.Dir) {
-        return $null
-    }
-
+    # available.
     $cacheFile = $script:UnplannedTeamCacheFile
-    $path      = Join-Path $paths.Dir $cacheFile
+    $path      = Get-UnplannedCacheFilePath -FileName $cacheFile
     return $path
 }
 
@@ -622,29 +652,17 @@ function Save-UnplannedTeamCache {
         return
     }
 
-    $dir = Split-Path -Parent $path
-    if (-not (Test-Path -LiteralPath $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
-    $json = ConvertTo-Json -InputObject @($Members) -Depth 5 -AsArray
-    Set-Content -LiteralPath $path -Value $json -Encoding UTF8
+    Save-UnplannedJsonCache -Path $path -Items $Members
 }
 
 
 function Read-UnplannedTeamCache {
     $path = Get-UnplannedTeamCachePath
-    if (-not $path -or -not (Test-Path -LiteralPath $path)) {
+    if (-not $path) {
         return @()
     }
 
-    try {
-        $members = @(Get-Content -LiteralPath $path -Raw | ConvertFrom-Json)
-    }
-    catch {
-        return @()
-    }
-
+    $members = Read-UnplannedJsonCache -Path $path
     return $members
 }
 
@@ -710,8 +728,13 @@ function Format-UnplannedMentionAnchor {
     $atSign         = '@'
     $quote          = '"'
 
+    # HTML-encode the visible label so a display name containing < > & can't
+    # break (or inject into) the anchor posted to the discussion thread. The Id
+    # is an identity GUID, so it needs no encoding.
+    $label = [System.Net.WebUtility]::HtmlEncode($Member.DisplayName)
+
     $dataAttr = "data-vss-mention=$quote$mentionVersion,$($Member.Id)$quote"
-    $anchor   = "<a href=$quote#$quote $dataAttr>$atSign$($Member.DisplayName)</a>"
+    $anchor   = "<a href=$quote#$quote $dataAttr>$atSign$label</a>"
     return $anchor
 }
 

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -16,6 +16,11 @@
 #   New-UnplannedWorkDebrief - read the day's ledger, total the time across all
 #                              firefights, and post a roll-up comment on the
 #                              daily story.
+#   az-Sync-UnplannedTeam      - resolve $env:AZ_DEBRIEF_TEAM (';'-separated
+#                              emails/names) to Azure DevOps identities and
+#                              cache them, so both debriefs can offer a
+#                              type-to-filter picker that tags teammates with
+#                              real notifying @-mentions.
 #
 # Like pow_timer.ps1 this is PowerShell-only - the Windows balloon reminder and
 # the non-blocking key poll have no bash counterpart.
@@ -29,12 +34,17 @@ $script:UnplannedDefaultStoryPriority   = 2
 $script:UnplannedPollIntervalMs         = 100
 $script:UnplannedPollsPerSecond         = 10
 
+$script:UnplannedTeamEnvVar    = 'AZ_DEBRIEF_TEAM'
+$script:UnplannedTeamCacheFile = 'debrief-team.json'
+$script:UnplannedMentionVersion = 'version:2.0'
+
 $script:UnplannedIconFire   = [char]::ConvertFromUtf32(0x1F525)   # fire
 $script:UnplannedIconMemo   = [char]::ConvertFromUtf32(0x1F4DD)   # memo
 $script:UnplannedIconClock  = [char]::ConvertFromUtf32(0x23F0)    # alarm clock
 $script:UnplannedIconCheck  = [char]::ConvertFromUtf32(0x2705)    # check mark
 $script:UnplannedIconRocket = [char]::ConvertFromUtf32(0x1F680)   # rocket
 $script:UnplannedIconBullet = [char]::ConvertFromUtf32(0x2022)    # bullet
+$script:UnplannedIconPeople = [char]::ConvertFromUtf32(0x1F465)   # busts in silhouette
 
 
 function Read-UnplannedYesNo {
@@ -350,7 +360,8 @@ function Format-UnplannedDebriefComment {
         [Parameter(Mandatory)] [int]    $ElapsedMinutes,
         [Parameter(Mandatory)] [int]    $ItemCount,
         [string] $Debrief,
-        [string] $FutureFeature
+        [string] $FutureFeature,
+        [AllowEmptyCollection()] [object[]] $Mentions
     )
 
     $iconCheck  = $script:UnplannedIconCheck
@@ -373,6 +384,12 @@ function Format-UnplannedDebriefComment {
     if ($FutureFeature) {
         $lines += "$iconRocket Future opportunity:"
         $lines += $FutureFeature
+        $lines += ''
+    }
+
+    $mentionLine = Format-UnplannedMentionLine -Members $Mentions
+    if ($mentionLine) {
+        $lines += $mentionLine
         $lines += ''
     }
 
@@ -452,7 +469,8 @@ function Format-UnplannedDailyDebrief {
     param(
         [Parameter(Mandatory)] [object[]] $Entries,
         [Parameter(Mandatory)] [int]      $TotalMinutes,
-        [datetime] $Date = (Get-Date)
+        [datetime] $Date = (Get-Date),
+        [AllowEmptyCollection()] [object[]] $Mentions
     )
 
     $iconCheck = $script:UnplannedIconCheck
@@ -470,11 +488,326 @@ function Format-UnplannedDailyDebrief {
         $lines += "$bullet Task #$($e.TaskId) - $($e.Minutes) min, $($e.ItemCount) item(s): $($e.Title)"
     }
 
+    $mentionLine = Format-UnplannedMentionLine -Members $Mentions
+    if ($mentionLine) {
+        $lines += ''
+        $lines += $mentionLine
+    }
+
     $lines += ''
     $lines += '<em>via bashcuts New-UnplannedWorkDebrief</em>'
 
     $body = $lines -join '<br/>'
     return $body
+}
+
+
+# ---------------------------------------------------------------------------
+# Debrief team tagging
+#
+# A roster of teammates (sourced from $env:AZ_DEBRIEF_TEAM, ';'- or
+# ','-separated emails/names) is resolved to Azure DevOps identities and cached
+# under the AzDO cache dir next to the per-day ledger. Both debriefs offer a
+# type-to-filter picker over that roster; the picked teammates are injected
+# into the comment as data-vss-mention anchors so they are actually notified.
+# Identity resolution (Get-AzDevOpsIdentity) and the anchor shape
+# (Format-UnplannedMentionAnchor) are the two places to revisit if a tagged
+# teammate does not receive a notification.
+# ---------------------------------------------------------------------------
+
+function Get-UnplannedTeamRoster {
+    # Split $env:AZ_DEBRIEF_TEAM into a clean list of teammate identifiers
+    # (emails and/or names). Accepts ';' or ',' separators, trims whitespace,
+    # and drops blanks and case-insensitive duplicates. Returns an empty array
+    # when the env var is unset.
+    $raw = [Environment]::GetEnvironmentVariable($script:UnplannedTeamEnvVar)
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return @()
+    }
+
+    $separators = [char[]]@(';', ',')
+    $parts      = $raw.Split($separators, [StringSplitOptions]::RemoveEmptyEntries)
+
+    $seen   = New-Object System.Collections.Generic.HashSet[string]
+    $roster = New-Object System.Collections.Generic.List[string]
+    foreach ($part in $parts) {
+        $trimmed = $part.Trim()
+        if ($trimmed -and $seen.Add($trimmed.ToLowerInvariant())) {
+            $roster.Add($trimmed)
+        }
+    }
+
+    $result = @($roster)
+    return $result
+}
+
+
+function Get-UnplannedTeamCachePath {
+    # Resolved-roster cache (display name + email + identity GUID) under the
+    # AzDO cache dir, so debriefs build mention anchors without re-hitting the
+    # identities API every session. Returns $null when the cache layout isn't
+    # available (same guard as Get-UnplannedLedgerPath).
+    if (-not (Get-Command Get-AzDevOpsCachePaths -ErrorAction SilentlyContinue)) {
+        return $null
+    }
+
+    $paths = Get-AzDevOpsCachePaths
+    if (-not $paths.Dir) {
+        return $null
+    }
+
+    $cacheFile = $script:UnplannedTeamCacheFile
+    $path      = Join-Path $paths.Dir $cacheFile
+    return $path
+}
+
+
+function Resolve-UnplannedTeamMember {
+    # Resolve one roster entry (email or display name) to a { DisplayName,
+    # Email, Id } record via the identities API. The Id is the identity GUID
+    # the discussion control needs for a notifying @-mention. Returns $null
+    # when the lookup fails or matches nobody, so Sync-UnplannedDebriefTeam can
+    # report the miss and skip it rather than caching a half-resolved entry.
+    param([Parameter(Mandatory)] [string] $Identifier)
+
+    if (-not (Get-Command Get-AzDevOpsIdentity -ErrorAction SilentlyContinue)) {
+        return $null
+    }
+
+    $result = Get-AzDevOpsIdentity -Query $Identifier
+    if ($result.ExitCode -ne 0) {
+        return $null
+    }
+
+    try {
+        $parsed = $result.Json | ConvertFrom-Json
+    }
+    catch {
+        return $null
+    }
+
+    $candidates = @($parsed.value)
+    if ($candidates.Count -eq 0) {
+        return $null
+    }
+
+    $identity = $candidates[0]
+
+    $displayName = if ($identity.providerDisplayName) {
+        $identity.providerDisplayName
+    } else {
+        $Identifier
+    }
+
+    $email = if ($identity.properties -and $identity.properties.Mail -and $identity.properties.Mail.'$value') {
+        $identity.properties.Mail.'$value'
+    } else {
+        $Identifier
+    }
+
+    $record = [PSCustomObject]@{
+        DisplayName = $displayName
+        Email       = $email
+        Id          = $identity.id
+    }
+    return $record
+}
+
+
+function Save-UnplannedTeamCache {
+    param([Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Members)
+
+    $path = Get-UnplannedTeamCachePath
+    if (-not $path) {
+        return
+    }
+
+    $dir = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    $json = ConvertTo-Json -InputObject @($Members) -Depth 5 -AsArray
+    Set-Content -LiteralPath $path -Value $json -Encoding UTF8
+}
+
+
+function Read-UnplannedTeamCache {
+    $path = Get-UnplannedTeamCachePath
+    if (-not $path -or -not (Test-Path -LiteralPath $path)) {
+        return @()
+    }
+
+    try {
+        $members = @(Get-Content -LiteralPath $path -Raw | ConvertFrom-Json)
+    }
+    catch {
+        return @()
+    }
+
+    return $members
+}
+
+
+function Sync-UnplannedDebriefTeam {
+    # Resolve every $env:AZ_DEBRIEF_TEAM entry to an identity record and write
+    # the roster cache. Returns the resolved records. Entries that don't resolve
+    # are reported and skipped so one bad email doesn't sink the whole roster.
+    $roster = Get-UnplannedTeamRoster
+    if ($roster.Count -eq 0) {
+        $envVar = $script:UnplannedTeamEnvVar
+        Write-Host "No team configured. Set `$env:$envVar (';'-separated emails) to enable debrief tagging." -ForegroundColor Yellow
+        return @()
+    }
+
+    $resolved = New-Object System.Collections.Generic.List[object]
+    foreach ($member in $roster) {
+        $record = Resolve-UnplannedTeamMember -Identifier $member
+        if ($null -eq $record -or -not $record.Id) {
+            Write-Host "  Could not resolve '$member' to an Azure DevOps identity - skipping." -ForegroundColor Yellow
+            continue
+        }
+
+        $resolved.Add($record)
+    }
+
+    $records = @($resolved)
+    Save-UnplannedTeamCache -Members $records
+    return $records
+}
+
+
+function Get-UnplannedDebriefTeam {
+    # Cached roster reader. Auto-syncs from $env:AZ_DEBRIEF_TEAM the first time
+    # (or after the cache is cleared) so callers don't have to run
+    # az-Sync-UnplannedTeam by hand. Returns an empty array when no team is
+    # configured.
+    $cached = Read-UnplannedTeamCache
+    if ($cached.Count -gt 0) {
+        return $cached
+    }
+
+    $roster = Get-UnplannedTeamRoster
+    if ($roster.Count -eq 0) {
+        return @()
+    }
+
+    $synced = Sync-UnplannedDebriefTeam
+    return $synced
+}
+
+
+function Format-UnplannedMentionAnchor {
+    # Build the Azure DevOps discussion @-mention anchor for one resolved
+    # teammate. The data-vss-mention attribute carries the identity GUID; the
+    # work-item discussion control turns this exact anchor shape into a real
+    # notification on save, and the version token mirrors what the AzDO web
+    # editor emits. If a tagged teammate is NOT notified, this anchor (and the
+    # identity GUID feeding it from Get-AzDevOpsIdentity) is what to revisit.
+    param([Parameter(Mandatory)] [object] $Member)
+
+    $mentionVersion = $script:UnplannedMentionVersion
+    $atSign         = '@'
+    $quote          = '"'
+
+    $dataAttr = "data-vss-mention=$quote$mentionVersion,$($Member.Id)$quote"
+    $anchor   = "<a href=$quote#$quote $dataAttr>$atSign$($Member.DisplayName)</a>"
+    return $anchor
+}
+
+
+function Format-UnplannedMentionLine {
+    # Compose the single "Tagged: @a @b" line appended to a debrief comment.
+    # Returns '' for an empty selection so both formatters can skip the line
+    # (and keep posting exactly as before) when nobody is tagged.
+    param([AllowEmptyCollection()] [object[]] $Members)
+
+    # Drop $null / unresolved entries so an omitted -Mentions arg (which arrives
+    # as @($null), a 1-element array) collapses to an empty line rather than a
+    # broken anchor.
+    $memberList = @($Members | Where-Object { $null -ne $_ -and $_.Id })
+    if ($memberList.Count -eq 0) {
+        return ''
+    }
+
+    $iconPeople = $script:UnplannedIconPeople
+
+    $anchors = New-Object System.Collections.Generic.List[string]
+    foreach ($member in $memberList) {
+        $anchor = Format-UnplannedMentionAnchor -Member $member
+        $anchors.Add($anchor)
+    }
+
+    $line = "$iconPeople Tagged: " + ($anchors -join ' ')
+    return $line
+}
+
+
+function Select-UnplannedMentionFromMenu {
+    # Numbered Read-Host fallback for Select-UnplannedDebriefMention when no
+    # Out-ConsoleGridView host is available. Accepts a comma-separated list of
+    # indices; ignores blanks and out-of-range entries. Returns the chosen
+    # member records.
+    param([Parameter(Mandatory)] [object[]] $Team)
+
+    Write-Host ''
+    Write-Host 'Teammates available to tag:' -ForegroundColor Cyan
+    for ($i = 0; $i -lt $Team.Count; $i++) {
+        $member = $Team[$i]
+        Write-Host ("  {0}) {1}  <{2}>" -f ($i + 1), $member.DisplayName, $member.Email)
+    }
+
+    $raw = Read-Host 'Numbers to tag (comma-separated, blank = none)'
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return @()
+    }
+
+    $separators = [char[]]@(';', ',')
+    $tokens     = $raw.Split($separators, [StringSplitOptions]::RemoveEmptyEntries)
+
+    $picked = New-Object System.Collections.Generic.List[object]
+    foreach ($token in $tokens) {
+        $index = 0
+        if ([int]::TryParse($token.Trim(), [ref]$index)) {
+            $zeroBased = $index - 1
+            if ($zeroBased -ge 0 -and $zeroBased -lt $Team.Count) {
+                $picked.Add($Team[$zeroBased])
+            }
+        }
+    }
+
+    $result = @($picked)
+    return $result
+}
+
+
+function Select-UnplannedDebriefMention {
+    # Type-to-filter picker over the cached roster for debrief tagging. Shows
+    # Name + Email so the user can confirm the right person before tagging.
+    # Out-ConsoleGridView multi-select when available (its filter box is the
+    # "type and the right names bubble up" behavior); a Read-Host numbered menu
+    # otherwise. Returns the selected member records - possibly empty, since
+    # tagging is always optional and 'tag nobody' leaves the debrief unchanged.
+    $team = Get-UnplannedDebriefTeam
+    if ($team.Count -eq 0) {
+        return @()
+    }
+
+    if (-not (Read-UnplannedYesNo -Prompt 'Tag teammate(s) on this debrief?')) {
+        return @()
+    }
+
+    if (Test-AzDevOpsGridAvailable) {
+        $grid = $team |
+            Select-Object DisplayName, Email, Id |
+            Out-ConsoleGridView -Title 'Pick teammate(s) to tag (filter as you type, Esc = none)' -OutputMode Multiple
+
+        $picked = @($grid)
+        return $picked
+    }
+
+    $menuPicked = Select-UnplannedMentionFromMenu -Team $team
+    return $menuPicked
 }
 
 
@@ -527,11 +860,14 @@ function Invoke-UnplannedDebrief {
         }
     }
 
+    $mentions = Select-UnplannedDebriefMention
+
     $commentBody = Format-UnplannedDebriefComment `
         -ElapsedMinutes $elapsedMinutes `
         -ItemCount      $itemList.Count `
         -Debrief        $debrief `
-        -FutureFeature  $futureFeature
+        -FutureFeature  $futureFeature `
+        -Mentions       $mentions
 
     Write-Host ""
     Write-Host "Posting debrief comment to Task #$TaskId..." -ForegroundColor Cyan
@@ -933,11 +1269,38 @@ function New-UnplannedWorkDebrief {
         return
     }
 
-    $body = Format-UnplannedDailyDebrief -Entries $entries -TotalMinutes $totalMinutes -Date $Date
+    $mentions = Select-UnplannedDebriefMention
+
+    $body = Format-UnplannedDailyDebrief -Entries $entries -TotalMinutes $totalMinutes -Date $Date -Mentions $mentions
     $result = Add-AzDevOpsDiscussionComment -Id $storyId -Body $body
     if ($result.ExitCode -eq 0) {
         Write-Host "Posted daily roll-up on story #$storyId." -ForegroundColor Green
     } else {
         Write-Host "Failed to post roll-up: $($result.Error)" -ForegroundColor Red
+    }
+}
+
+
+function az-Sync-UnplannedTeam {
+    # Refresh the cached debrief-tagging roster from $env:AZ_DEBRIEF_TEAM. Run
+    # this after changing the env var so the next debrief's tag picker reflects
+    # the new team. Resolution uses the Azure DevOps identities API, so it needs
+    # a configured org (same create gate as the other write commands).
+    [CmdletBinding()]
+    param()
+
+    if (-not (Test-AzDevOpsCreateGate -CommandName 'az-Sync-UnplannedTeam')) {
+        return
+    }
+
+    $members = Sync-UnplannedDebriefTeam
+    if ($members.Count -eq 0) {
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Cached $($members.Count) teammate(s) for debrief tagging:" -ForegroundColor Green
+    foreach ($member in $members) {
+        Write-Host ("  {0}  <{1}>" -f $member.DisplayName, $member.Email)
     }
 }


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #136 |
| [Changes](#changes) | ✅ 3 files |
| [Test Plan](#test-plan) | ✅ 4 items (manual) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/139#issuecomment-4632844981) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/139#issuecomment-4632854742) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/139#issuecomment-4632851718) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE (after fix) — [View](https://github.com/jdschleicher/bashcuts/pull/139#issuecomment-4632882236) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/139#issuecomment-4632893153) |
| 📚 Docs Check | ✅ CURRENT (README + AzDO diagrams synced) |
<!-- toc:end -->
<!-- pr-diagram:start -->
## How it works

`az-Sync-UnplannedTeam` resolves `$env:AZ_DEBRIEF_TEAM` to identity GUIDs and caches them as `debrief-team.json`. Both debrief flows (`az-Start-UnplannedWork`'s per-firefight stop and `New-UnplannedWorkDebrief`'s roll-up) then run the type-to-filter picker, which reads that cache (auto-syncing on a miss) and turns picks into `data-vss-mention` anchors injected into the posted discussion comment.

```mermaid
flowchart TD
    Sync([az-Sync-UnplannedTeam]):::pub
    PerFire([az-Start-UnplannedWork<br/>debrief]):::pub
    Daily([New-UnplannedWorkDebrief]):::pub

    Roster[Get-UnplannedTeamRoster<br/>split $env:AZ_DEBRIEF_TEAM]:::priv
    Resolve[Resolve-UnplannedTeamMember]:::priv
    GetTeam[Get-UnplannedDebriefTeam<br/>auto-sync on miss]:::priv
    Pick[Select-UnplannedDebriefMention<br/>type-to-filter Name+Email]:::priv
    Anchor[Format-UnplannedMentionAnchor<br/>HTML-encoded data-vss-mention]:::priv

    Identity["Get-AzDevOpsIdentity<br/>az devops invoke (ims/Identities)"]:::io
    TeamCache[(debrief-team.json)]:::io
    Post["Add-AzDevOpsDiscussionComment<br/>az boards work-item update --discussion"]:::io
    Done([teammate notified]):::pub

    Sync --> Roster --> Resolve --> Identity
    Resolve -- Save-UnplannedTeamCache --> TeamCache

    PerFire --> Pick
    Daily --> Pick
    Pick --> GetTeam --> TeamCache
    GetTeam -. cache miss .-> Sync
    Pick --> Anchor --> Post --> Done

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Tag teammates with real, notifying Azure DevOps `@`-mentions from both unplanned-work debriefs — the per-firefight debrief (`az-Start-UnplannedWork`) and the end-of-day roll-up (`New-UnplannedWorkDebrief`). PowerShell-only, matching the rest of the unplanned-work feature.

## Issue

Closes #136

## Changes

- **`powcuts_by_cli/azdevops_db.ps1`** — new `Get-AzDevOpsIdentity`, an `az devops invoke --area ims --resource Identities` wrapper (the single isolated spot for identity-GUID resolution).
- **`powcuts_by_cli/azdevops_unplanned.ps1`**
  - `$env:AZ_DEBRIEF_TEAM` (`;`/`,`-separated emails/names) seeds the roster.
  - `az-Sync-UnplannedTeam` (public) resolves each entry to an identity `{DisplayName, Email, Id}` and caches it as `debrief-team.json` under the AzDO cache dir; `Get-UnplannedDebriefTeam` auto-syncs when the cache is absent.
  - `Select-UnplannedDebriefMention` — type-to-filter `Out-ConsoleGridView` picker (Name + Email columns, multi-select) with a `Read-Host` numbered fallback.
  - `Format-UnplannedMentionAnchor` builds the HTML-encoded `data-vss-mention` anchor; `-Mentions` is threaded through both debrief formatters and both debrief flows.
  - Shared cache helpers `Get-UnplannedCacheFilePath` / `Read-UnplannedJsonCache` / `Save-UnplannedJsonCache` now back both the ledger and the team cache (DRY, per code review).
  - Tagging is optional — an empty selection posts the debrief exactly as before.
- **`README.md`** — documents `AZ_DEBRIEF_TEAM` in the env-var block and adds a "Tagging teammates" subsection.
- **`docs/azure-devops-diagrams.md`** — Section 11 + Diagram 9 updated for the tagging flow and `Get-AzDevOpsIdentity`.

## Test Plan

> ⚠️ Could not be run in CI — neither `pwsh` nor `az` is available in the build container. Run on a machine with both:

- [ ] **Parse:** `[Parser]::ParseFile()` on `azdevops_db.ps1` + `azdevops_unplanned.ps1` — zero errors
- [ ] **Roster:** `$env:AZ_DEBRIEF_TEAM='alice@x.com;bob@x.com'`, new pwsh, `az-Sync-UnplannedTeam` → confirm it caches name/email/id
- [ ] **Picker:** `az-Start-UnplannedWork`, stop the session, answer "Tag teammate(s)?" → the Name+Email filter picker appears and multi-select works
- [ ] **Notification (decisive):** tag a real teammate → confirm they actually receive an Azure DevOps notification; repeat for `New-UnplannedWorkDebrief`

### Known risk
The mention anchor needs the exact identity GUID Azure DevOps expects. The implementation uses the Identities-API `id` (best-known approach), isolated to `Get-AzDevOpsIdentity` + `Format-UnplannedMentionAnchor` so it's a one/two-helper fix if the live notification test shows it's wrong.