### PR TITLE
Make debrief text boxes read-only after a successful post in the timer overlay

### DIFF
--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -1147,6 +1147,11 @@ function Show-WpfTimerDebrief {
             $Script:WpfDebriefPostResult = $postResult
             $Script:WpfDebriefOutcome    = 'Posted'
 
+            # Notes are now committed to the item — lock them so they can't be
+            # edited, but keep them readable and selectable (IsReadOnly, not IsEnabled).
+            $debriefBox.IsReadOnly = $true
+            $nextBox.IsReadOnly    = $true
+
             $wantsResolve = ($closeEnabled -and ($chkResolve.IsChecked -eq $true))
 
             if ($wantsResolve) {


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #141 |
| [Changes](#changes) | ✅ 1 file |
| [Test Plan](#test-plan) | ✅ 4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4633069122) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4633072618) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4633071845) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4633073190) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4633081053) |
| 📚 Docs Check | ✅ CURRENT — run inline (no files/wiring changed) |
<!-- toc:end -->

## Summary
In the Windows WPF Pomodoro overlay (`Show-WpfTimerDebrief` in `powcuts_by_cli/pow_timer.ps1`), the **Debrief** and **Next** text boxes stayed fully editable after a successful post even though their content was already committed to the item — so further typing was silently discarded. This locks both boxes to read-only on a successful post, keeping the text visible and selectable. The failure branch is untouched, so the boxes stay editable for a retry.

## Issue
Closes #141

## Changes
- `powcuts_by_cli/pow_timer.ps1` — in the `$btnPost.Add_Click` success branch (`$exitCode -eq 0`) of `Show-WpfTimerDebrief`, set `$debriefBox.IsReadOnly = $true` and `$nextBox.IsReadOnly = $true`.

## Test Plan
- [ ] On Windows, run a short `az-Start-TimerSession`, type into Debrief/Next, end the countdown (or Esc), and click **Post Debrief**
- [ ] After "Posted. Start another session?" appears, confirm both boxes are no longer editable but the text is still visible and selectable/copyable
- [ ] Force a post failure (e.g. invalid org/item) and confirm "Post failed…" shows and both boxes remain editable for retry
- [ ] PowerShell-only / Windows-only change — no bash counterpart (macOS/Linux + unplanned-work debriefs use `Read-Host`)