### PR TITLE
Add bulk open-all gate to grid multi-select (#128)

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -358,8 +358,13 @@ flowchart TD
     Grid -- yes --> Pfx["Get-AzDevOpsWorkItemUrlPrefix<br/>(once, not per row)"]
     Pfx --> RowsFn["Get-AzDevOpsTreeRows<br/>(Type/Id/Title/State/Depth/Path/Url)"]
     RowsFn --> Show["Show-AzDevOpsRows<br/>→ Out-ConsoleGridView"]
-    Show --> Action["Invoke-AzDevOpsRowAction<br/>(per selected row)"]
-    Action --> Choice{Read-AzDevOpsRowActionChoice}
+    Show --> Action[Invoke-AzDevOpsRowAction]
+    Action --> Multi{"2+ rows selected?"}
+    Multi -- yes --> OpenAll["Invoke-AzDevOpsOpenAllSelected<br/>Read-AzDevOpsYesNo [y/N]"]
+    OpenAll -- yes --> OpenSel
+    OpenAll -- "no (incl. Enter)" --> PerRow
+    Multi -- no --> PerRow
+    PerRow["per selected row<br/>(Get-AzDevOpsRowId)"] --> Choice{Read-AzDevOpsRowActionChoice}
     Choice -- open --> OpenSel["az-Open-WorkItemById"]
     Choice -- create --> Child["New-AzDevOpsChildForRow<br/>(Get-AzDevOpsChildTypeFor →<br/>az-New-AzDevOpsFeature / UserStory / az-New-Task)"]
     Choice -- skip --> NoOp([skip])
@@ -380,7 +385,7 @@ flowchart TD
 
 Icon helper `Get-AzDevOpsTreeIcon` returns named codepoint locals (`$iconEpic`, `$iconFeature`, `$iconStory`) — never raw `[char]0x...` literals at the call site.
 
-The grid branch's post-selection step (`Invoke-AzDevOpsRowAction`) is shared by `az-Show-Board` and `az-Show-Features` too; `az-Show-Features` passes `-DefaultType 'Feature'` since its rows omit a Type column. For each selected work-item row it offers open-in-browser or create-the-hierarchical-child (Epic→Feature, Feature→User Story, requirement-tier→Task). `az-Show-Areas` / `az-Show-Iterations` use the parallel `Invoke-AzDevOpsClassificationAction`, which offers a Boards-hub open only (classification rows carry no work-item id).
+The grid branch's post-selection step (`Invoke-AzDevOpsRowAction`) is shared by `az-Show-Board` and `az-Show-Features` too; `az-Show-Features` passes `-DefaultType 'Feature'` since its rows omit a Type column. When more than one row is selected it first offers a single bulk-open gate (`Invoke-AzDevOpsOpenAllSelected`, a `[y/N]` prompt defaulting to no via `Read-AzDevOpsYesNo -DefaultNo`); a yes opens every selected row and returns, while no (or a bare Enter) falls through to the per-row loop. For each selected work-item row it then offers open-in-browser or create-the-hierarchical-child (Epic→Feature, Feature→User Story, requirement-tier→Task). The shared `Get-AzDevOpsRowId` helper extracts each row's work-item id (or 0 when the row carries none) for both the bulk and per-row paths. `az-Show-Areas` / `az-Show-Iterations` use the parallel `Invoke-AzDevOpsClassificationAction`, which offers a Boards-hub open only (classification rows carry no work-item id).
 
 ---
 
@@ -802,6 +807,8 @@ graph LR
 
     %% Interactive post-selection row actions (azdevops_views.ps1 + azdevops_classification.ps1)
     RowAction[Invoke-AzDevOpsRowAction]:::priv
+    OpenAllSel[Invoke-AzDevOpsOpenAllSelected]:::priv
+    RowId[Get-AzDevOpsRowId]:::priv
     RowChoice[Read-AzDevOpsRowActionChoice]:::priv
     ChildType[Get-AzDevOpsChildTypeFor]:::priv
     ChildForRow[New-AzDevOpsChildForRow]:::priv
@@ -1022,6 +1029,12 @@ graph LR
     Board --> RowAction
     ShowFeats --> RowAction
     Orphans --> RowAction
+    RowAction --> Multi2{"2+ rows?"}
+    Multi2 -- yes --> OpenAllSel
+    OpenAllSel --> YN
+    OpenAllSel --> RowId
+    OpenAllSel --> OpenUrl
+    RowAction --> RowId
     RowAction --> RowType
     RowAction --> ChildType
     RowAction --> RowChoice

--- a/powcuts_by_cli/azdevops_views.ps1
+++ b/powcuts_by_cli/azdevops_views.ps1
@@ -999,12 +999,64 @@ function Read-AzDevOpsRowActionChoice {
 }
 
 
+function Get-AzDevOpsRowId {
+    # Returns the positive work-item id from a selected grid row, or 0 when the
+    # row carries no usable Id column (classification nodes, header rows). Shared
+    # by the bulk-open gate and the per-row dispatcher so the presence check
+    # lives in one place.
+    param([Parameter(Mandatory)] $Row)
+
+    $hasId = $Row.PSObject.Properties.Match('Id').Count -gt 0 -and [int]$Row.Id -gt 0
+    if (-not $hasId) {
+        return 0
+    }
+
+    $id = [int]$Row.Id
+    return $id
+}
+
+
+function Invoke-AzDevOpsOpenAllSelected {
+    # Bulk-open gate for multi-row grid selections. Asks once whether to open
+    # every selected row in the browser; on yes, opens each row that carries a
+    # usable work-item id and returns $true. On no - a bare Enter is the safe
+    # default via Read-AzDevOpsYesNo -DefaultNo - returns $false so the caller
+    # drops to the per-row open/create prompt loop.
+    param([Parameter(Mandatory)] $Rows)
+
+    $rows  = @($Rows)
+    $count = $rows.Count
+
+    Write-Host ""
+    $prompt  = "Open all $count selected items in the browser?"
+    $openAll = Read-AzDevOpsYesNo -Prompt $prompt -DefaultNo
+
+    if (-not $openAll) {
+        return $false
+    }
+
+    foreach ($row in $rows) {
+        $id = Get-AzDevOpsRowId -Row $row
+        if ($id -le 0) {
+            Write-Host "(selected row has no work-item id - nothing to open)" -ForegroundColor Yellow
+            continue
+        }
+
+        az-Open-WorkItemById -Id $id
+    }
+
+    return $true
+}
+
+
 function Invoke-AzDevOpsRowAction {
     # Post-selection dispatcher shared by the interactive az-Show-* work-item
-    # views. For each selected row, prompts the user to open it in the browser
-    # or create its hierarchical child. Rows without a usable work-item id are
-    # skipped with a hint. -DefaultType supplies the type for views whose rows
-    # omit a Type column.
+    # views. When more than one row is selected, first offers a single bulk-open
+    # gate; declining (or a single-row selection) falls through to the per-row
+    # loop, which prompts to open each row in the browser or create its
+    # hierarchical child. Rows without a usable work-item id are skipped with a
+    # hint. -DefaultType supplies the type for views whose rows omit a Type
+    # column.
     param(
         $Selected,
         [string] $DefaultType
@@ -1014,14 +1066,22 @@ function Invoke-AzDevOpsRowAction {
         return
     }
 
-    foreach ($row in @($Selected)) {
-        $hasId = $row.PSObject.Properties.Match('Id').Count -gt 0 -and [int]$row.Id -gt 0
-        if (-not $hasId) {
+    $rows = @($Selected)
+
+    if ($rows.Count -gt 1) {
+        $openedAll = Invoke-AzDevOpsOpenAllSelected -Rows $rows
+        if ($openedAll) {
+            return
+        }
+    }
+
+    foreach ($row in $rows) {
+        $id = Get-AzDevOpsRowId -Row $row
+        if ($id -le 0) {
             Write-Host "(selected row has no work-item id - nothing to open)" -ForegroundColor Yellow
             continue
         }
 
-        $id   = [int]$row.Id
         $type = Resolve-AzDevOpsRowType -Row $row -DefaultType $DefaultType
 
         $childType = if ($type) {


### PR DESCRIPTION
When 2+ rows are selected in an az-Show-* grid view, Invoke-AzDevOpsRowAction
now asks once whether to open every selected item in the browser before
falling into the per-row open/create-child prompt loop. A yes opens all rows
with a usable id and returns; a no (bare Enter is the safe [y/N] default)
falls through to today's per-row behavior. Single-row selections are
unchanged.

Reuses the existing Read-AzDevOpsYesNo -DefaultNo helper for the prompt, and
extracts the row-id presence check into Get-AzDevOpsRowId so it is shared by
the bulk-open gate and the per-row dispatcher.