### PR TITLE
Add "Open work item in browser" button to the Pomodoro timer countdown overlay and debrief form

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,10 @@ On **Windows** the countdown morphs into a themed debrief form that shares the t
 
 On **macOS/Linux** the debrief is collected with terminal `Read-Host` prompts after the snake animation, and a `Posting...` indicator shows while the comment is sent.
 
+### Opening the work item in your browser
+
+When the chosen integration supplies an `OpenItem` capability, both timer surfaces add a one-click jump to the item in your browser — no need to copy the ID into a separate command. On **Windows** an **Open work item** button appears on the countdown overlay (open it mid-session without stopping the clock) and on the debrief form (open it while you write your notes — the form stays put). On **macOS/Linux** the **Start another session?** menu gains an `[o] Open work item in browser` choice that opens the item and re-prompts, so opening never consumes your restart decision. The built-in **Azure DevOps** integration maps `OpenItem` to `az-Open-WorkItemById`; integrations without an `OpenItem` simply don't show the button or option.
+
 ### Closing the story when a session finishes the task
 
 When the chosen integration supplies a `CloseItem` capability, the debrief surface adds a one-click way to transition the work item to its done state right after the comment lands — so a session that actually finished the task doesn't leave the item lingering in **Active**. On **Windows** the debrief form renders a **Work complete — resolve this story** checkbox above **Post Debrief**; ticking it makes the post sequence run the comment, then the state transition, and reports both outcomes before the **Start another session?** choice appears. On **macOS/Linux** the same trigger is a `Resolve this item now? [y/N]` prompt that follows a successful comment post (default **No** — your work item is never resolved without an explicit yes).
@@ -548,6 +552,13 @@ Register-TimerIntegration `
     -ViewHint    {
         param([Parameter(Mandatory)] [int] $Id)
         "View: my-tracker open $Id"
+    } `
+    -OpenItem    {
+        # Optional. When present, the countdown overlay and debrief form show an
+        # "Open work item" button (Windows) and the terminal next-action menu
+        # offers `[o] Open work item in browser`.
+        param([Parameter(Mandatory)] [int] $Id)
+        Open-MyTrackerItem -Id $Id
     } `
     -CloseItem   {
         # Optional. When present, the debrief shows a resolve checkbox

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -12,8 +12,8 @@
 #                                countdown to end early and still post a debrief.
 #   Register-TimerIntegration  - add an integration (Name, Description,
 #                                FetchItems, AddComment, optional ViewHint,
-#                                optional CloseItem). Registering with an
-#                                existing Name replaces it.
+#                                optional OpenItem, optional CloseItem).
+#                                Registering with an existing Name replaces it.
 #
 # Integration contract (each entry of $script:TimerIntegrations):
 #   Name        [string]      - display name shown in the picker
@@ -25,6 +25,15 @@
 #   ViewHint    [scriptblock] - param([int]$Id); returns a one-line string
 #                               printed after a successful comment post
 #                               (e.g. "View discussion: az-Open-WorkItemById 1234")
+#   OpenItem    [scriptblock] - optional; param([int]$Id); opens the work item
+#                               in the OS browser. Azure DevOps maps this to
+#                               az-Open-WorkItemById. When provided, both the
+#                               WPF countdown overlay and the WPF debrief form
+#                               surface an "Open work item" button (clicking it
+#                               opens the browser without stopping the timer or
+#                               closing the form); the terminal path offers an
+#                               "[o] Open in browser" choice in the next-action
+#                               menu.
 #   CloseItem   [scriptblock] - optional; param([int]$Id); transitions the work
 #                               item to its done state. Azure DevOps maps this
 #                               to System.State=$script:TimerCloseState (default
@@ -134,42 +143,70 @@ function Read-TimerNextAction {
     # Console counterpart to the WPF debrief's restart buttons. Offers the same
     # three-way choice and returns the shared action token: 'SameItem' reuses
     # the work item just debriefed, 'NewItem' returns to the picker, 'Done'
-    # (also the blank/unrecognized default) ends the loop.
+    # (also the blank/unrecognized default) ends the loop. When -OpenAction is
+    # supplied an extra "[o] Open work item" choice opens the item in the
+    # browser and re-prompts, so opening never consumes the restart decision.
     param(
-        [Parameter(Mandatory)] [string] $ItemLabel
+        [Parameter(Mandatory)] [string] $ItemLabel,
+        [scriptblock] $OpenAction
     )
 
-    Write-Host ""
-    Write-Host "Start another session?" -ForegroundColor Cyan
-    Write-Host "  [s] Same item — $ItemLabel"
-    Write-Host "  [p] Pick another item"
-    Write-Host "  [d] Done"
+    $openEnabled = ($null -ne $OpenAction)
 
-    $raw = Read-Host "Choose [s/p/D]"
-    if (-not $raw) {
-        return 'Done'
+    $prompt = if ($openEnabled) {
+        "Choose [s/p/o/D]"
+    } else {
+        "Choose [s/p/D]"
     }
 
-    $normalized = $raw.Trim().ToLowerInvariant()
-    switch ($normalized) {
-        's' {
-            return 'SameItem'
+    while ($true) {
+        Write-Host ""
+        Write-Host "Start another session?" -ForegroundColor Cyan
+        Write-Host "  [s] Same item — $ItemLabel"
+        Write-Host "  [p] Pick another item"
+        if ($openEnabled) {
+            Write-Host "  [o] Open work item in browser"
         }
+        Write-Host "  [d] Done"
 
-        'same' {
-            return 'SameItem'
-        }
-
-        'p' {
-            return 'NewItem'
-        }
-
-        'pick' {
-            return 'NewItem'
-        }
-
-        default {
+        $raw = Read-Host $prompt
+        if (-not $raw) {
             return 'Done'
+        }
+
+        $normalized = $raw.Trim().ToLowerInvariant()
+        switch ($normalized) {
+            's' {
+                return 'SameItem'
+            }
+
+            'same' {
+                return 'SameItem'
+            }
+
+            'p' {
+                return 'NewItem'
+            }
+
+            'pick' {
+                return 'NewItem'
+            }
+
+            'o' {
+                if ($openEnabled) {
+                    & $OpenAction
+                }
+            }
+
+            'open' {
+                if ($openEnabled) {
+                    & $OpenAction
+                }
+            }
+
+            default {
+                return 'Done'
+            }
         }
     }
 }
@@ -275,6 +312,7 @@ function az-Register-TimerIntegration {
         [Parameter(Mandatory)] [scriptblock] $FetchItems,
         [Parameter(Mandatory)] [scriptblock] $AddComment,
         [scriptblock] $ViewHint,
+        [scriptblock] $OpenItem,
         [scriptblock] $CloseItem
     )
 
@@ -284,6 +322,7 @@ function az-Register-TimerIntegration {
         FetchItems  = $FetchItems
         AddComment  = $AddComment
         ViewHint    = $ViewHint
+        OpenItem    = $OpenItem
         CloseItem   = $CloseItem
     }
 
@@ -355,12 +394,18 @@ function Show-TimerCountdown {
     # Delegates to the WPF circular overlay on Windows; falls back to the
     # snake-animation on macOS / Linux. Returns the same outcome shape in
     # both paths so the orchestrator (az-Start-TimerSession) is unchanged.
-    param([Parameter(Mandatory)] [int] $Seconds)
+    # -OpenAction, when supplied, adds an "Open work item" button to the WPF
+    # overlay; the snake fallback has no buttons and ignores it (the terminal
+    # next-action menu carries the open affordance instead).
+    param(
+        [Parameter(Mandatory)] [int] $Seconds,
+        [scriptblock] $OpenAction
+    )
 
     $onWindows = Test-WpfIsWindows
 
     if ($onWindows) {
-        $result = Show-WpfTimerCountdown -Seconds $Seconds
+        $result = Show-WpfTimerCountdown -Seconds $Seconds -OpenAction $OpenAction
         return $result
     }
 
@@ -429,10 +474,16 @@ function Show-WpfTimerCountdown {
     # as Show-TimerCountdown so az-Start-TimerSession needs no changes.
     # If "Capture Story" is clicked the overlay closes, az-New-AzDevOpsUserStory
     # runs in the terminal, then the overlay reopens with the remaining time.
-    param([Parameter(Mandatory)] [int] $Seconds)
+    # When -OpenAction is supplied an "Open work item" button is shown; clicking
+    # it opens the item in the browser without stopping the countdown.
+    param(
+        [Parameter(Mandatory)] [int] $Seconds,
+        [scriptblock] $OpenAction
+    )
 
     Add-Type -AssemblyName PresentationFramework, WindowsBase, PresentationCore
 
+    $openEnabled    = ($null -ne $OpenAction)
     $flashMaxTicks  = 15
     $defaultSeconds = $Seconds
 
@@ -535,6 +586,26 @@ function Show-WpfTimerCountdown {
         $actionRow.Children.Add($btnCapture)  | Out-Null
         $actionRow.Children.Add($btnComplete) | Out-Null
         $vbox.Children.Add($actionRow) | Out-Null
+
+        $openRow = New-Object System.Windows.Controls.StackPanel -Property @{
+            Orientation         = 'Horizontal'
+            HorizontalAlignment = 'Center'
+            Margin              = '0,0,0,5'
+            Visibility          = [System.Windows.Visibility]::Collapsed
+        }
+        $btnOpenItem = New-Object System.Windows.Controls.Button -Property @{
+            Content    = 'Open work item'
+            Width      = 120
+            Height     = 22
+            Background = $brushes.Button
+            Foreground = $brushes.White
+        }
+        $openRow.Children.Add($btnOpenItem) | Out-Null
+        $vbox.Children.Add($openRow) | Out-Null
+
+        if ($openEnabled) {
+            $openRow.Visibility = [System.Windows.Visibility]::Visible
+        }
 
         $exitHint = New-Object System.Windows.Controls.TextBlock -Property @{
             Text                = 'Click time to pause  ·  Right-click to exit'
@@ -690,6 +761,10 @@ function Show-WpfTimerCountdown {
                 $Script:WpfOutcome = 'Interrupted'
                 $mainWin.Close()
             }
+        })
+
+        $btnOpenItem.Add_Click({
+            & $OpenAction
         })
 
         # ---- Show ----
@@ -872,6 +947,30 @@ function New-TimerCloseScript {
 }
 
 
+function New-TimerOpenScript {
+    # Builds the closure that invokes the chosen integration's OpenItem against
+    # the picked item's Id. Both WPF surfaces (countdown overlay + debrief form)
+    # and the terminal next-action menu need the same { & $chosen.OpenItem -Id
+    # $pickedItem.Id }.GetNewClosure() shape, so they share this helper instead
+    # of inlining it. Returns $null when the integration supplies no OpenItem,
+    # so callers can use the result directly as the "is open available?" gate.
+    param(
+        [Parameter(Mandatory)] $Integration,
+        [Parameter(Mandatory)] $Item
+    )
+
+    if ($null -eq $Integration.OpenItem) {
+        return $null
+    }
+
+    $openScript = {
+        & $Integration.OpenItem -Id $Item.Id
+    }.GetNewClosure()
+
+    return $openScript
+}
+
+
 function Show-WpfTimerDebrief {
     # Windows-only themed debrief form the countdown overlay morphs into. Two
     # multiline fields (Debrief + Next) share the timer's dark/blue theme. On
@@ -895,6 +994,7 @@ function Show-WpfTimerDebrief {
     param(
         [Parameter(Mandatory)] [bool]        $Interrupted,
         [Parameter(Mandatory)] [scriptblock] $SubmitAction,
+        [scriptblock] $OpenAction,
         [scriptblock] $CloseAction
     )
 
@@ -908,6 +1008,7 @@ function Show-WpfTimerDebrief {
     $Script:WpfDebriefCloseRequested = $false
     $Script:WpfDebriefCloseResult    = $null
 
+    $openEnabled   = ($null -ne $OpenAction)
     $closeEnabled  = ($null -ne $CloseAction)
     $checkboxLabel = "Work complete — resolve this story (sets State=$script:TimerCloseState)"
 
@@ -954,6 +1055,27 @@ function Show-WpfTimerDebrief {
         Cursor              = [System.Windows.Input.Cursors]::SizeAll
     }
     $vbox.Children.Add($titleLabel) | Out-Null
+
+    # ---- Open-item button (only when integration supplies an OpenAction) ----
+
+    $openPanel = New-Object System.Windows.Controls.StackPanel -Property @{
+        HorizontalAlignment = 'Center'
+        Margin              = '0,0,0,12'
+        Visibility          = [System.Windows.Visibility]::Collapsed
+    }
+    $btnOpenItem = New-Object System.Windows.Controls.Button -Property @{
+        Content    = 'Open work item'
+        Width      = 130
+        Height     = 24
+        Background = $brushes.Button
+        Foreground = $brushes.White
+    }
+    $openPanel.Children.Add($btnOpenItem) | Out-Null
+    $vbox.Children.Add($openPanel) | Out-Null
+
+    if ($openEnabled) {
+        $openPanel.Visibility = [System.Windows.Visibility]::Visible
+    }
 
     # ---- Debrief field ----
 
@@ -1117,6 +1239,10 @@ function Show-WpfTimerDebrief {
             $Script:WpfDebriefOutcome = 'Cancelled'
         }
         $mainWin.Close()
+    })
+
+    $btnOpenItem.Add_Click({
+        & $OpenAction
     })
 
     $btnPost.Add_Click({
@@ -1294,8 +1420,10 @@ function az-Start-TimerSession {
             Write-Host "Starting $Minutes-minute session on item $($pickedItem.Id): $($pickedItem.Title)" -ForegroundColor Green
             Start-Sleep -Seconds 2
 
+            $openAction = New-TimerOpenScript -Integration $chosen -Item $pickedItem
+
             $seconds         = $Minutes * 60
-            $countdownResult = Show-TimerCountdown -Seconds $seconds
+            $countdownResult = Show-TimerCountdown -Seconds $seconds -OpenAction $openAction
 
             $onWindows = Test-WpfIsWindows
 
@@ -1326,6 +1454,7 @@ function az-Start-TimerSession {
                 $debriefResult = Show-WpfTimerDebrief `
                     -Interrupted  $countdownResult.Interrupted `
                     -SubmitAction $submitAction `
+                    -OpenAction   $openAction `
                     -CloseAction  $closeAction
 
                 if (-not $debriefResult.PostResult) {
@@ -1393,7 +1522,7 @@ function az-Start-TimerSession {
                 }
 
                 $itemLabel  = "$($pickedItem.Id): $($pickedItem.Title)"
-                $nextAction = Read-TimerNextAction -ItemLabel $itemLabel
+                $nextAction = Read-TimerNextAction -ItemLabel $itemLabel -OpenAction $openAction
             }
 
             $resolved      = Resolve-TimerNextAction -Action $nextAction
@@ -1464,6 +1593,10 @@ az-Register-TimerIntegration `
         param([Parameter(Mandatory)] [int] $Id)
         $hint = "View discussion: az-Open-WorkItemById $Id"
         return $hint
+    } `
+    -OpenItem    {
+        param([Parameter(Mandatory)] [int] $Id)
+        az-Open-WorkItemById -Id $Id
     } `
     -CloseItem   {
         param([Parameter(Mandatory)] [int] $Id)


### PR DESCRIPTION
<!-- toc:start -->
## 🧭 Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #140 |
| [Changes](#changes) | ✅ 2 files |
| [Shell parity](#shell-parity) | ⚠️ PowerShell-only (by design) |
| [Test Plan](#test-plan) | ✅ 5 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4633794158) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4633798490) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4633802270) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4633798965) |
| ✅ Criteria Check | ✅ PASS (7/7 code-verifiable) — [View](#issuecomment-4633812462) |
| 📄 Docs Check | ✅ CURRENT — [View](#issuecomment-4633813305) |

> **Reviewer note:** `pwsh` is not on PATH in the CI environment, so the PowerShell parse gate was reviewed by reading (braces/params balanced). Please run a local `pwsh -NoProfile` parse of `powcuts_by_cli/pow_timer.ps1` and the Windows / macOS-Linux runtime checks before merge.
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

An integration that supplies an optional `OpenItem` scriptblock gets a one-build open-closure (`New-TimerOpenScript`, `$null` when absent) that is threaded into all three session surfaces. The closure is gated once — when present, the two WPF surfaces show an **Open work item** button and the terminal next-action menu shows `[o]`; all three route to `az-Open-WorkItemById`, which launches the browser. When absent, the affordance is simply hidden.

```mermaid
flowchart TD
    Register([az-Register-TimerIntegration<br/>optional OpenItem param]):::pub
    Contract[OpenItem scriptblock<br/>on integration]:::priv
    Start([az-Start-TimerSession]):::pub
    NewOpen[New-TimerOpenScript<br/>returns null if no OpenItem]:::priv
    Gate{OpenItem<br/>supplied?}
    Hidden([affordance hidden]):::priv

    Countdown["Show-WpfTimerCountdown<br/>Open work item button<br/>clock keeps running"]:::pub
    Debrief["Show-WpfTimerDebrief<br/>Open work item button<br/>form stays open"]:::pub
    Menu["Read-TimerNextAction<br/>o Open in browser<br/>re-prompts"]:::pub

    OpenById[az-Open-WorkItemById]:::priv
    Browser["Start-Process url<br/>browser"]:::io

    Register --> Contract
    Start --> NewOpen --> Gate
    Gate -- no --> Hidden
    Gate -- yes --> Countdown
    Gate -- yes --> Debrief
    Gate -- yes --> Menu
    Countdown --> OpenById
    Debrief --> OpenById
    Menu --> OpenById
    OpenById --> Browser
    Contract -.consumed by.-> NewOpen

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Adds a one-click **Open work item** affordance to every `Start-TimerSession` surface, so you can jump to the Azure DevOps work item in your browser without copying its ID into a separate command. The action is threaded through the integration contract (mirroring the existing optional `CloseItem`), so the timer stays integration-agnostic.

## Issue

Closes #140

## Changes

- **`powcuts_by_cli/pow_timer.ps1`**
  - `az-Register-TimerIntegration` gains an optional `OpenItem` scriptblock (`param([int]$Id)`), documented in the integration-contract header
  - New `New-TimerOpenScript` helper builds the open closure (mirrors `New-TimerCloseScript`); returns `$null` when no `OpenItem`, so callers use it directly as the "is open available?" gate
  - `Show-WpfTimerCountdown` / `Show-WpfTimerDebrief` render an **Open work item** button when an `OpenAction` is supplied — clicking opens the browser without stopping the countdown or closing the form
  - `Read-TimerNextAction` offers an `[o] Open work item in browser` choice (macOS/Linux) that opens and re-prompts, so opening never consumes the restart decision
  - The built-in **Azure DevOps** integration maps `OpenItem` → `az-Open-WorkItemById`
- **`README.md`** — new "Opening the work item in your browser" subsection + `-OpenItem` in the custom-integration registration example

## Shell parity

PowerShell-only — `pow_timer.ps1` has no bash counterpart (bash has no timer). Cross-platform within PowerShell: WPF buttons on Windows, `[o]` terminal option on macOS/Linux. Gated on the integration supplying `OpenItem`, so integrations without it are unaffected.

## Test Plan

- [ ] **Windows pwsh:** `reinit`, run `Start-TimerSession` → **Open work item** button on the countdown overlay opens the item and the timer keeps running
- [ ] **Windows pwsh:** reach the debrief form → button opens the item and the form stays open
- [ ] **macOS/Linux pwsh:** `Start-TimerSession -Minutes 1` → at the next-action menu, `[o]` opens the item in the browser and re-prompts
- [ ] Register a dummy integration with no `OpenItem` → no button / no `[o]` option appears
- [ ] `pwsh` parses `powcuts_by_cli/pow_timer.ps1` with zero errors

https://claude.ai/code/session_011ShAnu7nU5koA5cMP4Hqbb