### PR TITLE
Rework debrief team tagging into a blank in-form field (no prompt, no grid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ Press **Esc** during the countdown (or use **Mark Complete Early** on the Window
 
 On both platforms the **Start another session?** choice appears after every successful post (completed or interrupted). On macOS/Linux it's a terminal prompt — `[s] Same item / [p] Pick another item / [d] Done` (blank or `d` ends the session) — mirroring the Windows buttons: **Same item** loops straight back to the countdown on the work item you just debriefed, **Pick another** returns to the picker so you can pivot to a different story / integration without retyping the command. **Ctrl-C** is still a hard exit — no debrief, no comment.
 
-When the chosen integration is Azure DevOps and you've cached a roster with `az-Sync-AzDevOpsTeam`, the debrief first asks **"Tag teammate(s) on this debrief?"** so you can notify colleagues on the posted comment — see [Tagging teammates](#tagging-teammates) below. Custom integrations can opt into the same picker by registering with `-SupportsMentions`.
+When the chosen integration is Azure DevOps and you've cached a roster with `az-Sync-AzDevOpsTeam`, the debrief form shows a **"Tag teammates" field** (type a name/email, click a suggestion) so you can notify colleagues on the posted comment — see [Tagging teammates](#tagging-teammates) below. Custom integrations can opt into the same field by registering with `-SupportsMentions`.
 
 ### Registering your own integration
 
@@ -727,5 +727,10 @@ $env:AZ_TEAM = 'contractor@example.com;lead@othergroup.com'
 az-Sync-AzDevOpsTeam
 ```
 
-Once a roster is cached, each debrief asks **"Tag teammate(s) on this debrief? [y/N]"**. Answer yes and you get a type-to-filter picker showing each teammate's **name and email** so you can confirm the right person; the ones you pick are added to the posted comment as real `@`-mentions, so they're notified. Tagging is always optional — the prompt defaults to no, and picking nobody (or skipping it) posts the debrief exactly as before. If you've never run `az-Sync-AzDevOpsTeam`, the prompt is skipped entirely.
+Once a roster is cached, each debrief gives you a **"Tag teammates" field** — there's no yes/no prompt to get past:
+
+- **On Windows** (the Pomodoro timer's debrief form) it's a blank text box above the **Post** button. Start typing a name or email and a small list of matching teammates appears underneath; click one to add it. Added people show on a **"Tagged: …"** line (click that line to clear). Leave the box empty to tag nobody.
+- **On macOS/Linux and in the unplanned-work debriefs** it's a single blank prompt — `Tag teammates (; or , separated names/emails, blank = none)`. Type one or more teammates (or just press Enter to skip).
+
+Either way the people you pick are added to the posted comment as real `@`-mentions, so they're notified. Typed entries resolve against the cached roster first and fall back to a live identity lookup, so a name that's slightly outside your synced team still works. Tagging is always optional, and if you've never run `az-Sync-AzDevOpsTeam` the field doesn't appear at all.
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -625,14 +625,14 @@ flowchart TD
     AskFuture -- yes --> MaybeStory["(opt) az-New-AzDevOpsUserStory"]
     AskFuture -- no --> Tag
     MaybeStory --> Tag
-    Tag["Select-AzDevOpsMention<br/>type-to-filter roster picker (Name+Email)<br/>→ Format-AzDevOpsMentionAnchor (data-vss-mention)"]
+    Tag["Select-AzDevOpsMention<br/>typed tag field → ConvertFrom-AzDevOpsMentionInput<br/>→ Format-AzDevOpsMentionAnchor (data-vss-mention)"]
     Tag --> PostComment
     PostComment["Format-UnplannedDebriefComment<br/>(+ @-mention anchors)<br/>→ Add-AzDevOpsDiscussionComment<br/>→ az boards work-item update (--discussion)"]
     PostComment --> Ledger["Add-UnplannedLedgerEntry<br/>unplanned-YYYY-MM-DD.json"]
     Ledger --> Done([end])
 
     DebriefDay([New-UnplannedWorkDebrief]) --> ReadLedger["read day ledger<br/>Measure-Object -Property Minutes"]
-    ReadLedger --> TagDay["Select-AzDevOpsMention<br/>(same shared roster picker)"]
+    ReadLedger --> TagDay["Select-AzDevOpsMention<br/>(same shared typed tag field)"]
     TagDay --> Rollup["Format-UnplannedDailyDebrief<br/>(+ @-mention anchors)<br/>→ Add-AzDevOpsDiscussionComment on daily story"]
     Rollup --> Done2([end])
 
@@ -644,7 +644,7 @@ flowchart TD
     class Find,NewStory,Task,FlushDesc,PostComment,Ledger,Rollup,ResolveTeam,TeamCache io
 ```
 
-Capture lands in two places per firefight: the accumulated bullet items flush to the Task **description** once at stop, and a single **discussion comment** carries the time spent, debrief notes, and any future-feature opportunity. Before each comment posts, `Select-AzDevOpsMention` offers a type-to-filter picker over the cached team roster (`team.json`). That roster and picker are **shared** — they live in `azdevops_team.ps1` and the Pomodoro timer's debrief (`pow_timer.ps1`) tags through the same surface. `az-Sync-AzDevOpsTeam` builds the roster primarily from a **project team's members** (`az devops team list-member`, which returns name/email/identity-GUID in one call), optionally supplemented by `$env:AZ_TEAM` (';'/','-separated emails/names resolved individually via `Get-AzDevOpsIdentity`). Picked teammates are injected as real `data-vss-mention` anchors so they're notified. Tagging is optional — an empty pick (or an un-synced roster) posts the debrief unchanged. Pure-UI helpers (`Show-UnplannedStatus`, `Format-UnplannedElapsed`, `Read-UnplannedYesNo`) are session-internal and omitted from the dependency map below.
+Capture lands in two places per firefight: the accumulated bullet items flush to the Task **description** once at stop, and a single **discussion comment** carries the time spent, debrief notes, and any future-feature opportunity. Before each comment posts, the debrief shows a **typed tag field** (`Select-AzDevOpsMention` — a blank Read-Host here; an in-form text box with a live suggestion list on the Pomodoro timer's WPF debrief). Whatever you type (';'/','-separated names/emails) flows through `ConvertFrom-AzDevOpsMentionInput` → `Resolve-AzDevOpsMentionToken`, which matches each token against the cached roster (`team.json`) first and falls back to a live `Get-AzDevOpsIdentity` lookup. That roster and tag surface are **shared** — they live in `azdevops_team.ps1` and the timer (`pow_timer.ps1`) tags through the same code. `az-Sync-AzDevOpsTeam` builds the roster primarily from a **project team's members** (`az devops team list-member`, which returns name/email/identity-GUID in one call), optionally supplemented by `$env:AZ_TEAM`. Picked teammates are injected as real `data-vss-mention` anchors so they're notified. Tagging is optional — a blank field (or an un-synced roster) posts the debrief unchanged. Pure-UI helpers (`Show-UnplannedStatus`, `Format-UnplannedElapsed`, `Read-UnplannedYesNo`) are session-internal and omitted from the dependency map below.
 
 ---
 
@@ -719,7 +719,8 @@ graph LR
     UWTeamRead[Read-AzDevOpsTeamCache]:::priv
     UWTeamPath[Get-AzDevOpsTeamCachePath]:::priv
     UWMentionPick[Select-AzDevOpsMention]:::priv
-    UWMentionMenu[Select-AzDevOpsMentionFromMenu]:::priv
+    UWMentionInput[ConvertFrom-AzDevOpsMentionInput]:::priv
+    UWMentionToken[Resolve-AzDevOpsMentionToken]:::priv
     UWAnchor[Format-AzDevOpsMentionAnchor]:::priv
     UWMentionLine[Format-AzDevOpsMentionLine]:::priv
 
@@ -1231,7 +1232,9 @@ graph LR
     InvUWDebrief --> UWMentionLine
     NewUWDebrief --> UWMentionLine
     UWMentionPick --> UWGetTeam
-    UWMentionPick --> UWMentionMenu
+    UWMentionPick --> UWMentionInput
+    UWMentionInput --> UWMentionToken
+    UWMentionToken --> UWResolve
     UWGetTeam --> UWTeamRead
     UWMentionLine --> UWAnchor
     UWTeamSave --> UWTeamPath

--- a/powcuts_by_cli/azdevops_team.ps1
+++ b/powcuts_by_cli/azdevops_team.ps1
@@ -24,8 +24,14 @@
 #                          changing $env:AZ_TEAM.
 #
 # Internal entry points (called by the debriefs):
-#   Select-AzDevOpsMention     - the optional "Tag teammate(s)?" type-to-filter
-#                                picker over the cached roster.
+#   Select-AzDevOpsMention     - console tag field for the debriefs with no WPF
+#                                form (non-Windows timer + unplanned). A blank
+#                                Read-Host (type names/emails, blank = none) -
+#                                no yes/no gate, no grid. The WPF timer form has
+#                                its own in-form tag field (Show-WpfTimerDebrief).
+#   ConvertFrom-AzDevOpsMentionInput - resolve a typed ';'/','-separated tag
+#                                string to teammate records (roster match first,
+#                                live identities lookup as fallback).
 #   Format-AzDevOpsMentionLine - render the picked members as a single
 #                                "Tagged: @a @b" line for a comment body.
 #
@@ -39,6 +45,7 @@ $script:AzDevOpsTeamEnvVar     = 'AZ_TEAM'
 $script:AzDevOpsTeamCacheFile  = 'team.json'
 $script:AzDevOpsMentionVersion = 'version:2.0'
 $script:AzDevOpsTeamIconPeople = [char]::ConvertFromUtf32(0x1F465)   # busts in silhouette
+$script:AzDevOpsListSeparators = [char[]]@(';', ',')                 # roster / tag-field delimiters
 
 
 function New-AzDevOpsTeamMemberRecord {
@@ -104,7 +111,7 @@ function Get-AzDevOpsTeamEnvRoster {
         return @()
     }
 
-    $separators = [char[]]@(';', ',')
+    $separators = $script:AzDevOpsListSeparators
     $parts      = $raw.Split($separators, [StringSplitOptions]::RemoveEmptyEntries)
 
     $seen   = New-Object System.Collections.Generic.HashSet[string]
@@ -374,73 +381,104 @@ function Format-AzDevOpsMentionLine {
 }
 
 
-function Select-AzDevOpsMentionFromMenu {
-    # Numbered Read-Host fallback for Select-AzDevOpsMention when no
-    # Out-ConsoleGridView host is available. Accepts a comma-separated list of
-    # indices; ignores blanks and out-of-range entries. Returns the chosen
-    # member records.
-    param([Parameter(Mandatory)] [object[]] $Team)
+function Resolve-AzDevOpsMentionToken {
+    # Resolve one typed token (a name or email) to a teammate record. Prefers a
+    # match in the already-synced roster - exact email first, then a name/email
+    # substring - so tagging is instant and offline. Falls back to a live
+    # identities lookup when the roster has no match, so typing a teammate works
+    # even before az-Sync-AzDevOpsTeam has run. Returns $null when nothing matches.
+    param(
+        [Parameter(Mandatory)] [string] $Token,
+        [AllowEmptyCollection()] [object[]] $Roster
+    )
 
-    Write-Host ''
-    Write-Host 'Teammates available to tag:' -ForegroundColor Cyan
-    for ($i = 0; $i -lt $Team.Count; $i++) {
-        $member = $Team[$i]
-        Write-Host ("  {0}) {1}  <{2}>" -f ($i + 1), $member.DisplayName, $member.Email)
+    $needle = $Token.Trim()
+    if (-not $needle) {
+        return $null
     }
 
-    $raw = Read-Host 'Numbers to tag (comma-separated, blank = none)'
-    if ([string]::IsNullOrWhiteSpace($raw)) {
+    $lower = $needle.ToLowerInvariant()
+
+    $exact = @($Roster | Where-Object {
+        $_.Email -and $_.Email.ToLowerInvariant() -eq $lower
+    })
+    if ($exact.Count -ge 1) {
+        $hit = $exact[0]
+        return $hit
+    }
+
+    $contains = @($Roster | Where-Object {
+        ($_.DisplayName -and $_.DisplayName.ToLowerInvariant().Contains($lower)) -or
+        ($_.Email -and $_.Email.ToLowerInvariant().Contains($lower))
+    })
+    if ($contains.Count -ge 1) {
+        $hit = $contains[0]
+        return $hit
+    }
+
+    $live = Resolve-AzDevOpsTeamMember -Identifier $needle
+    return $live
+}
+
+
+function ConvertFrom-AzDevOpsMentionInput {
+    # Turn a free-text tag field (';'- or ','-separated names/emails) into the
+    # teammate records to mention. Each token resolves via Resolve-AzDevOpsMentionToken;
+    # unresolved tokens are reported and skipped so one typo doesn't sink the rest.
+    # De-dupes by identity id. Blank input returns an empty array.
+    param(
+        [AllowEmptyString()] [string] $Text,
+        [AllowEmptyCollection()] [object[]] $Roster
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
         return @()
     }
 
-    $separators = [char[]]@(';', ',')
-    $tokens     = $raw.Split($separators, [StringSplitOptions]::RemoveEmptyEntries)
+    $separators = $script:AzDevOpsListSeparators
+    $tokens     = $Text.Split($separators, [StringSplitOptions]::RemoveEmptyEntries)
 
-    $picked = New-Object System.Collections.Generic.List[object]
+    $records = New-Object System.Collections.Generic.List[object]
+    $seenIds = New-Object System.Collections.Generic.HashSet[string]
     foreach ($token in $tokens) {
-        $index = 0
-        if ([int]::TryParse($token.Trim(), [ref]$index)) {
-            $zeroBased = $index - 1
-            if ($zeroBased -ge 0 -and $zeroBased -lt $Team.Count) {
-                $picked.Add($Team[$zeroBased])
-            }
+        $member = Resolve-AzDevOpsMentionToken -Token $token -Roster $Roster
+        if ($null -eq $member -or -not $member.Id) {
+            Write-Host "  Could not match '$($token.Trim())' to a teammate - skipping." -ForegroundColor Yellow
+            continue
+        }
+
+        if ($seenIds.Add($member.Id)) {
+            $records.Add($member)
         }
     }
 
-    $result = @($picked)
+    $result = @($records)
     return $result
 }
 
 
 function Select-AzDevOpsMention {
-    # Type-to-filter picker over the cached roster for debrief tagging. Shows
-    # Name + Email so the user can confirm the right person before tagging.
-    # Out-ConsoleGridView multi-select when available (its filter box is the
-    # "type and the right names bubble up" behavior); a Read-Host numbered menu
-    # otherwise. Returns the selected member records - possibly empty, since
-    # tagging is always optional and 'tag nobody' leaves the debrief unchanged.
-    # An empty cache (no roster synced) returns silently so a user who never
-    # tags isn't nagged - run az-Sync-AzDevOpsTeam to populate it.
-    $team = Get-AzDevOpsTeam
-    if ($team.Count -eq 0) {
+    # Console teammate tagging for the debriefs that have no WPF form (the
+    # non-Windows timer path and the unplanned-work debriefs). A single blank
+    # field - no yes/no gate, no grid: type one or more teammates (';'/','-
+    # separated names or emails), or leave it blank to tag nobody. Typed tokens
+    # resolve against the cached roster first, then a live identities lookup, so
+    # it works with or without a prior az-Sync-AzDevOpsTeam. Returns the matched
+    # records (possibly empty). A user who has never run az-Sync-AzDevOpsTeam
+    # has no roster, so the field is skipped silently rather than shown on every
+    # debrief.
+    $roster = @(Get-AzDevOpsTeam)
+    if ($roster.Count -eq 0) {
         return @()
     }
 
-    if (-not (Read-AzDevOpsYesNo -Prompt 'Tag teammate(s) on this debrief?' -DefaultNo)) {
+    $raw = Read-Host 'Tag teammates (; or , separated names/emails, blank = none)'
+    if ([string]::IsNullOrWhiteSpace($raw)) {
         return @()
     }
 
-    if (Test-AzDevOpsGridAvailable) {
-        $grid = $team |
-            Select-Object DisplayName, Email, Id |
-            Out-ConsoleGridView -Title 'Pick teammate(s) to tag (filter as you type, Esc = none)' -OutputMode Multiple
-
-        $picked = @($grid)
-        return $picked
-    }
-
-    $menuPicked = Select-AzDevOpsMentionFromMenu -Team $team
-    return $menuPicked
+    $members = ConvertFrom-AzDevOpsMentionInput -Text $raw -Roster $roster
+    return $members
 }
 
 

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -43,12 +43,14 @@
 #                               (WPF) / "Resolve this item now? [y/N]" prompt
 #                               (terminal) that fires only after a successful
 #                               AddComment.
-#   SupportsMentions [bool]   - optional; when set the debrief offers the shared
-#                               "Tag teammate(s)?" picker (Select-AzDevOpsMention
-#                               in azdevops_team.ps1) and appends a notifying
-#                               @-mention line to the composed comment. Only the
-#                               Azure DevOps integration sets it - the anchors
-#                               are AzDO identity GUIDs, meaningless elsewhere.
+#   SupportsMentions [bool]   - optional; when set (and a roster has been synced
+#                               via az-Sync-AzDevOpsTeam) the debrief shows a
+#                               "Tag teammates" field — an in-form type-to-filter
+#                               box on the WPF debrief, a typed Read-Host on the
+#                               console path — and appends a notifying @-mention
+#                               line to the composed comment. Only the Azure
+#                               DevOps integration sets it; the anchors are AzDO
+#                               identity GUIDs, meaningless elsewhere.
 #
 # Azure DevOps integration is registered at the bottom of this file; reads
 # $HOME/.bashcuts-cache/azure-devops/assigned.json (populated by
@@ -1011,6 +1013,14 @@ function Show-WpfTimerDebrief {
     # { Cancelled; NextAction; PostResult; CloseRequested; CloseResult } for the
     # orchestrator, where NextAction is 'Done' / 'SameItem' / 'NewItem'.
     #
+    # -TeamRoster, when non-empty, renders a "Tag teammates" field above the Post
+    # button: a blank textbox you type a name/email into; a live suggestion list
+    # under it filters the roster, and clicking a suggestion adds that teammate
+    # to a "Tagged:" line (click the line to clear). The selected records are
+    # passed to -SubmitAction as its THIRD argument, so SubmitAction's signature
+    # is param($DebriefText, $NextText, $Mentions). An empty roster hides the
+    # field entirely and SubmitAction receives an empty mention set.
+    #
     # The az post is synchronous on the dispatcher thread, so the spinner can't
     # truly animate during the call. The form forces a Render-priority dispatch
     # before posting so the "Posting..." overlay paints, then blocks briefly on
@@ -1018,6 +1028,7 @@ function Show-WpfTimerDebrief {
     param(
         [Parameter(Mandatory)] [bool]        $Interrupted,
         [Parameter(Mandatory)] [scriptblock] $SubmitAction,
+        [AllowEmptyCollection()] [object[]]  $TeamRoster = @(),
         [scriptblock] $OpenAction,
         [scriptblock] $CloseAction
     )
@@ -1032,8 +1043,15 @@ function Show-WpfTimerDebrief {
     $Script:WpfDebriefCloseRequested = $false
     $Script:WpfDebriefCloseResult    = $null
 
+    # Backing state for the tag-teammates field: the records picked so far, and
+    # the roster records parallel to the visible suggestion list (so a click maps
+    # back to a record without binding WPF to PSObject properties).
+    $Script:WpfDebriefMentions   = New-Object System.Collections.Generic.List[object]
+    $Script:WpfDebriefSuggestions = New-Object System.Collections.Generic.List[object]
+
     $openEnabled   = ($null -ne $OpenAction)
     $closeEnabled  = ($null -ne $CloseAction)
+    $tagEnabled    = (@($TeamRoster).Count -gt 0)
     $checkboxLabel = "Work complete — resolve this story (sets State=$script:TimerCloseState)"
 
     $brushes = New-WpfBrushSet -ProgressColor $script:WpfColorProgress
@@ -1146,6 +1164,53 @@ function Show-WpfTimerDebrief {
         Margin                      = '0,0,0,12'
     }
     $vbox.Children.Add($nextBox) | Out-Null
+
+    # ---- Tag-teammates field (only when a synced roster is supplied) ----
+
+    $tagLabel = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text       = 'Tag teammates (optional) — type a name or email'
+        FontSize   = 11
+        Foreground = $brushes.Hint
+        Margin     = '0,0,0,3'
+        Visibility = [System.Windows.Visibility]::Collapsed
+    }
+    $vbox.Children.Add($tagLabel) | Out-Null
+
+    $tagBox = New-Object System.Windows.Controls.TextBox -Property @{
+        Background  = $brushes.Button
+        Foreground  = $brushes.White
+        BorderBrush = $brushes.Stroke
+        Padding     = '4'
+        Margin      = '0,0,0,3'
+        Visibility  = [System.Windows.Visibility]::Collapsed
+    }
+    $vbox.Children.Add($tagBox) | Out-Null
+
+    $tagSuggestList = New-Object System.Windows.Controls.ListBox -Property @{
+        Background  = $brushes.Bg
+        Foreground  = $brushes.White
+        BorderBrush = $brushes.Stroke
+        MaxHeight   = 96
+        Margin      = '0,0,0,3'
+        Visibility  = [System.Windows.Visibility]::Collapsed
+    }
+    $vbox.Children.Add($tagSuggestList) | Out-Null
+
+    $tagChosenText = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text         = ''
+        FontSize     = 11
+        Foreground   = $brushes.White
+        TextWrapping = 'Wrap'
+        Margin       = '0,0,0,10'
+        Cursor       = [System.Windows.Input.Cursors]::Hand
+        Visibility   = [System.Windows.Visibility]::Collapsed
+    }
+    $vbox.Children.Add($tagChosenText) | Out-Null
+
+    if ($tagEnabled) {
+        $tagLabel.Visibility = [System.Windows.Visibility]::Visible
+        $tagBox.Visibility   = [System.Windows.Visibility]::Visible
+    }
 
     # ---- Resolve checkbox (only when integration supplies a CloseAction) ----
 
@@ -1269,9 +1334,74 @@ function Show-WpfTimerDebrief {
         & $OpenAction
     })
 
+    # Repaint the "Tagged:" line from the chosen-mentions backing list.
+    $refreshTagChosen = {
+        if ($Script:WpfDebriefMentions.Count -gt 0) {
+            $names = @($Script:WpfDebriefMentions | ForEach-Object { $_.DisplayName })
+            $tagChosenText.Text       = 'Tagged: ' + ($names -join ', ') + '   (click to clear)'
+            $tagChosenText.Visibility = [System.Windows.Visibility]::Visible
+        } else {
+            $tagChosenText.Text       = ''
+            $tagChosenText.Visibility = [System.Windows.Visibility]::Collapsed
+        }
+    }
+
+    $tagBox.Add_TextChanged({
+        $needle = $tagBox.Text.Trim().ToLowerInvariant()
+        if (-not $needle) {
+            $tagSuggestList.Items.Clear()
+            $tagSuggestList.Visibility = [System.Windows.Visibility]::Collapsed
+            return
+        }
+
+        $chosenIds = @($Script:WpfDebriefMentions | ForEach-Object { $_.Id })
+
+        $matches = @($TeamRoster | Where-Object {
+            ($_.Id -notin $chosenIds) -and (
+                ($_.DisplayName -and $_.DisplayName.ToLowerInvariant().Contains($needle)) -or
+                ($_.Email -and $_.Email.ToLowerInvariant().Contains($needle))
+            )
+        } | Select-Object -First 6)
+
+        $Script:WpfDebriefSuggestions.Clear()
+        $tagSuggestList.Items.Clear()
+        foreach ($member in $matches) {
+            $Script:WpfDebriefSuggestions.Add($member)
+            $tagSuggestList.Items.Add("$($member.DisplayName)  <$($member.Email)>") | Out-Null
+        }
+
+        $tagSuggestList.Visibility = if ($tagSuggestList.Items.Count -gt 0) {
+            [System.Windows.Visibility]::Visible
+        } else {
+            [System.Windows.Visibility]::Collapsed
+        }
+    })
+
+    $tagSuggestList.Add_SelectionChanged({
+        $index = $tagSuggestList.SelectedIndex
+        if ($index -lt 0 -or $index -ge $Script:WpfDebriefSuggestions.Count) {
+            return
+        }
+
+        $member = $Script:WpfDebriefSuggestions[$index]
+        $Script:WpfDebriefMentions.Add($member)
+
+        $tagBox.Text = ''
+        $tagSuggestList.Items.Clear()
+        $tagSuggestList.Visibility = [System.Windows.Visibility]::Collapsed
+
+        & $refreshTagChosen
+    })
+
+    $tagChosenText.Add_MouseLeftButtonUp({
+        $Script:WpfDebriefMentions.Clear()
+        & $refreshTagChosen
+    })
+
     $btnPost.Add_Click({
         $debriefText = $debriefBox.Text
         $nextText    = $nextBox.Text
+        $mentions    = @($Script:WpfDebriefMentions)
 
         $btnPost.IsEnabled      = $false
         $statusText.Foreground  = $brushes.White
@@ -1286,7 +1416,7 @@ function Show-WpfTimerDebrief {
             [System.Windows.Threading.DispatcherPriority]::Render
         )
 
-        $postResult = & $SubmitAction $debriefText $nextText
+        $postResult = & $SubmitAction $debriefText $nextText $mentions
 
         $spinner.Timer.Stop()
         $spinner.Text.Visibility = [System.Windows.Visibility]::Collapsed
@@ -1454,14 +1584,14 @@ function az-Start-TimerSession {
             $seconds         = $Minutes * 60
             $countdownResult = Show-TimerCountdown -Seconds $seconds -OpenAction $openAction
 
-            # Optional teammate tagging, offered only for integrations whose
-            # comments can carry AzDO @-mention anchors (SupportsMentions). The
-            # picker is a console TUI, so it runs here - before either debrief
-            # branch - rather than fighting the WPF form; the selection is then
-            # threaded into the composed comment in both the WPF and console paths.
-            $mentions = @()
-            if ($chosen.SupportsMentions -and (Get-Command Select-AzDevOpsMention -ErrorAction SilentlyContinue)) {
-                $mentions = Select-AzDevOpsMention
+            # Teammate tagging is offered only for integrations whose comments
+            # can carry AzDO @-mention anchors (SupportsMentions) and only once a
+            # roster has been synced. The WPF debrief form renders an in-form tag
+            # field from this roster; the console path prompts with a typed field
+            # below. An empty roster disables tagging on both paths.
+            $teamRoster = @()
+            if ($chosen.SupportsMentions -and (Get-Command Get-AzDevOpsTeam -ErrorAction SilentlyContinue)) {
+                $teamRoster = @(Get-AzDevOpsTeam)
             }
 
             $onWindows = Test-WpfIsWindows
@@ -1470,8 +1600,9 @@ function az-Start-TimerSession {
 
                 $submitAction = {
                     param(
-                        [string] $DebriefText,
-                        [string] $NextText
+                        [string]   $DebriefText,
+                        [string]   $NextText,
+                        [object[]] $Mentions
                     )
 
                     $composed = Format-TimerCommentBody `
@@ -1480,7 +1611,7 @@ function az-Start-TimerSession {
                         -TotalSeconds   $countdownResult.TotalSeconds `
                         -Debrief        $DebriefText `
                         -Next           $NextText `
-                        -Mentions       $mentions
+                        -Mentions       $Mentions
 
                     $posted = & $chosen.AddComment -Id $pickedItem.Id -Body $composed
                     return $posted
@@ -1494,6 +1625,7 @@ function az-Start-TimerSession {
                 $debriefResult = Show-WpfTimerDebrief `
                     -Interrupted  $countdownResult.Interrupted `
                     -SubmitAction $submitAction `
+                    -TeamRoster   $teamRoster `
                     -OpenAction   $openAction `
                     -CloseAction  $closeAction
 
@@ -1524,6 +1656,11 @@ function az-Start-TimerSession {
                 $iconMemo = $script:TimerIconMemo
                 $debrief  = Read-Host "$iconMemo Debrief — what did you accomplish?"
                 $next     = Read-Host "$iconMemo Next — what's the next step?"
+
+                $mentions = @()
+                if ($teamRoster.Count -gt 0 -and (Get-Command Select-AzDevOpsMention -ErrorAction SilentlyContinue)) {
+                    $mentions = Select-AzDevOpsMention
+                }
 
                 $body = Format-TimerCommentBody `
                     -Interrupted    $countdownResult.Interrupted `

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -1378,6 +1378,11 @@ function Show-WpfTimerDebrief {
     })
 
     $tagSuggestList.Add_SelectionChanged({
+        # The bounds guard is load-bearing, not defensive: clearing $tagBox.Text
+        # and the Items below re-fires TextChanged + SelectionChanged from inside
+        # this handler with SelectedIndex = -1, so the guard turns each re-entry
+        # into a safe no-op (without it, the empty re-entry would index past the
+        # suggestion list). Keep it.
         $index = $tagSuggestList.SelectedIndex
         if ($index -lt 0 -or $index -ge $Script:WpfDebriefSuggestions.Count) {
             return


### PR DESCRIPTION

## Table of Contents

&gt; **Reviews were completed on [#146](https://github.com/jdschleicher/bashcuts/pull/146)** — this PR is a continuation of branch `claude/team-tagging-debriefs-SPBZt` and carries the *same commits*, so the skill verdicts below link to comments on #146.

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Context](#context) | ✅ |
| [Changes](#changes) | ✅ 4 files |
| [Review status](#review-status) | ✅ |
| [Test Plan](#test-plan) | ✅ 5 items |
| **Skill Reports** (reviewed on #146) | |
| 🐚 Bash Engineer | ✅ APPROVE (no bash files) — [View](https://github.com/jdschleicher/bashcuts/pull/146#issuecomment-4635001698) |
| 💠 PowerShell Engineer | ✅ APPROVE (5 LOW) — [View](https://github.com/jdschleicher/bashcuts/pull/146#issuecomment-4635025148) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/146#issuecomment-4635029653) |
| 🧼 Clean-Code Engineer | ✅ APPROVE (1 MEDIUM, 1 LOW) — [View](https://github.com/jdschleicher/bashcuts/pull/146#issuecomment-4635013478) |
| ✅ Criteria Check (#136) | ✅ PASS (approved supersessions) — [View](https://github.com/jdschleicher/bashcuts/pull/146#issuecomment-4635068402) |
| 📚 Docs Check | ✅ CURRENT (pipeline, no comment) |
| 🧭 AzDO Diagrams | ✅ CURRENT (pipeline, no comment) |

<!-- pr-diagram:start -->
## How it works

This PR turns debrief teammate tagging into a blank, in-form **field**. Three debriefs surface it once the AzDO integration sets `SupportsMentions` and a roster has been synced: `az-Start-TimerSession` shows a WPF type-to-filter box, while `Start-UnplannedWork` / `New-UnplannedWorkDebrief` use a typed console `Read-Host`. Whatever is typed flows through one shared resolution path — split, resolve against the cached `team.json` roster (else a live identity lookup), then render a notifying `data-vss-mention` line appended to the posted comment. An empty roster hides the field on both paths.

```mermaid
flowchart TD
    StartTimer([az-Start-TimerSession]):::pub
    Unplanned([Start-UnplannedWork /<br/>New-UnplannedWorkDebrief]):::pub

    Gate{SupportsMentions<br/>+ roster synced?}
    Roster[(team.json roster)]:::io

    WpfField["Show-WpfTimerDebrief<br/>in-form 'Tag teammates' box"]
    Suggest["live type-to-filter<br/>suggestion ListBox"]
    Tagged["click suggestion →<br/>'Tagged:' line (click clears)"]
    Console["Select-AzDevOpsMention<br/>typed Read-Host"]

    Convert[ConvertFrom-AzDevOpsMentionInput<br/>split on ; or ,]:::priv
    Resolve[Resolve-AzDevOpsMentionToken<br/>roster match first]:::priv
    Live["Get-AzDevOpsIdentity<br/>live fallback"]:::io
    Format[Format-AzDevOpsMentionLine /<br/>Format-AzDevOpsMentionAnchor]:::priv
    Comment([data-vss-mention line<br/>appended to comment]):::pub

    StartTimer --> Gate
    Unplanned --> Gate
    Gate -- empty roster --> NoField([field hidden]):::priv
    Gate -- WPF --> WpfField
    Gate -- console --> Console

    Roster -.feeds.-> WpfField
    WpfField --> Suggest --> Tagged --> Format
    Console --> Convert

    Convert --> Resolve
    Resolve -- roster hit --> Format
    Resolve -- no match --> Live --> Format
    Roster -.feeds.-> Resolve

    Format --> Comment

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Follow-up to **#146** (merged). That PR landed teammate tagging with a yes/no **&#34;Tag teammate(s)?&#34;** prompt feeding an `Out-ConsoleGridView` picker that fired *before* the debrief. Per testing feedback, this reworks it into a **blank &#34;Tag teammates&#34; field** that lives inside the debrief itself — no yes/no gate, no grid:

- **WPF timer debrief** (`Show-WpfTimerDebrief`) — an in-form text box above **Post** with a **live type-to-filter suggestion list** drawn from the cached roster; click a suggestion to add it to a **&#34;Tagged: …&#34;** line (click the line to clear). Selected records pass to `SubmitAction` as a third argument; the form takes a new `-TeamRoster` param.
- **Console timer path + both unplanned debriefs** — a single typed `Read-Host &#39;Tag teammates (; or , separated names/emails, blank = none)&#39;`. Blank tags nobody; a never-synced roster skips the field silently.

Whatever is typed is split on `;`/`,` by `ConvertFrom-AzDevOpsMentionInput` and each token resolved by `Resolve-AzDevOpsMentionToken` — roster-match first, then a live `Get-AzDevOpsIdentity` fallback — before being appended as a notifying `data-vss-mention` anchor line.

## Context

The branch had two commits pushed **after** #146 was merged, so they never reached `main`:
- `95c4171` — Replace tag picker with an in-form blank field (no prompt, no grid)
- `de1d374` — Document the load-bearing `SelectionChanged` bounds guard

This PR brings exactly those two commits into `main`.

## Changes

- **`powcuts_by_cli/azdevops_team.ps1`** — `Select-AzDevOpsMention` is now a blank `Read-Host` field (empty-roster guard, no prompt/grid); new `ConvertFrom-AzDevOpsMentionInput` + `Resolve-AzDevOpsMentionToken` (roster-then-live resolution); removed `Select-AzDevOpsMentionFromMenu`; named the `;`/`,` split as `$script:AzDevOpsListSeparators`.
- **`powcuts_by_cli/pow_timer.ps1`** — `Show-WpfTimerDebrief` gains the in-form &#34;Tag teammates&#34; control (`-TeamRoster` param, `TextChanged` filter → suggestion `ListBox`, `SelectionChanged` add, clickable &#34;Tagged:&#34; clear); orchestrator rewired to a 3-arg `SubmitAction` and a roster fetch; console branch uses the typed field.
- **`README.md`** / **`docs/azure-devops-diagrams.md`** — Tagging section, timer pointer, and AzDO diagram updated for the field-based flow.

## Review status

These exact commits were reviewed in this session (comments on #146, since this PR is a continuation of that branch):
- 🐚 Bash — ✅ APPROVE (no bash files) · 💠 PowerShell — ✅ APPROVE (5 LOW) · 🛡️ Security — ✅ PASS · 🧼 Clean-Code — ✅ APPROVE (1 MEDIUM, 1 LOW)
- 📚 Docs — ✅ CURRENT · ✅ Criteria (#136) — PASS (approved supersessions) · 🧭 AzDO Diagrams — ✅ CURRENT

## Test Plan

PowerShell-only feature; `pwsh` was unavailable in the build container, so confirm locally:

- [ ] Fresh PowerShell terminal — `powcuts_home.ps1` dot-sources without parse errors.
- [ ] `Start-TimerSession -Minutes 1` on an AzDO item → WPF debrief shows the blank **Tag teammates** box; typing filters the suggestion list; clicking adds to &#34;Tagged:&#34;; the picked teammate is notified on the posted comment.
- [ ] `Start-UnplannedWork` → stop → typed `Read-Host` tag field; entered names resolve and notify.
- [ ] Leave the field blank → debrief posts unchanged, no mention line.
- [ ] With no roster synced (`az-Sync-AzDevOpsTeam` never run) → no tag field appears.

https://claude.ai/code/session_01CuUjx5xi8aeYjFmWoPKsh3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuUjx5xi8aeYjFmWoPKsh3)_