### PR TITLE
Prompt for User Story description in Feature child-story batch

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -511,7 +511,7 @@ DRY note: `Read-AzDevOpsEpicPick` and `Read-AzDevOpsFeaturePick` are 2-line wrap
 
 ## 9. `az-New-AzDevOpsFeatureStories` — batch child-story loop
 
-Batch counterpart to `az-New-AzDevOpsUserStory`. Captures parent / area / iteration **once** at the top, then loops per-story prompts (title, AC, priority, story points) until the user submits an empty title or answers `n` to "Add another?". Mid-batch failures don't abort. Each child create runs through the same `Invoke-AzDevOpsWorkItemCreate` + `Invoke-AzDevOpsParentLink` pair the single-shot creator uses, so failure modes / schema enforcement stay identical.
+Batch counterpart to `az-New-AzDevOpsUserStory`. Captures parent / area / iteration **once** at the top, then loops per-story prompts (title, description via `Read-AzDevOpsUserStoryDescription`, AC, priority, story points) until the user submits an empty title or answers `n` to "Add another?". Mid-batch failures don't abort. Each child create runs through the same `Invoke-AzDevOpsWorkItemCreate` + `Invoke-AzDevOpsParentLink` pair the single-shot creator uses, so failure modes / schema enforcement stay identical.
 
 ```mermaid
 flowchart TD
@@ -530,7 +530,8 @@ flowchart TD
     Loop[Story loop iteration N] --> ReadTitle["Read-Host 'Story title (Enter to finish batch)'"]
     ReadTitle --> EmptyTitle{empty?}
     EmptyTitle -- yes --> Summary
-    EmptyTitle -- no --> ReadAC[Read-AzDevOpsAcceptanceCriteria]
+    EmptyTitle -- no --> ReadDesc["Read-AzDevOpsUserStoryDescription<br/>(As-a / I-want / so-that prompts)"]
+    ReadDesc --> ReadAC[Read-AzDevOpsAcceptanceCriteria]
     ReadAC --> ReadPrio["Read-AzDevOpsPriority -Previous $previousPriority<br/>(Enter reuses last answer)"]
     ReadPrio --> ReadSP["Read-AzDevOpsStoryPoints -Previous $previousStoryPoints"]
     ReadSP --> Create["Invoke-AzDevOpsWorkItemCreate<br/>+ Invoke-AzDevOpsParentLink"]
@@ -1199,6 +1200,7 @@ graph LR
     NewSB --> ReadH
     NewSB --> ParentTest
     NewSB --> ResIA
+    NewSB --> USDesc
     NewSB --> AC
     NewSB --> Pri
     NewSB --> Pts

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -939,7 +939,8 @@ function Test-AzDevOpsParentIsFeature {
 function az-New-AzDevOpsFeatureStories {
     # Batch-create child User Stories under an existing Feature. Captures
     # parent / area / iteration ONCE up front; loops per-story prompts for
-    # title, AC, priority (Enter to reuse last), story points (same). At the
+    # title, description (As a / I want / so that), AC, priority (Enter to
+    # reuse last), story points (same). At the
     # end of each story prompts "Add another story? (y/N/c)" - 'c' re-picks
     # area / iteration without exiting the loop. Empty title at the top of
     # any iteration aborts the batch cleanly.
@@ -1005,6 +1006,7 @@ function az-New-AzDevOpsFeatureStories {
             break
         }
 
+        $description = Read-AzDevOpsUserStoryDescription
         $acceptanceCriteria = Read-AzDevOpsAcceptanceCriteria
         $priority = Resolve-AzDevOpsTypePriorityOrPrompt    -Type 'USER_STORY' -Previous $previousPriority
         $storyPoints = Resolve-AzDevOpsTypeStoryPointsOrPrompt -Type 'USER_STORY' -Previous $previousStoryPoints
@@ -1012,7 +1014,7 @@ function az-New-AzDevOpsFeatureStories {
 
         $createArgs = @{
             Title              = $title
-            Description        = ''
+            Description        = $description
             Priority           = $priority
             StoryPoints        = $storyPoints
             AcceptanceCriteria = $acceptanceCriteria


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Root cause](#root-cause) | ✅ |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | ✅ 5 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/154#issuecomment-4755530755) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/154#issuecomment-4755532542) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/154#issuecomment-4755533829) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/154#issuecomment-4755532918) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/154#issuecomment-4755537310) |
| 📚 AzDO Diagrams | ✅ STALE → fixed (commit c1f910d) |
<!-- toc:end -->

## Summary

Fixes a bug in the Azure DevOps create flow: after creating a Feature and opting into **"Add child stories now?"**, the per-story batch loop never asked for the canonical **"As a … / I want … / so that …"** description prompt that the single-shot `az-New-AzDevOpsUserStory` shows.

## Root cause

`az-New-AzDevOpsFeatureStories` (the batch creator that the Feature hand-off invokes) hardcoded `Description = ''` in its per-story loop, so the three-clause User Story description was silently skipped for every batch-created child.

## Changes

| File | Change |
|------|--------|
| `powcuts_by_cli/azdevops_create.ps1` | Call `Read-AzDevOpsUserStoryDescription` per story in the batch loop and pass its result as `Description` (was `''`). Updated the function docstring to list the description prompt. |
| `docs/azure-devops-diagrams.md` | Diagram 9 (batch story loop) gains the As-a/I-want/so-that node between the empty-title gate and the AC reader; prose prompt list + dependency-map edge updated to match. |

PowerShell-only — the Azure DevOps create flow has no bash counterpart, so no parity change is needed.

## Test Plan

- [ ] Open a fresh PowerShell terminal (or `. $profile`) to load the updated function
- [ ] Run `az-New-AzDevOpsFeature`, complete the Feature prompts, let it create
- [ ] At **"Add child stories now?"** answer `y`, enter a story title
- [ ] Confirm the prompts now appear in order: `As a ...`, `I want ...`, `so that ...`, then `Acceptance criterion #1`, priority, story points
- [ ] Confirm the created child story's Description field shows the three clauses on separate lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)