### PR TITLE
Guard against re-wrapping a List[T] in @() — recurring PowerShell fixed-size-array errors

### DIFF
--- a/.claude/commands/senior-powershell-engineer.md
+++ b/.claude/commands/senior-powershell-engineer.md
@@ -181,6 +181,22 @@ git diff main...HEAD -- 'powcuts_by_cli/*.ps1' 'powcuts_home.ps1' \
 
 ---
 
+## Check 11 — `@()` Around a Typed Collection [HIGH]
+
+Wrapping an already-built `[System.Collections.Generic.List[object]]` (or any typed collection) in the `@()` array-subexpression converts it to a **fixed-size `[object[]]`**. A later `.Add()` on that result throws `Collection was of a fixed size` / `does not contain a method named 'Add'` at runtime. This footgun keeps getting reintroduced — flag it.
+
+```bash
+git diff main...HEAD -- 'powcuts_by_cli/*.ps1' \
+  | grep "^+" | grep -v "^+++" \
+  | grep -nE '=\s*@\(\$[A-Za-z_][A-Za-z0-9_]*\)\s*$|return\s+@\(\$[A-Za-z_][A-Za-z0-9_]*\)\s*$' || true
+```
+
+For each hit, check what the wrapped variable is. **Flag** as **[HIGH]** when it's a `List`/typed collection the function built up with `.Add()` (look for a nearby `New-Object System.Collections.Generic.List` or `[List[...]]::new()`): the `@()` is a redundant fixed-size conversion. Suggested fix — return/pass the `List` directly (the binder coerces a `List` into an `[object[]]` parameter, and PowerShell unrolls it on output just like an array); cast `[object[]]$var` only when a downstream `[object[]]` parameter genuinely demands an array.
+
+**Do not flag** the legitimate uses of `@()`: normalizing an *unknown* return (scalar / `$null` / array) to an array — `$roster = @(Get-AzDevOpsTeam)` — or producing an empty array (`return @()`). The smell is specifically `@($localList)` on a collection the same function just constructed.
+
+---
+
 ## Output Format
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,22 @@ o-sfdx   o-git   o-gh   o-az   o-cci
 - **alias vs function (bash)** — use `alias` only for fixed substitutions. The moment you need `$1`, `$2`, `$@`, `read`, conditionals, or anything multi-line, use a function. Aliases don't expand positional parameters the way callers expect.
 - **No `Write-Host` for data (PowerShell)** — `Write-Host` cannot be captured or piped. Use it only for user-facing status messages. For values the caller might want to consume, use `Write-Output`, plain expressions, or `return`.
 - **No in-script aliases (PowerShell)** — inside committed `.ps1` files prefer full cmdlet names (`Where-Object` over `?`, `ForEach-Object` over `%`, `Get-ChildItem` over `ls`/`gci`).
+- **Never re-wrap a typed collection in `@()` (PowerShell)** — once you've built a `[System.Collections.Generic.List[object]]` (or any typed collection), do **not** pass its result through the `@()` array-subexpression. `@()` forces the list into a **fixed-size `[object[]]`**, and the next `.Add()` on that result throws `Collection was of a fixed size` / `does not contain a method named 'Add'` at runtime — a footgun that keeps getting reintroduced. The `List` already exposes `.Count` and enumerates (and PowerShell unrolls it on output exactly like an array), so return it as-is. Only cast `[object[]]$records` when a downstream `[object[]]`-typed parameter genuinely needs an array — and even then the parameter binder usually coerces a `List` for you, so prefer passing the `List` directly. **Bad:**
+  ```powershell
+  $records = New-Object System.Collections.Generic.List[object]
+  # ... $records.Add(...) ...
+  $roster = @($records)          # now a fixed-size object[]; a later .Add() blows up
+  Save-AzDevOpsTeamCache -Members $roster
+  return $roster
+  ```
+  **Good:**
+  ```powershell
+  $records = New-Object System.Collections.Generic.List[object]
+  # ... $records.Add(...) ...
+  Save-AzDevOpsTeamCache -Members $records   # [object[]] param coerces the List
+  return $records
+  ```
+  Reserve `@(...)` for the cases it's actually meant for: normalizing an *unknown* return (scalar / `$null` / array) to an array so `.Count` and `foreach` are safe (`$roster = @(Get-AzDevOpsTeam)`), or producing an empty array (`return @()`). It is not a no-op finisher to slap on a `List` you already control.
 - **Quote variable expansions (bash)** — paths with spaces (`C:\Program Files`, `~/Library/Application Support`) break unquoted `$var`. The README explicitly warns about path-with-spaces; new code must respect that.
 - **macOS `start`** — `.bcut_home` aliases `start` to `open` on Darwin. Code that uses `start` to open files/URLs is fine; **don't redefine `start` and don't pass platform-specific flags** (e.g. Windows `start /B`, mac `open -a "App"`) without an OS conditional.
 - **No comments for self-evident code** — only comment where the logic is genuinely non-obvious.

--- a/powcuts_by_cli/azdevops_team.ps1
+++ b/powcuts_by_cli/azdevops_team.ps1
@@ -123,8 +123,7 @@ function Get-AzDevOpsTeamEnvRoster {
         }
     }
 
-    $result = @($roster)
-    return $result
+    return $roster
 }
 
 
@@ -314,9 +313,8 @@ function Sync-AzDevOpsTeam {
         }
     }
 
-    $roster = @($records)
-    Save-AzDevOpsTeamCache -Members $roster
-    return $roster
+    Save-AzDevOpsTeamCache -Members $records
+    return $records
 }
 
 
@@ -452,8 +450,7 @@ function ConvertFrom-AzDevOpsMentionInput {
         }
     }
 
-    $result = @($records)
-    return $result
+    return $records
 }
 
 


### PR DESCRIPTION
<!-- toc:start -->
## Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #156 |
| [Changes](#changes) | ✅ 3 files |
| [Test Plan](#test-plan) | ✅ 3 items |
| **Skill Reports** | |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/157#issuecomment-4781677519) |
| 🛡️ Security Audit | ✅ No concerns — [View](https://github.com/jdschleicher/bashcuts/pull/157#issuecomment-4781677363) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/157#issuecomment-4781678916) |
| 📚 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/157#issuecomment-4781690034) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/157#issuecomment-4781691227) |

_Bash Engineer: APPROVE — no bash files changed (no comment posted). AzDO Diagrams: CURRENT (no comment posted)._
<!-- toc:end -->

## Summary
Wrapping an already-built `[System.Collections.Generic.List[object]]` in the `@()` array-subexpression forces it into a **fixed-size `[object[]]`**, so a later `.Add()` throws `Collection was of a fixed size` / `does not contain a method named &#39;Add&#39;` at runtime. This idiom kept getting reintroduced and breaking the roster/mention flows. This PR removes the live occurrences and adds a documented guardrail + automated review check so it stops coming back.

## Issue
Closes #156

## Changes
- **`powcuts_by_cli/azdevops_team.ps1`** — dropped the redundant `@()` re-wrap in three spots and return/pass the `List` directly:
  - `Get-AzDevOpsTeamEnvRoster` (was `$result = @($roster)`)
  - `Sync-AzDevOpsTeam` (was `$roster = @($records)`; the `[object[]] $Members` cache param coerces the `List`)
  - `ConvertFrom-AzDevOpsMentionInput` (was `$result = @($records)`)
  - The issue named two occurrences; a third identical one (`:126`) in the same file was fixed too — same defect, not a repo-wide purge.
- **`CLAUDE.md`** — new Code Style Mandate &#34;Never re-wrap a typed collection in `@()`&#34; with Bad/Good snippets, plus the legitimate `@()` uses to preserve (normalizing unknown returns, empty arrays).
- **`.claude/commands/senior-powershell-engineer.md`** — new &#34;Check 11 — `@()` Around a Typed Collection [HIGH]&#34; with a `git diff` grep heuristic.

Legitimate `@(...)` uses (`@($json | ConvertFrom-Json)`, `@($Roster | Where-Object …)`) were intentionally left untouched.

## Test Plan
- [ ] Fresh PowerShell terminal: `az-Sync-AzDevOpsTeam` → pick a team with ≥1 member → prints `Cached N teammate(s)…` with no `Collection was of a fixed size` error
- [ ] `Get-AzDevOpsTeam` returns the same members (cache round-trips)
- [ ] Single-member case (`$env:AZ_TEAM` = one email) still reports `Cached 1 teammate(s)` (`.Count` survives the output unroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApbYEcqJmMi1uBTaSdzk5Q)_