### PR TITLE
Fix fixed-size-array crash in timer debrief Post handler (#158)

### DIFF
--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -1406,7 +1406,7 @@ function Show-WpfTimerDebrief {
     $btnPost.Add_Click({
         $debriefText = $debriefBox.Text
         $nextText    = $nextBox.Text
-        $mentions    = @($Script:WpfDebriefMentions)
+        $mentions    = $Script:WpfDebriefMentions
 
         $btnPost.IsEnabled      = $false
         $statusText.Foreground  = $brushes.White


### PR DESCRIPTION
<!-- toc:start -->
## Navigation

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #158 |
| [Changes](#changes) | ✅ 1 file |
| [Test Plan](#test-plan) | ✅ 4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4785154540) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4785159780) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4785151325) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4785156916) |
| 📚 Docs Check | ✅ CURRENT — [View](#issuecomment-4785165903) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4785167990) |
<!-- toc:end -->

## Summary
On Windows, finishing a `Start-Timer` session and clicking **Post Debrief** threw `Exception calling "ShowDialog" with "0" argument(s): "argument types do not match"`. The message was misleading — the fault was raised inside the modal WPF event-handler pump and re-thrown out through `$mainWin.ShowDialog()`. The real cause was the #156 / PR #157 fixed-size-array idiom recurring in `pow_timer.ps1`: the `$Script:WpfDebriefMentions` `List[object]` was re-wrapped with `@()` in the Post Debrief click handler, coercing it to a fixed-size `[object[]]`.

## Issue
Closes #158

## Changes
- **`powcuts_by_cli/pow_timer.ps1`** (`Show-WpfTimerDebrief`, line 1409) — dropped the `@()` array-subexpression around `$Script:WpfDebriefMentions`; the `List` is now passed directly and coerced to `[object[]]` at the downstream `$Mentions` param boundary, mirroring PR #157's fix style.

The legitimate pipeline-normalizing `@(… | ForEach-Object)` / `@(… | Where-Object)` forms in the same function were intentionally left untouched.

## Test Plan
- [ ] `[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/pow_timer.ps1',[ref]$null,[ref]$null)` → no parse errors
- [ ] `Start-Timer` → countdown → tag ≥1 teammate → **Post Debrief** posts with no `ShowDialog` / `Collection was of a fixed size` error
- [ ] Tag 2+ teammates, then Post — succeeds
- [ ] Post with nobody tagged — still posts cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8yqyMW2WgRiHWDuGCPzke)_