### PR TITLE
Fix WPF debrief tag picker: keyboard navigation + multi-add

### DIFF
--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -1452,13 +1452,7 @@ function Show-WpfTimerDebrief {
             return
         }
 
-        if ($key -eq [System.Windows.Input.Key]::Escape) {
-            $tagBox.Focus() | Out-Null
-            $e.Handled = $true
-            return
-        }
-
-        if ($key -eq [System.Windows.Input.Key]::Tab) {
+        if ($key -eq [System.Windows.Input.Key]::Escape -or $key -eq [System.Windows.Input.Key]::Tab) {
             $tagBox.Focus() | Out-Null
             $e.Handled = $true
             return
@@ -1466,8 +1460,21 @@ function Show-WpfTimerDebrief {
     })
 
     # A single mouse click selects the item (sets SelectedIndex) and bubbles up to
-    # here, committing it - preserving the pre-keyboard click-to-tag behavior.
+    # here, committing it - preserving the pre-keyboard click-to-tag behavior. The
+    # hit-test walks up from the clicked element to confirm a ListBoxItem was hit,
+    # so a click in the list's empty chrome doesn't commit the standing highlight.
     $tagSuggestList.Add_MouseLeftButtonUp({
+        $e   = $args[1]
+        $node = $e.OriginalSource
+
+        while ($null -ne $node -and $node -isnot [System.Windows.Controls.ListBoxItem]) {
+            $node = [System.Windows.Media.VisualTreeHelper]::GetParent($node)
+        }
+
+        if ($null -eq $node) {
+            return
+        }
+
         & $commitTagSuggestion
     })
 

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -1346,9 +1346,34 @@ function Show-WpfTimerDebrief {
         }
     }
 
+    # Commit the highlighted suggestion: add it to the chosen mentions, reset the
+    # filter field + list, repaint the "Tagged:" line, and return focus to the
+    # tag box so the next teammate can be typed straight away. Driven explicitly
+    # by a click / Space / Enter (NOT SelectionChanged) so arrow-key navigation
+    # can move the highlight without each pass-over tagging a teammate.
+    $commitTagSuggestion = {
+        $index = $tagSuggestList.SelectedIndex
+        if ($index -lt 0 -or $index -ge $Script:WpfDebriefSuggestions.Count) {
+            return
+        }
+
+        $member = $Script:WpfDebriefSuggestions[$index]
+        $Script:WpfDebriefMentions.Add($member)
+
+        $Script:WpfDebriefSuggestions.Clear()
+        $tagBox.Text = ''
+        $tagSuggestList.Items.Clear()
+        $tagSuggestList.Visibility = [System.Windows.Visibility]::Collapsed
+
+        & $refreshTagChosen
+
+        $tagBox.Focus() | Out-Null
+    }
+
     $tagBox.Add_TextChanged({
         $needle = $tagBox.Text.Trim().ToLowerInvariant()
         if (-not $needle) {
+            $Script:WpfDebriefSuggestions.Clear()
             $tagSuggestList.Items.Clear()
             $tagSuggestList.Visibility = [System.Windows.Visibility]::Collapsed
             return
@@ -1377,25 +1402,73 @@ function Show-WpfTimerDebrief {
         }
     })
 
-    $tagSuggestList.Add_SelectionChanged({
-        # The bounds guard is load-bearing, not defensive: clearing $tagBox.Text
-        # and the Items below re-fires TextChanged + SelectionChanged from inside
-        # this handler with SelectedIndex = -1, so the guard turns each re-entry
-        # into a safe no-op (without it, the empty re-entry would index past the
-        # suggestion list). Keep it.
-        $index = $tagSuggestList.SelectedIndex
-        if ($index -lt 0 -or $index -ge $Script:WpfDebriefSuggestions.Count) {
+    # Tab out of the filter box drops focus INTO the suggestion list (highlighting
+    # the first match) instead of advancing to the next form control, so the user
+    # can arrow through matches and Space/Enter to pick. Only plain Tab while the
+    # list is showing matches is intercepted; Shift+Tab and a hidden list fall
+    # through to default focus traversal.
+    $tagBox.Add_PreviewKeyDown({
+        $e = $args[1]
+        if ($e.Key -ne [System.Windows.Input.Key]::Tab) {
             return
         }
 
-        $member = $Script:WpfDebriefSuggestions[$index]
-        $Script:WpfDebriefMentions.Add($member)
+        $shiftHeld = ([System.Windows.Input.Keyboard]::Modifiers -band [System.Windows.Input.ModifierKeys]::Shift) -ne 0
+        if ($shiftHeld) {
+            return
+        }
 
-        $tagBox.Text = ''
-        $tagSuggestList.Items.Clear()
-        $tagSuggestList.Visibility = [System.Windows.Visibility]::Collapsed
+        if ($tagSuggestList.Visibility -ne [System.Windows.Visibility]::Visible -or $tagSuggestList.Items.Count -eq 0) {
+            return
+        }
 
-        & $refreshTagChosen
+        if ($tagSuggestList.SelectedIndex -lt 0) {
+            $tagSuggestList.SelectedIndex = 0
+        }
+
+        $tagSuggestList.UpdateLayout()
+        $firstItem = $tagSuggestList.ItemContainerGenerator.ContainerFromIndex($tagSuggestList.SelectedIndex)
+        if ($firstItem) {
+            $firstItem.Focus() | Out-Null
+        } else {
+            $tagSuggestList.Focus() | Out-Null
+        }
+
+        $e.Handled = $true
+    })
+
+    # In the suggestion list: Up/Down move the highlight (native ListBox handling);
+    # Space and Enter commit the highlighted teammate; Escape / Shift+Tab return
+    # to the filter box. Committing lives in $commitTagSuggestion (a click does
+    # the same via MouseLeftButtonUp below) so selection is never auto-tagged just
+    # by arrowing over an item.
+    $tagSuggestList.Add_PreviewKeyDown({
+        $e   = $args[1]
+        $key = $e.Key
+
+        if ($key -eq [System.Windows.Input.Key]::Space -or $key -eq [System.Windows.Input.Key]::Enter) {
+            & $commitTagSuggestion
+            $e.Handled = $true
+            return
+        }
+
+        if ($key -eq [System.Windows.Input.Key]::Escape) {
+            $tagBox.Focus() | Out-Null
+            $e.Handled = $true
+            return
+        }
+
+        if ($key -eq [System.Windows.Input.Key]::Tab) {
+            $tagBox.Focus() | Out-Null
+            $e.Handled = $true
+            return
+        }
+    })
+
+    # A single mouse click selects the item (sets SelectedIndex) and bubbles up to
+    # here, committing it - preserving the pre-keyboard click-to-tag behavior.
+    $tagSuggestList.Add_MouseLeftButtonUp({
+        & $commitTagSuggestion
     })
 
     $tagChosenText.Add_MouseLeftButtonUp({


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #160 |
| [Changes](#changes) | ✅ 1 file |
| [Notes](#notes) | ✅ |
| [Test Plan](#test-plan-windows--pwsh) | 0/6 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/162#issuecomment-4785225929) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/162#issuecomment-4785229963) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/162#issuecomment-4785229406) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/162#issuecomment-4785231764) |
| 📖 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/162#issuecomment-4785242451) |
| ✅ Criteria Check | ✅ PASS (7/7) — [View](https://github.com/jdschleicher/bashcuts/pull/162#issuecomment-4785242882) |
<!-- toc:end -->

## Summary
Reworks the in-form **&#34;Tag teammates&#34;** picker in the WPF debrief form (`Show-WpfTimerDebrief`, `powcuts_by_cli/pow_timer.ps1`) so teammate selection is keyboard-drivable and adding a second/third teammate no longer breaks the suggestion list.

The root cause of both reported bugs was committing a selection inside `SelectionChanged`. That auto-commit-on-highlight makes arrow-key navigation impossible (arrowing would tag every item passed over) and is the fragile multi-add path. Committing now happens on **explicit gestures** only — mouse click, **Space**, **Enter**.

## Issue
Closes #160

## Changes
`powcuts_by_cli/pow_timer.ps1`:
- New `$commitTagSuggestion` scriptblock — single commit path (add member, clear box, refilter, return focus to the box).
- Removed the `SelectionChanged` auto-commit handler.
- `PreviewKeyDown` on `$tagBox`: plain **Tab** (while the list is visible &amp; non-empty) drops focus into the suggestion list and highlights the first match; Shift+Tab and a hidden list fall through to default traversal.
- `PreviewKeyDown` on `$tagSuggestList`: **Space/Enter** commit the highlight; **Esc / Shift+Tab** return to the filter box; Up/Down use native ListBox highlight movement.
- `MouseLeftButtonUp` on the list preserves single-click commit (no regression).
- Empty-needle branch now also clears the stale suggestion backing list.

## Notes
- **PowerShell / Windows-only** — the WPF form has no bash or non-Windows console counterpart, so no parity work is in scope.
- The separate **Post Debrief** fixed-size-array crash is tracked in #158, not this PR.
- `pwsh` was unavailable in the build environment, so the real parser couldn&#39;t run; changes are localized and manually reviewed (brace/paren balanced).

## Test Plan (Windows + pwsh)
- [ ] `Start-Timer` → finish → type into the Tag field → suggestions filter
- [ ] Press **Tab** → focus lands in the list, first item highlighted
- [ ] Arrow Up/Down, press **Space** (then **Enter**) → teammate added to &#34;Tagged:&#34;, focus returns to box
- [ ] Type again → add a **second** teammate → list stays healthy, both names shown
- [ ] **Click** a suggestion → still commits; click the &#34;Tagged:&#34; line → clears all
- [ ] `pow_timer.ps1` parses: `[System.Management.Automation.Language.Parser]::ParseFile(...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsZJRsWYFkZdbfpmS8PLJQ)_