### PR TITLE
Share the timer WPF debrief form with unplanned work

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,8 +736,8 @@ az-Sync-AzDevOpsTeam
 
 Once a roster is cached, each debrief gives you a **"Tag teammates" field** — there's no yes/no prompt to get past:
 
-- **On Windows** (the Pomodoro timer's debrief form) it's a blank text box above the **Post** button. Start typing a name or email and a small list of matching teammates appears underneath; click one to add it. Added people show on a **"Tagged: …"** line (click that line to clear). Leave the box empty to tag nobody.
-- **On macOS/Linux and in the unplanned-work debriefs** it's a single blank prompt — `Tag teammates (; or , separated names/emails, blank = none)`. Type one or more teammates (or just press Enter to skip).
+- **On Windows** (the Pomodoro timer's debrief form, and the per-firefight `az-Start-UnplannedWork` stop, which reuses the same WPF form) it's a blank text box above the **Post** button. Start typing a name or email and a small list of matching teammates appears underneath; click one to add it. Added people show on a **"Tagged: …"** line (click that line to clear). Leave the box empty to tag nobody.
+- **On macOS/Linux** it's a single blank prompt — `Tag teammates (; or , separated names/emails, blank = none)`. Type one or more teammates (or just press Enter to skip).
 
 Either way the people you pick are added to the posted comment as real `@`-mentions, so they're notified. Typed entries resolve against the cached roster first and fall back to a live identity lookup, so a name that's slightly outside your synced team still works. Tagging is always optional, and if you've never run `az-Sync-AzDevOpsTeam` the field doesn't appear at all.
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -616,6 +616,8 @@ Free-for-all companion to the Pomodoro timer for work that can't be time-boxed. 
 
 The session starts the instant you've named the firefight: the daily story and child Task are **created at the end** (debrief time), not up front, so a burning fire isn't blocked on `az boards` round-trips. The daily-story id is cached per day (`unplanned-story-YYYY-MM-DD.json`) so the next firefight grabs it with no WIQL lookup and no risk of duplicate daily stories. If the create fails after the session, `Show-UnplannedCapturedItemsFallback` prints the captured items so the work isn't lost.
 
+The debrief itself mirrors the Pomodoro timer: the captured items flush to the Task description up front (so nothing is lost on cancel), then on Windows `Invoke-UnplannedDebriefWpf` collects notes, the future-opportunity, and teammate tags through the **same themed WPF form the timer uses** (`Show-WpfTimerDebrief`, re-labelled for firefighting, with a read-only captured-items review list); macOS/Linux falls back to `Invoke-UnplannedDebriefConsole`'s terminal prompts. Both paths share `Write-UnplannedPostVerdict` and the `New-UnplannedFutureStory` create-story tail.
+
 ```mermaid
 flowchart TD
     Start([az-Start-UnplannedWork]) --> Gate{Test-AzDevOpsCreateGate}
@@ -647,15 +649,19 @@ flowchart TD
     Fallback --> Done
     Task -- ok --> Debrief[Invoke-UnplannedDebrief]
 
-    Debrief --> FlushDesc["Format-UnplannedItemsDescription<br/>→ Set-AzDevOpsWorkItemField<br/>→ az boards work-item update (System.Description)"]
-    FlushDesc --> AskFuture{future-feature opportunity?}
-    AskFuture -- yes --> MaybeStory["(opt) az-New-AzDevOpsUserStory"]
-    AskFuture -- no --> Tag
-    MaybeStory --> Tag
-    Tag["Select-AzDevOpsMention<br/>typed tag field → ConvertFrom-AzDevOpsMentionInput<br/>→ Format-AzDevOpsMentionAnchor (data-vss-mention)"]
+    Debrief --> FlushDesc["Save-UnplannedItemsToTask<br/>→ Format-UnplannedItemsDescription<br/>→ Set-AzDevOpsWorkItemField<br/>→ az boards work-item update (System.Description)"]
+    FlushDesc --> DebriefPlat{Test-WpfIsWindows?}
+
+    DebriefPlat -- Windows --> WpfForm["Invoke-UnplannedDebriefWpf<br/>Show-WpfTimerDebrief (shared timer form)<br/>notes + future opportunity + items review<br/>+ in-form tag box (Get-AzDevOpsTeam roster)"]
+    WpfForm --> PostComment["SubmitAction: Format-UnplannedDebriefComment<br/>(+ @-mention anchors)<br/>→ Add-AzDevOpsDiscussionComment<br/>→ az boards work-item update (--discussion)"]
+
+    DebriefPlat -- macOS/Linux --> ConsoleDebrief["Invoke-UnplannedDebriefConsole<br/>Read-Host notes + future-opportunity prompt"]
+    ConsoleDebrief --> Tag["Select-AzDevOpsMention<br/>typed tag field → ConvertFrom-AzDevOpsMentionInput<br/>→ Format-AzDevOpsMentionAnchor (data-vss-mention)"]
     Tag --> PostComment
-    PostComment["Format-UnplannedDebriefComment<br/>(+ @-mention anchors)<br/>→ Add-AzDevOpsDiscussionComment<br/>→ az boards work-item update (--discussion)"]
-    PostComment --> Ledger["Add-UnplannedLedgerEntry<br/>unplanned-YYYY-MM-DD.json"]
+
+    PostComment --> Verdict["Write-UnplannedPostVerdict<br/>(Get-TimerResultExitCode)"]
+    Verdict --> FutureStory["(opt) New-UnplannedFutureStory<br/>→ az-New-AzDevOpsUserStory"]
+    FutureStory --> Ledger["Add-UnplannedLedgerEntry<br/>unplanned-YYYY-MM-DD.json"]
     Ledger --> Done([end])
 
     DebriefDay([New-UnplannedWorkDebrief]) --> ReadLedger["read day ledger<br/>Measure-Object -Property Minutes"]
@@ -733,6 +739,11 @@ graph LR
     NewUWTask[New-UnplannedWorkTask]:::priv
     UWFallback[Show-UnplannedCapturedItemsFallback]:::priv
     InvUWDebrief[Invoke-UnplannedDebrief]:::priv
+    InvUWDebriefWpf[Invoke-UnplannedDebriefWpf]:::priv
+    InvUWDebriefConsole[Invoke-UnplannedDebriefConsole]:::priv
+    UWSaveItems[Save-UnplannedItemsToTask]:::priv
+    UWPostVerdict[Write-UnplannedPostVerdict]:::priv
+    UWFutureStory[New-UnplannedFutureStory]:::priv
     UWBalloon[New-UnplannedBalloon]:::priv
     WpfStopwatch[Show-WpfStopwatch]:::priv
     UWLedger[Add-UnplannedLedgerEntry]:::priv
@@ -1279,10 +1290,17 @@ graph LR
     StartUW --> UWBalloon
     StartUW --> WpfStopwatch
     StartUW --> InvUWDebrief
-    InvUWDebrief --> SetField
-    InvUWDebrief --> AddDisc
-    InvUWDebrief --> NewS
+    InvUWDebrief --> UWSaveItems --> SetField
+    InvUWDebrief --> InvUWDebriefWpf
+    InvUWDebrief --> InvUWDebriefConsole
     InvUWDebrief --> UWLedger
+    InvUWDebriefWpf --> AddDisc
+    InvUWDebriefWpf --> UWPostVerdict
+    InvUWDebriefWpf --> UWFutureStory
+    InvUWDebriefConsole --> AddDisc
+    InvUWDebriefConsole --> UWPostVerdict
+    InvUWDebriefConsole --> UWFutureStory
+    UWFutureStory --> NewS
     NewUWDebrief --> AddDisc
     NewUWDebrief --> UWLedger
 
@@ -1297,9 +1315,11 @@ graph LR
     UWRosterSync --> UWResolve --> Identity --> AzJson
     UWResolve --> UWMemberRec
     UWRosterSync --> UWTeamSave
-    InvUWDebrief --> UWMentionPick
+    InvUWDebriefConsole --> UWMentionPick
     NewUWDebrief --> UWMentionPick
-    InvUWDebrief --> UWMentionLine
+    InvUWDebriefWpf --> UWGetTeam
+    InvUWDebriefWpf --> UWMentionLine
+    InvUWDebriefConsole --> UWMentionLine
     NewUWDebrief --> UWMentionLine
     UWMentionPick --> UWGetTeam
     UWMentionPick --> UWMentionInput

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -12,7 +12,11 @@
 #                              Esc/Q to stop and debrief. A reminder balloon
 #                              pops every -ReminderMinutes until you stop. On
 #                              stop the captured items flush to the Task
-#                              description and a debrief comment is posted.
+#                              description and a debrief comment is posted - on
+#                              Windows via the same themed WPF debrief form the
+#                              Pomodoro timer uses (Show-WpfTimerDebrief),
+#                              re-labelled for firefighting; on macOS/Linux via
+#                              the terminal debrief.
 #   New-UnplannedWorkDebrief - read the day's ledger, total the time across all
 #                              firefights, and post a roll-up comment on the
 #                              daily story.
@@ -572,14 +576,177 @@ function Show-UnplannedCapturedItemsFallback {
 }
 
 
+function Save-UnplannedItemsToTask {
+    # Flush the captured items to the Task description. Done up-front, before the
+    # debrief is collected, so the firefight log survives even if the user
+    # cancels the debrief form without posting a comment. A failed update is
+    # surfaced but non-fatal — the debrief still proceeds.
+    param(
+        [Parameter(Mandatory)] [int]    $TaskId,
+        [Parameter(Mandatory)] [string] $Title,
+        [object[]] $Items
+    )
+
+    $descriptionBody = Format-UnplannedItemsDescription -TaskTitle $Title -Items @($Items)
+
+    Write-Host "Updating Task #$TaskId description with captured items..." -ForegroundColor Cyan
+    $descResult = Set-AzDevOpsWorkItemField -Id $TaskId -Fields @("System.Description=$descriptionBody")
+    if ($descResult.ExitCode -ne 0) {
+        Write-Host "  Could not update description: $($descResult.Error)" -ForegroundColor Yellow
+    }
+}
+
+
+function Write-UnplannedPostVerdict {
+    # Shared post-comment verdict for both debrief paths: a green check + view
+    # hint on success, a red line on failure. Reads the AddComment envelope's
+    # outcome through the timer's Get-TimerResultExitCode so the two features
+    # interpret "missing ExitCode means success" the same way.
+    param(
+        [Parameter(Mandatory)] $Result,
+        [Parameter(Mandatory)] [int] $TaskId
+    )
+
+    $iconCheck = $script:UnplannedIconCheck
+    $exitCode  = Get-TimerResultExitCode -Result $Result
+
+    if ($exitCode -eq 0) {
+        Write-Host "$iconCheck Debrief posted on Task #$TaskId." -ForegroundColor Green
+        Write-Host "   View: az-Open-WorkItemById $TaskId" -ForegroundColor DarkGray
+    } else {
+        Write-Host "Debrief comment failed: $($Result.Error)" -ForegroundColor Red
+    }
+}
+
+
+function New-UnplannedFutureStory {
+    # Terminal tail shared by both debrief paths: when the user captured a
+    # prevent-this-firefight opportunity, offer to spin it into a user story via
+    # az-New-AzDevOpsUserStory. Blank text is a no-op. Kept out of the WPF form
+    # deliberately so story creation stays an interactive terminal flow.
+    param([AllowEmptyString()] [string] $FutureText)
+
+    if (-not $FutureText) {
+        return
+    }
+
+    if (-not (Read-UnplannedYesNo -Prompt 'Create a user story for that opportunity now?')) {
+        return
+    }
+
+    if (Get-Command az-New-AzDevOpsUserStory -ErrorAction SilentlyContinue) {
+        az-New-AzDevOpsUserStory -Title $FutureText | Out-Null
+    }
+}
+
+
+function Invoke-UnplannedDebriefConsole {
+    # macOS / Linux debrief path: terminal prompts for the debrief notes and the
+    # optional future-opportunity, the console mention picker, then post + verdict.
+    # The captured items are already on the Task description (flushed by the
+    # dispatcher), so this only gathers notes and posts the comment.
+    param(
+        [Parameter(Mandatory)] [int] $TaskId,
+        [Parameter(Mandatory)] [int] $ElapsedMinutes,
+        [object[]] $Items
+    )
+
+    $itemList = @($Items)
+
+    $iconMemo = $script:UnplannedIconMemo
+    $debrief  = Read-Host "$iconMemo Debrief notes for this firefight"
+
+    $futureFeature = ''
+    if (Read-UnplannedYesNo -Prompt 'Is there an opportunity for a new feature / user story to prevent this firefight in future?') {
+        $futureFeature = Read-Host '  Describe the opportunity (one line)'
+    }
+
+    $mentions = Select-AzDevOpsMention
+
+    $commentBody = Format-UnplannedDebriefComment `
+        -ElapsedMinutes $ElapsedMinutes `
+        -ItemCount      $itemList.Count `
+        -Debrief        $debrief `
+        -FutureFeature  $futureFeature `
+        -Mentions       $mentions
+
+    Write-Host ""
+    Write-Host "Posting debrief comment to Task #$TaskId..." -ForegroundColor Cyan
+    $commentResult = Add-AzDevOpsDiscussionComment -Id $TaskId -Body $commentBody
+    Write-UnplannedPostVerdict -Result $commentResult -TaskId $TaskId
+
+    New-UnplannedFutureStory -FutureText $futureFeature
+}
+
+
+function Invoke-UnplannedDebriefWpf {
+    # Windows debrief path: the same themed WPF form the Pomodoro timer uses
+    # (Show-WpfTimerDebrief), re-labelled for firefighting. The form carries the
+    # debrief notes + future-opportunity fields, a read-only review list of the
+    # captured items, and the in-form tag-teammates box (replacing the console
+    # mention picker). Its SubmitAction composes + posts the debrief comment under
+    # the form's spinner; the future-opportunity → create-story prompt runs in the
+    # terminal tail after the form closes, fed by the form's captured text.
+    param(
+        [Parameter(Mandatory)] [int] $TaskId,
+        [Parameter(Mandatory)] [int] $ElapsedMinutes,
+        [object[]] $Items
+    )
+
+    $itemList   = @($Items)
+    $teamRoster = @(Get-AzDevOpsTeam)
+
+    $submitAction = {
+        param(
+            [string]   $DebriefText,
+            [string]   $FutureText,
+            [object[]] $Mentions
+        )
+
+        $commentBody = Format-UnplannedDebriefComment `
+            -ElapsedMinutes $ElapsedMinutes `
+            -ItemCount      $itemList.Count `
+            -Debrief        $DebriefText `
+            -FutureFeature  $FutureText `
+            -Mentions       $Mentions
+
+        $posted = Add-AzDevOpsDiscussionComment -Id $TaskId -Body $commentBody
+        return $posted
+    }.GetNewClosure()
+
+    $header         = "Unplanned session complete — $ElapsedMinutes min, $($itemList.Count) item(s)"
+    $primaryLabel   = 'Debrief notes for this firefight'
+    $secondaryLabel = 'Future opportunity (optional) — a feature/user story to prevent this firefight?'
+
+    $debriefResult = Show-WpfTimerDebrief `
+        -Interrupted    $false `
+        -SubmitAction   $submitAction `
+        -TeamRoster     $teamRoster `
+        -WindowTitle    'Unplanned Work Debrief' `
+        -HeaderText     $header `
+        -PrimaryLabel   $primaryLabel `
+        -SecondaryLabel $secondaryLabel `
+        -Items          $itemList `
+        -NoRestart
+
+    if (-not $debriefResult.PostResult) {
+        Write-Host "No debrief posted - captured items were saved to the Task description." -ForegroundColor DarkGray
+        return
+    }
+
+    Write-UnplannedPostVerdict -Result $debriefResult.PostResult -TaskId $TaskId
+
+    New-UnplannedFutureStory -FutureText $debriefResult.SecondaryText
+}
+
+
 function Invoke-UnplannedDebrief {
     # Stop-of-session tail, split out of az-Start-UnplannedWork so the orchestrator
-    # reads as gate -> story -> task -> loop -> debrief. Flushes the captured
-    # items to the Task description, prompts for debrief notes + an optional
-    # future-feature opportunity (offering to create a user story for it via
-    # az-New-AzDevOpsUserStory), posts the debrief comment, and records the
-    # session in the day's ledger. Elapsed minutes come from $StartTime so the
-    # recorded time is accurate regardless of the on-screen counter.
+    # reads as gate -> story -> task -> loop -> debrief. Computes the elapsed
+    # minutes from $StartTime (accurate regardless of the on-screen counter),
+    # flushes the captured items to the Task description, then dispatches to the
+    # shared WPF debrief form on Windows or the terminal debrief elsewhere, and
+    # records the session in the day's ledger.
     param(
         [Parameter(Mandatory)] [int]      $TaskId,
         [Parameter(Mandatory)] [int]      $StoryId,
@@ -600,44 +767,12 @@ function Invoke-UnplannedDebrief {
     Write-Host "$iconCheck Unplanned session complete - $elapsedMinutes min, $($itemList.Count) item(s)." -ForegroundColor Green
     Write-Host ""
 
-    $descriptionBody = Format-UnplannedItemsDescription -TaskTitle $Title -Items $itemList
-    Write-Host "Updating Task #$TaskId description with captured items..." -ForegroundColor Cyan
-    $descResult = Set-AzDevOpsWorkItemField -Id $TaskId -Fields @("System.Description=$descriptionBody")
-    if ($descResult.ExitCode -ne 0) {
-        Write-Host "  Could not update description: $($descResult.Error)" -ForegroundColor Yellow
-    }
+    Save-UnplannedItemsToTask -TaskId $TaskId -Title $Title -Items $itemList
 
-    $iconMemo = $script:UnplannedIconMemo
-    $debrief = Read-Host "$iconMemo Debrief notes for this firefight"
-
-    $futureFeature = ''
-    if (Read-UnplannedYesNo -Prompt 'Is there an opportunity for a new feature / user story to prevent this firefight in future?') {
-        $futureFeature = Read-Host '  Describe the opportunity (one line)'
-
-        if ($futureFeature -and (Read-UnplannedYesNo -Prompt '  Create that user story now?')) {
-            if (Get-Command az-New-AzDevOpsUserStory -ErrorAction SilentlyContinue) {
-                az-New-AzDevOpsUserStory -Title $futureFeature | Out-Null
-            }
-        }
-    }
-
-    $mentions = Select-AzDevOpsMention
-
-    $commentBody = Format-UnplannedDebriefComment `
-        -ElapsedMinutes $elapsedMinutes `
-        -ItemCount      $itemList.Count `
-        -Debrief        $debrief `
-        -FutureFeature  $futureFeature `
-        -Mentions       $mentions
-
-    Write-Host ""
-    Write-Host "Posting debrief comment to Task #$TaskId..." -ForegroundColor Cyan
-    $commentResult = Add-AzDevOpsDiscussionComment -Id $TaskId -Body $commentBody
-    if ($commentResult.ExitCode -eq 0) {
-        Write-Host "$iconCheck Debrief posted on Task #$TaskId." -ForegroundColor Green
-        Write-Host "   View: az-Open-WorkItemById $TaskId" -ForegroundColor DarkGray
+    if (Test-WpfIsWindows) {
+        Invoke-UnplannedDebriefWpf -TaskId $TaskId -ElapsedMinutes $elapsedMinutes -Items $itemList
     } else {
-        Write-Host "Debrief comment failed: $($commentResult.Error)" -ForegroundColor Red
+        Invoke-UnplannedDebriefConsole -TaskId $TaskId -ElapsedMinutes $elapsedMinutes -Items $itemList
     }
 
     Add-UnplannedLedgerEntry -StoryId $StoryId -TaskId $TaskId -Title $Title -Minutes $elapsedMinutes -ItemCount $itemList.Count

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -999,26 +999,44 @@ function New-TimerOpenScript {
 
 function Show-WpfTimerDebrief {
     # Windows-only themed debrief form the countdown overlay morphs into. Two
-    # multiline fields (Debrief + Next) share the timer's dark/blue theme. On
-    # Post the form disables the button, shows a spinner, and runs -SubmitAction
-    # (which composes + posts the comment and returns the { Json, Error,
-    # ExitCode } envelope). The "Start another session?" choice is revealed ONLY
-    # after a successful post (ExitCode 0); a failed post keeps the form open
-    # with the error so the user can retry. The "Start another?" choice offers
-    # "Same item" (reuse the work item just debriefed), "Pick another" (return
-    # to the picker), and "Done". When -CloseAction is supplied, a "Work
+    # multiline fields (Debrief + Next by default) share the timer's dark/blue
+    # theme. On Post the form disables the button, shows a spinner, and runs
+    # -SubmitAction (which composes + posts the comment and returns the { Json,
+    # Error, ExitCode } envelope). The "Start another session?" choice is
+    # revealed ONLY after a successful post (ExitCode 0); a failed post keeps the
+    # form open with the error so the user can retry. The "Start another?" choice
+    # offers "Same item" (reuse the work item just debriefed), "Pick another"
+    # (return to the picker), and "Done". When -CloseAction is supplied, a "Work
     # complete — resolve this story" checkbox renders above the Post button;
     # when ticked, a successful comment post is followed by an invocation of
     # CloseAction and its outcome is reflected in the status line. Returns
-    # { Cancelled; NextAction; PostResult; CloseRequested; CloseResult } for the
-    # orchestrator, where NextAction is 'Done' / 'SameItem' / 'NewItem'.
+    # { Cancelled; NextAction; PostResult; CloseRequested; CloseResult;
+    # PrimaryText; SecondaryText } for the orchestrator, where NextAction is
+    # 'Done' / 'SameItem' / 'NewItem' and Primary/SecondaryText are the two
+    # field values captured at a successful post (so a caller can reuse e.g. the
+    # secondary text after the form closes).
+    #
+    # The form is shared with the unplanned-work debrief (azdevops_unplanned.ps1)
+    # via these knobs, all defaulting to the timer's wording so the timer call
+    # site is unchanged:
+    #   -PrimaryLabel / -SecondaryLabel - the two field labels.
+    #   -WindowTitle / -HeaderText      - the window title and the form heading
+    #                                     (HeaderText overrides the interrupted/
+    #                                     complete default when supplied).
+    #   -Items                          - timestamped session items rendered in a
+    #                                     read-only review list above the tag
+    #                                     field; hidden when empty (the timer
+    #                                     logs none).
+    #   -NoRestart                      - hide the "Same item" / "Pick another"
+    #                                     buttons and relabel "Done" to "Close"
+    #                                     for one-and-done flows (unplanned work).
     #
     # -TeamRoster, when non-empty, renders a "Tag teammates" field above the Post
     # button: a blank textbox you type a name/email into; a live suggestion list
     # under it filters the roster, and clicking a suggestion adds that teammate
     # to a "Tagged:" line (click the line to clear). The selected records are
     # passed to -SubmitAction as its THIRD argument, so SubmitAction's signature
-    # is param($DebriefText, $NextText, $Mentions). An empty roster hides the
+    # is param($PrimaryText, $SecondaryText, $Mentions). An empty roster hides the
     # field entirely and SubmitAction receives an empty mention set.
     #
     # The az post is synchronous on the dispatcher thread, so the spinner can't
@@ -1030,7 +1048,13 @@ function Show-WpfTimerDebrief {
         [Parameter(Mandatory)] [scriptblock] $SubmitAction,
         [AllowEmptyCollection()] [object[]]  $TeamRoster = @(),
         [scriptblock] $OpenAction,
-        [scriptblock] $CloseAction
+        [scriptblock] $CloseAction,
+        [string] $WindowTitle    = 'Timer Debrief',
+        [string] $HeaderText     = '',
+        [string] $PrimaryLabel   = 'Debrief — what did you accomplish?',
+        [string] $SecondaryLabel = 'Next — what''s the next step?',
+        [AllowEmptyCollection()] [object[]] $Items = @(),
+        [switch] $NoRestart
     )
 
     Add-Type -AssemblyName PresentationFramework, WindowsBase, PresentationCore
@@ -1042,6 +1066,16 @@ function Show-WpfTimerDebrief {
     $Script:WpfDebriefPostResult     = $null
     $Script:WpfDebriefCloseRequested = $false
     $Script:WpfDebriefCloseResult    = $null
+    $Script:WpfDebriefPrimaryText    = ''
+    $Script:WpfDebriefSecondaryText  = ''
+
+    # Trailing prompt on the post-success status line. The one-and-done unplanned
+    # flow (-NoRestart) drops the "Start another session?" invitation.
+    $startAnotherSuffix = if ($NoRestart) {
+        ''
+    } else {
+        ' Start another session?'
+    }
 
     # Backing state for the tag-teammates field: the records picked so far, and
     # the roster records parallel to the visible suggestion list (so a click maps
@@ -1059,7 +1093,7 @@ function Show-WpfTimerDebrief {
     # ---- Window + container ----
 
     $mainWin = New-Object System.Windows.Window -Property @{
-        Title                 = 'Timer Debrief'
+        Title                 = $WindowTitle
         SizeToContent         = 'WidthAndHeight'
         WindowStyle           = 'None'
         AllowsTransparency    = $true
@@ -1081,14 +1115,16 @@ function Show-WpfTimerDebrief {
 
     # ---- Title (drag handle) ----
 
-    $headerText = if ($Interrupted) {
+    $resolvedHeaderText = if ($HeaderText) {
+        $HeaderText
+    } elseif ($Interrupted) {
         'Session interrupted — debrief'
     } else {
         'Session complete — debrief'
     }
 
     $titleLabel = New-Object System.Windows.Controls.TextBlock -Property @{
-        Text                = $headerText
+        Text                = $resolvedHeaderText
         FontSize            = 15
         FontWeight          = 'Bold'
         Foreground          = $brushes.White
@@ -1122,7 +1158,7 @@ function Show-WpfTimerDebrief {
     # ---- Debrief field ----
 
     $debriefLabel = New-Object System.Windows.Controls.TextBlock -Property @{
-        Text       = 'Debrief — what did you accomplish?'
+        Text       = $PrimaryLabel
         FontSize   = 11
         Foreground = $brushes.Hint
         Margin     = '0,0,0,3'
@@ -1145,7 +1181,7 @@ function Show-WpfTimerDebrief {
     # ---- Next field ----
 
     $nextLabel = New-Object System.Windows.Controls.TextBlock -Property @{
-        Text       = 'Next — what''s the next step?'
+        Text       = $SecondaryLabel
         FontSize   = 11
         Foreground = $brushes.Hint
         Margin     = '0,0,0,3'
@@ -1164,6 +1200,38 @@ function Show-WpfTimerDebrief {
         Margin                      = '0,0,0,12'
     }
     $vbox.Children.Add($nextBox) | Out-Null
+
+    # ---- Captured-items review (read-only; only when the session logged items) ----
+
+    $sessionItems = @($Items)
+
+    $itemsLabel = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text       = "Captured items ($($sessionItems.Count))"
+        FontSize   = 11
+        Foreground = $brushes.Hint
+        Margin     = '0,0,0,3'
+        Visibility = [System.Windows.Visibility]::Collapsed
+    }
+    $vbox.Children.Add($itemsLabel) | Out-Null
+
+    $itemsList = New-Object System.Windows.Controls.ListBox -Property @{
+        Background  = $brushes.Bg
+        Foreground  = $brushes.White
+        BorderBrush = $brushes.Stroke
+        MaxHeight   = 96
+        Margin      = '0,0,0,12'
+        Visibility  = [System.Windows.Visibility]::Collapsed
+    }
+    $vbox.Children.Add($itemsList) | Out-Null
+
+    if ($sessionItems.Count -gt 0) {
+        foreach ($entry in $sessionItems) {
+            $itemsList.Items.Add("[$($entry.Time)] $($entry.Text)") | Out-Null
+        }
+
+        $itemsLabel.Visibility = [System.Windows.Visibility]::Visible
+        $itemsList.Visibility  = [System.Windows.Visibility]::Visible
+    }
 
     # ---- Tag-teammates field (only when a synced roster is supplied) ----
 
@@ -1429,8 +1497,10 @@ function Show-WpfTimerDebrief {
         $exitCode = Get-TimerResultExitCode -Result $postResult
 
         if ($exitCode -eq 0) {
-            $Script:WpfDebriefPostResult = $postResult
-            $Script:WpfDebriefOutcome    = 'Posted'
+            $Script:WpfDebriefPostResult    = $postResult
+            $Script:WpfDebriefOutcome       = 'Posted'
+            $Script:WpfDebriefPrimaryText   = $debriefText
+            $Script:WpfDebriefSecondaryText = $nextText
 
             # Notes are now committed to the item — lock them so they can't be
             # edited, but keep them readable and selectable (IsReadOnly, not IsEnabled).
@@ -1460,13 +1530,13 @@ function Show-WpfTimerDebrief {
 
                 $closeExit = Get-TimerResultExitCode -Result $closeResult
                 if ($closeExit -eq 0) {
-                    $statusText.Text = "Posted + Resolved (State=$script:TimerCloseState). Start another session?"
+                    $statusText.Text = "Posted + Resolved (State=$script:TimerCloseState).$startAnotherSuffix"
                 } else {
                     $statusText.Foreground = $brushes.DarkRed
-                    $statusText.Text       = "Posted; resolve failed. Start another session?"
+                    $statusText.Text       = "Posted; resolve failed.$startAnotherSuffix"
                 }
             } else {
-                $statusText.Text = 'Posted. Start another session?'
+                $statusText.Text = "Posted.$startAnotherSuffix"
             }
 
             $postPanel.Visibility = [System.Windows.Visibility]::Collapsed
@@ -1500,6 +1570,16 @@ function Show-WpfTimerDebrief {
         $mainWin.Close()
     })
 
+    # For a one-and-done flow there's no item to loop back to, so the only
+    # post-success affordance is closing the form — hide the restart choices and
+    # relabel "Done" accordingly. NextAction stays 'Done', so the orchestrator's
+    # restart resolver short-circuits.
+    if ($NoRestart) {
+        $btnSameItem.Visibility = [System.Windows.Visibility]::Collapsed
+        $btnNewItem.Visibility  = [System.Windows.Visibility]::Collapsed
+        $btnDone.Content        = 'Close'
+    }
+
     # ---- Show ----
 
     $debriefBox.Focus() | Out-Null
@@ -1513,6 +1593,8 @@ function Show-WpfTimerDebrief {
         PostResult     = $Script:WpfDebriefPostResult
         CloseRequested = $Script:WpfDebriefCloseRequested
         CloseResult    = $Script:WpfDebriefCloseResult
+        PrimaryText    = $Script:WpfDebriefPrimaryText
+        SecondaryText  = $Script:WpfDebriefSecondaryText
     }
     return $result
 }


### PR DESCRIPTION
<!-- toc:start -->
## Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #161 |
| [Changes](#changes) | ✅ 4 files |
| [Test Plan](#test-plan) | 0/4 (manual runtime) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/163#issuecomment-4789380891) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/163#issuecomment-4789391520) |
| 🛡️ Security Audit | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/163#issuecomment-4789398869) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/163#issuecomment-4789391172) |
| ✅ Criteria Check | ✅ PASS (11/13; pwsh parse N/A here) — [View](https://github.com/jdschleicher/bashcuts/pull/163#issuecomment-4789434383) |
| 📚 Docs Check | ✅ CURRENT — README tagging section fixed on-branch |
| 🗺️ AzDO Diagrams Check | ✅ CURRENT — diagram updates verified |
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

This PR restructures the unplanned-work debrief. `Invoke-UnplannedDebrief` becomes a dispatcher: it flushes the captured items to the Task description up front (so a cancelled debrief never loses them), then branches on platform — Windows reuses the timer's generalized `Show-WpfTimerDebrief` form, macOS/Linux keeps the terminal flow. Both paths share the post-verdict and create-story tails, and the dispatcher records the ledger.

```mermaid
flowchart TD
    StartUW([az-Start-UnplannedWork]):::pub
    Disp[Invoke-UnplannedDebrief<br/>dispatcher]:::priv

    Save[Save-UnplannedItemsToTask]:::priv
    SetDesc["az boards work-item update<br/>(System.Description)"]:::io
    Plat{Test-WpfIsWindows?}

    Wpf[Invoke-UnplannedDebriefWpf]:::priv
    Form[Show-WpfTimerDebrief<br/>shared timer form<br/>+ items review + in-form tag box]:::priv
    Con[Invoke-UnplannedDebriefConsole<br/>Read-Host + mention picker]:::priv

    Post["Add-AzDevOpsDiscussionComment<br/>(--discussion)"]:::io
    Verdict[Write-UnplannedPostVerdict<br/>Get-TimerResultExitCode]:::priv
    Future[New-UnplannedFutureStory]:::priv
    NewStory([az-New-AzDevOpsUserStory]):::pub
    Ledger[(Add-UnplannedLedgerEntry<br/>unplanned-YYYY-MM-DD.json)]:::io

    StartUW --> Disp
    Disp --> Save --> SetDesc
    Disp --> Plat
    Plat -- Windows --> Wpf --> Form --> Post
    Plat -- macOS/Linux --> Con --> Post
    Post --> Verdict --> Future
    Future -.on opportunity.-> NewStory
    Disp --> Ledger

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
Aligns `az-Start-UnplannedWork` with `az-Start-TimerSession` so both firefighting and Pomodoro sessions share the same themed WPF debrief form on Windows. Previously the timer morphed its overlay into a polished WPF debrief form (`Show-WpfTimerDebrief`) while unplanned work dropped to bare terminal `Read-Host` prompts on every platform.

## Issue
Closes #161

## Changes
**`powcuts_by_cli/pow_timer.ps1`** — generalized `Show-WpfTimerDebrief` (all timer defaults preserved):
- Configurable `-WindowTitle`, `-HeaderText`, `-PrimaryLabel`, `-SecondaryLabel`
- Optional `-Items` read-only captured-items review list (hidden when empty — the timer logs none)
- `-NoRestart` switch — hides the Same/Pick buttons and relabels Done → Close for one-and-done flows
- Returns `PrimaryText`/`SecondaryText` so a caller can reuse captured field text after the form closes

**`powcuts_by_cli/azdevops_unplanned.ps1`** — split `Invoke-UnplannedDebrief`:
- Dispatcher: elapsed calc, up-front description flush (so a cancelled form never loses items), ledger
- `Invoke-UnplannedDebriefWpf` (Windows): reuses `Show-WpfTimerDebrief` with firefight labels, the items review list, and the in-form tag box
- `Invoke-UnplannedDebriefConsole` (macOS/Linux fallback, terminal prompts)
- New helpers: `Save-UnplannedItemsToTask`, `Write-UnplannedPostVerdict` (via shared `Get-TimerResultExitCode`), `New-UnplannedFutureStory` (create-story stays a terminal tail)

**`docs/azure-devops-diagrams.md`** — updated section 11 flow + dependency map for the new debrief structure.

### Open-question decisions
- **Captured-items panel → read-only** (the issue's green-lit MVP).
- **Second field → kept** as a free-text "Future opportunity" field; create-story prompt stays in the terminal tail, fed by it.

## Test Plan
PowerShell-only (no bash counterpart). `pwsh` unavailable in CI env — brace/paren balance verified manually.
- [ ] `pwsh -NoProfile` parses `pow_timer.ps1` and `azdevops_unplanned.ps1` clean
- [ ] **Timer regression** (Windows): `az-Start-TimerSession -Minutes 1` → debrief form, labels, restart buttons unchanged
- [ ] **Unplanned WPF** (Windows): `az-Start-UnplannedWork` → stopwatch → form shows firefight labels, captured-items list, in-form tag box, posts under spinner, "Close" (no "start another"), then terminal create-story prompt
- [ ] **Fallback** (macOS/Linux): `az-Start-UnplannedWork` → terminal debrief unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhKw8SoSeoDhkqo39SvFB3)_