### PR TITLE
Polish unplanned-work WPF flow: parent Feature, open-task button, trimmed debrief, az-job spinner

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -614,9 +614,9 @@ Private helpers:
 
 Free-for-all companion to the Pomodoro timer for work that can't be time-boxed. Each day rolls up under one **Unplanned Work — yyyy-MM-dd** User Story; every firefight is a child Task with its own debrief. PowerShell-only (the Windows balloon reminder + key-poll loop have no bash counterpart). `New-UnplannedWorkDebrief` is the end-of-day roll-up over a local per-day ledger.
 
-The session starts the instant you've named the firefight: the daily story and child Task are **created at the end** (debrief time), not up front, so a burning fire isn't blocked on `az boards` round-trips. The daily-story id is cached per day (`unplanned-story-YYYY-MM-DD.json`) so the next firefight grabs it with no WIQL lookup and no risk of duplicate daily stories. If the create fails after the session, `Show-UnplannedCapturedItemsFallback` prints the captured items so the work isn't lost.
+The session starts the instant you've named the firefight: the daily story and child Task are **created at the end** (debrief time), not up front, so a burning fire isn't blocked on `az boards` round-trips. The daily-story id is cached per day (`unplanned-story-YYYY-MM-DD.json`) so the next firefight grabs it with no WIQL lookup and no risk of duplicate daily stories. On the **first** creation of the day, `New-UnplannedWorkStory` runs `Read-UnplannedParentFeature` to pick a parent Feature (orphan-safe — a skipped/failed pick leaves the story parentless rather than blocking the session) and links it with `Invoke-AzDevOpsParentLink`; cached/existing stories skip the prompt. On Windows the whole at-stop `az boards` chain runs under a lightweight `New-WpfProgressWindow` spinner whose status names the step in flight (finding story → creating Task → saving items); off Windows it's a no-op stub and the per-step `Write-Host` lines stay the feedback. If the create fails after the session, `Show-UnplannedCapturedItemsFallback` prints the captured items so the work isn't lost.
 
-The debrief itself mirrors the Pomodoro timer: the captured items flush to the Task description up front (so nothing is lost on cancel), then on Windows `Invoke-UnplannedDebriefWpf` collects notes, the future-opportunity, and teammate tags through the **same themed WPF form the timer uses** (`Show-WpfTimerDebrief`, re-labelled for firefighting, with a read-only captured-items review list); macOS/Linux falls back to `Invoke-UnplannedDebriefConsole`'s terminal prompts. Both paths share `Write-UnplannedPostVerdict` and the `New-UnplannedFutureStory` create-story tail.
+The debrief itself mirrors the Pomodoro timer: the captured items flush to the Task description up front (so nothing is lost on cancel), then on Windows `Invoke-UnplannedDebriefWpf` collects notes, the future-opportunity, and teammate tags through the **same themed WPF form the timer uses** (`Show-WpfTimerDebrief`, re-labelled for firefighting). The form passes no `-Items` — the captured items are already on the Task description, so the read-only review list is omitted — and passes an `-OpenAction` so an **"Open in Azure DevOps"** button opens the just-created Task; macOS/Linux falls back to `Invoke-UnplannedDebriefConsole`'s terminal prompts. Both paths share `Write-UnplannedPostVerdict` and the `New-UnplannedFutureStory` create-story tail.
 
 ```mermaid
 flowchart TD
@@ -639,7 +639,7 @@ flowchart TD
     CacheCheck -- hit --> HaveStory[daily story id]
     CacheCheck -- miss --> Find["Find-UnplannedWorkStoryId<br/>WIQL by title (+ AZ_AREA)<br/>→ Invoke-AzDevOpsBoardsQuery"]
     Find -- found --> SaveStory["Save-UnplannedCachedStoryId"]
-    Find -- 0 --> NewStory["New-UnplannedWorkStory<br/>→ Invoke-AzDevOpsWorkItemCreate<br/>→ az boards work-item create (User Story)"]
+    Find -- 0 --> NewStory["New-UnplannedWorkStory<br/>Read-UnplannedParentFeature (pick parent Feature,<br/>orphan-safe) → Invoke-AzDevOpsWorkItemCreate<br/>→ az boards work-item create (User Story)<br/>→ Invoke-AzDevOpsParentLink"]
     NewStory --> SaveStory
     SaveStory --> HaveStory
 
@@ -652,7 +652,7 @@ flowchart TD
     Debrief --> FlushDesc["Save-UnplannedItemsToTask<br/>→ Format-UnplannedItemsDescription<br/>→ Set-AzDevOpsWorkItemField<br/>→ az boards work-item update (System.Description)"]
     FlushDesc --> DebriefPlat{Test-WpfIsWindows?}
 
-    DebriefPlat -- Windows --> WpfForm["Invoke-UnplannedDebriefWpf<br/>Show-WpfTimerDebrief (shared timer form)<br/>notes + future opportunity + items review<br/>+ in-form tag box (Get-AzDevOpsTeam roster)"]
+    DebriefPlat -- Windows --> WpfForm["Invoke-UnplannedDebriefWpf<br/>Show-WpfTimerDebrief (shared timer form)<br/>notes + future opportunity + 'Open in Azure DevOps'<br/>+ in-form tag box (Get-AzDevOpsTeam roster)"]
     WpfForm --> PostComment["SubmitAction: Format-UnplannedDebriefComment<br/>(+ @-mention anchors)<br/>→ Add-AzDevOpsDiscussionComment<br/>→ az boards work-item update (--discussion)"]
 
     DebriefPlat -- macOS/Linux --> ConsoleDebrief["Invoke-UnplannedDebriefConsole<br/>Read-Host notes + future-opportunity prompt"]
@@ -736,6 +736,8 @@ graph LR
     UWStoryCachePath[Get-UnplannedStoryCachePath]:::priv
     FindUW[Find-UnplannedWorkStoryId]:::priv
     NewUWStory[New-UnplannedWorkStory]:::priv
+    UWParentFeat[Read-UnplannedParentFeature]:::priv
+    UWProgress[New-WpfProgressWindow]:::priv
     NewUWTask[New-UnplannedWorkTask]:::priv
     UWFallback[Show-UnplannedCapturedItemsFallback]:::priv
     InvUWDebrief[Invoke-UnplannedDebrief]:::priv
@@ -1279,6 +1281,8 @@ graph LR
     UWGetCachedStory --> UWJsonRead
     GetDaily --> FindUW --> Boards
     GetDaily --> NewUWStory --> InvCreate
+    NewUWStory --> UWParentFeat --> PFeat
+    NewUWStory --> InvLink
     GetDaily --> UWSaveCachedStory
     UWSaveCachedStory --> UWStoryCachePath
     UWSaveCachedStory --> UWJsonSave
@@ -1289,6 +1293,7 @@ graph LR
     StartUW --> UWFallback
     StartUW --> UWBalloon
     StartUW --> WpfStopwatch
+    StartUW --> UWProgress
     StartUW --> InvUWDebrief
     InvUWDebrief --> UWSaveItems --> SetField
     InvUWDebrief --> InvUWDebriefWpf

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -131,13 +131,53 @@ function Find-UnplannedWorkStoryId {
 }
 
 
+function Read-UnplannedParentFeature {
+    # Interactive Story -> Feature parent pick for the daily catch-all story,
+    # mirroring az-New-AzDevOpsUserStory: pick a Feature from the cached
+    # hierarchy, and on an orphan pick offer to create one inline. Returns the
+    # chosen Feature id, or 0 to leave the daily story parentless - a skipped or
+    # failed pick must never block the firefight. Runs only when the daily story
+    # is first created for the day (a cached / existing story skips it).
+    $hierarchy = Read-AzDevOpsHierarchyCache
+    if ($null -eq $hierarchy) {
+        return 0
+    }
+
+    $featureId = Read-AzDevOpsFeaturePick -Hierarchy $hierarchy -ChildType 'USER_STORY'
+
+    if ($featureId -eq 0) {
+        $featureId = Resolve-AzDevOpsOrphanParent -ParentLabel 'Feature' -CreateParent {
+            az-New-AzDevOpsFeature -NoChildStoriesPrompt -NoOpen
+        }
+    }
+
+    return $featureId
+}
+
+
 function New-UnplannedWorkStory {
     # Creates the daily catch-all User Story via the shared create path so
     # priority / area / iteration / schema handling matches az-New-AzDevOps*.
-    # Returns the new id, or 0 on failure.
-    param([Parameter(Mandatory)] [string] $Title)
+    # Prompts once (first creation of the day) for a parent Feature so the day's
+    # firefighting rolls up under a real Feature; a skipped / failed pick leaves
+    # the story parentless rather than blocking the session. Returns the new id,
+    # or 0 on failure. -Progress is the session's WPF progress controller (a
+    # no-op stub off Windows); the parent pick is interactive, so the window is
+    # suspended around it and the az writes report their step.
+    param(
+        [Parameter(Mandatory)] [string] $Title,
+        [object] $Progress
+    )
 
-    $resolved = Resolve-AzDevOpsIterationArea -Type 'USER_STORY'
+    if ($null -eq $Progress) {
+        $Progress = New-WpfProgressWindow -Disabled
+    }
+
+    & $Progress.Suspend()
+    $featureId = Read-UnplannedParentFeature
+    $resolved  = Resolve-AzDevOpsIterationArea -Type 'USER_STORY'
+    & $Progress.Resume()
+
     if (-not $resolved.Ok) {
         return 0
     }
@@ -154,6 +194,7 @@ function New-UnplannedWorkStory {
         Area               = $resolved.Area
     }
 
+    & $Progress.SetStatus 'Creating today''s story...'
     $created = Invoke-AzDevOpsWorkItemCreate @createArgs
     if (-not $created.Ok) {
         Write-Host "Failed to create the daily Unplanned Work story: $($created.Error)" -ForegroundColor Red
@@ -161,6 +202,16 @@ function New-UnplannedWorkStory {
     }
 
     $newId = $created.Id
+
+    if ($featureId -gt 0) {
+        & $Progress.SetStatus 'Linking story to Feature...'
+        $link = Invoke-AzDevOpsParentLink -Id $newId -ParentId $featureId
+        if (-not $link.Ok) {
+            Write-Host "Story #$newId created but linking to Feature #$featureId failed: $($link.Error)" -ForegroundColor Yellow
+            Write-Host "  Re-link manually if needed." -ForegroundColor Yellow
+        }
+    }
+
     return $newId
 }
 
@@ -229,7 +280,12 @@ function Get-UnplannedWorkDailyStory {
     # can't race into creating duplicates), then falls back to a WIQL lookup,
     # then creates. The resolved id is cached on the way out. -NoCreate returns
     # 0 instead of creating when none exists (used by the daily-debrief reader).
-    param([switch] $NoCreate)
+    # -Progress flows the session's WPF progress controller into the create path
+    # so New-UnplannedWorkStory can report its az-boards steps.
+    param(
+        [switch] $NoCreate,
+        [object] $Progress
+    )
 
     $title = Get-UnplannedWorkDailyStoryTitle
 
@@ -251,7 +307,7 @@ function Get-UnplannedWorkDailyStory {
     }
 
     Write-Host "No daily story for today yet - creating '$title'..." -ForegroundColor Cyan
-    $newId = New-UnplannedWorkStory -Title $title
+    $newId = New-UnplannedWorkStory -Title $title -Progress $Progress
     if ($newId -gt 0) {
         Save-UnplannedCachedStoryId -Id $newId
     }
@@ -682,10 +738,12 @@ function Invoke-UnplannedDebriefConsole {
 function Invoke-UnplannedDebriefWpf {
     # Windows debrief path: the same themed WPF form the Pomodoro timer uses
     # (Show-WpfTimerDebrief), re-labelled for firefighting. The form carries the
-    # debrief notes + future-opportunity fields, a read-only review list of the
-    # captured items, and the in-form tag-teammates box (replacing the console
-    # mention picker). Its SubmitAction composes + posts the debrief comment under
-    # the form's spinner; the future-opportunity → create-story prompt runs in the
+    # debrief notes + future-opportunity fields, an "Open in Azure DevOps" button
+    # for the just-created Task, and the in-form tag-teammates box (replacing the
+    # console mention picker). The captured items are already flushed to the Task
+    # description, so the form omits the read-only review list (it passes no
+    # -Items). Its SubmitAction composes + posts the debrief comment under the
+    # form's spinner; the future-opportunity → create-story prompt runs in the
     # terminal tail after the form closes, fed by the form's captured text.
     param(
         [Parameter(Mandatory)] [int] $TaskId,
@@ -714,6 +772,10 @@ function Invoke-UnplannedDebriefWpf {
         return $posted
     }.GetNewClosure()
 
+    $openAction = {
+        az-Open-WorkItemById $TaskId
+    }.GetNewClosure()
+
     $header         = "Unplanned session complete — $ElapsedMinutes min, $($itemList.Count) item(s)"
     $primaryLabel   = 'Debrief notes for this firefight'
     $secondaryLabel = 'Future opportunity (optional) — a feature/user story to prevent this firefight?'
@@ -722,11 +784,12 @@ function Invoke-UnplannedDebriefWpf {
         -Interrupted    $false `
         -SubmitAction   $submitAction `
         -TeamRoster     $teamRoster `
+        -OpenAction     $openAction `
+        -OpenLabel      'Open in Azure DevOps' `
         -WindowTitle    'Unplanned Work Debrief' `
         -HeaderText     $header `
         -PrimaryLabel   $primaryLabel `
         -SecondaryLabel $secondaryLabel `
-        -Items          $itemList `
         -NoRestart
 
     if (-not $debriefResult.PostResult) {
@@ -746,14 +809,22 @@ function Invoke-UnplannedDebrief {
     # minutes from $StartTime (accurate regardless of the on-screen counter),
     # flushes the captured items to the Task description, then dispatches to the
     # shared WPF debrief form on Windows or the terminal debrief elsewhere, and
-    # records the session in the day's ledger.
+    # records the session in the day's ledger. -Progress is the session's WPF
+    # progress controller (a no-op stub off Windows): the items-flush reports its
+    # step under it, then it's closed before the debrief form opens so the form
+    # isn't left sitting behind the progress window.
     param(
         [Parameter(Mandatory)] [int]      $TaskId,
         [Parameter(Mandatory)] [int]      $StoryId,
         [Parameter(Mandatory)] [string]   $Title,
         [Parameter(Mandatory)] [datetime] $StartTime,
-        [object[]] $Items
+        [object[]] $Items,
+        [object] $Progress
     )
+
+    if ($null -eq $Progress) {
+        $Progress = New-WpfProgressWindow -Disabled
+    }
 
     $itemList = @($Items)
 
@@ -767,7 +838,10 @@ function Invoke-UnplannedDebrief {
     Write-Host "$iconCheck Unplanned session complete - $elapsedMinutes min, $($itemList.Count) item(s)." -ForegroundColor Green
     Write-Host ""
 
+    & $Progress.SetStatus 'Saving captured items...'
     Save-UnplannedItemsToTask -TaskId $TaskId -Title $Title -Items $itemList
+
+    & $Progress.Stop()
 
     if (Test-WpfIsWindows) {
         Invoke-UnplannedDebriefWpf -TaskId $TaskId -ElapsedMinutes $elapsedMinutes -Items $itemList
@@ -1113,21 +1187,36 @@ function az-Start-UnplannedWork {
         # + child Task are created now, just before the debrief flushes the
         # captured items and posts the comment. A failed create surfaces the
         # captured items rather than losing them.
-        $storyId = Get-UnplannedWorkDailyStory
-        if ($storyId -le 0) {
-            Write-Host "No daily Unplanned Work story available - cannot record this session." -ForegroundColor Red
-            Show-UnplannedCapturedItemsFallback -Title $Title -Items $items
-            return
-        }
+        #
+        # On Windows a small progress window names the az-boards step in flight
+        # (find/create story → create Task → save items) so the user isn't left
+        # staring at a frozen terminal; off Windows it's a no-op stub and the
+        # per-step Write-Host lines stay the feedback. Invoke-UnplannedDebrief
+        # closes it before opening the debrief form; the finally closes it again
+        # (idempotent) on any early return.
+        $progress = New-WpfProgressWindow -Title 'Unplanned Work' -InitialStatus 'Finding today''s story...'
 
-        $taskId = New-UnplannedWorkTask -Title $Title -StoryId $storyId
-        if ($taskId -le 0) {
-            Write-Host "Could not create the firefight Task - cannot record this session." -ForegroundColor Red
-            Show-UnplannedCapturedItemsFallback -Title $Title -Items $items
-            return
-        }
+        try {
+            $storyId = Get-UnplannedWorkDailyStory -Progress $progress
+            if ($storyId -le 0) {
+                Write-Host "No daily Unplanned Work story available - cannot record this session." -ForegroundColor Red
+                Show-UnplannedCapturedItemsFallback -Title $Title -Items $items
+                return
+            }
 
-        Invoke-UnplannedDebrief -TaskId $taskId -StoryId $storyId -Title $Title -StartTime $startTime -Items $items
+            & $progress.SetStatus 'Creating firefight Task...'
+            $taskId = New-UnplannedWorkTask -Title $Title -StoryId $storyId
+            if ($taskId -le 0) {
+                Write-Host "Could not create the firefight Task - cannot record this session." -ForegroundColor Red
+                Show-UnplannedCapturedItemsFallback -Title $Title -Items $items
+                return
+            }
+
+            Invoke-UnplannedDebrief -TaskId $taskId -StoryId $storyId -Title $Title -StartTime $startTime -Items $items -Progress $progress
+        }
+        finally {
+            & $progress.Stop()
+        }
     }
     finally {
         [Console]::OutputEncoding = $previousEncoding

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -173,10 +173,10 @@ function New-UnplannedWorkStory {
         $Progress = New-WpfProgressWindow -Disabled
     }
 
-    & $Progress.Suspend()
+    & $Progress.Suspend
     $featureId = Read-UnplannedParentFeature
     $resolved  = Resolve-AzDevOpsIterationArea -Type 'USER_STORY'
-    & $Progress.Resume()
+    & $Progress.Resume
 
     if (-not $resolved.Ok) {
         return 0
@@ -841,7 +841,7 @@ function Invoke-UnplannedDebrief {
     & $Progress.SetStatus 'Saving captured items...'
     Save-UnplannedItemsToTask -TaskId $TaskId -Title $Title -Items $itemList
 
-    & $Progress.Stop()
+    & $Progress.Stop
 
     if (Test-WpfIsWindows) {
         Invoke-UnplannedDebriefWpf -TaskId $TaskId -ElapsedMinutes $elapsedMinutes -Items $itemList
@@ -1215,7 +1215,7 @@ function az-Start-UnplannedWork {
             Invoke-UnplannedDebrief -TaskId $taskId -StoryId $storyId -Title $Title -StartTime $startTime -Items $items -Progress $progress
         }
         finally {
-            & $progress.Stop()
+            & $progress.Stop
         }
     }
     finally {

--- a/powcuts_by_cli/pow_common.ps1
+++ b/powcuts_by_cli/pow_common.ps1
@@ -425,3 +425,151 @@ function New-WpfSpinnerControl {
     }
     return $result
 }
+
+
+function New-WpfProgressController {
+    # Private - the no-op controller returned off Windows / when WPF can't load
+    # / when a caller asks for a disabled progress window. Every member is a
+    # do-nothing scriptblock so call sites drive the real and stub controllers
+    # identically; the feature's own Write-Host lines stay the non-Windows
+    # feedback. Unapproved-verb-free (New is approved); treated as private.
+    $result = [PSCustomObject]@{
+        SetStatus = { param([string] $Text) }
+        Suspend   = { }
+        Resume    = { }
+        Stop      = { }
+    }
+    return $result
+}
+
+
+function New-WpfProgressWindow {
+    # Lightweight non-modal WPF progress window: a spinner glyph beside a status
+    # line, themed to match the timer / unplanned forms. Built for a synchronous
+    # script that runs a chain of slow calls and wants to show which step it's on
+    # - the az-boards chain az-Start-UnplannedWork runs at session stop. Returns
+    # a controller object whose scriptblock members drive it:
+    #   SetStatus <text> - repaint the status line. Forces a Render-priority
+    #                      dispatch so the new text paints before the next
+    #                      synchronous call blocks the UI thread (same trick the
+    #                      debrief form's "Posting..." overlay uses - the window
+    #                      is non-modal so there's no message pump to animate the
+    #                      spinner during a blocking call; the changing status
+    #                      text is the real progress signal).
+    #   Suspend / Resume - hide / re-show the window around an interactive
+    #                      terminal prompt, so a topmost window doesn't sit over a
+    #                      console picker (mirrors the stopwatch's hide/show-
+    #                      around-"Create New Story" pattern).
+    #   Stop             - stop the spinner and close the window; idempotent, so
+    #                      a caller can close early and a finally can close again.
+    # Off Windows, when -Disabled is set, or when PresentationFramework can't be
+    # loaded, returns the no-op controller so callers never branch on platform.
+    param(
+        [string] $Title         = 'Working',
+        [string] $InitialStatus = 'Working...',
+        [switch] $Disabled
+    )
+
+    if ($Disabled -or -not (Test-WpfIsWindows)) {
+        $stub = New-WpfProgressController
+        return $stub
+    }
+
+    try {
+        Add-Type -AssemblyName PresentationFramework, WindowsBase, PresentationCore
+    }
+    catch {
+        $stub = New-WpfProgressController
+        return $stub
+    }
+
+    $brushes = New-WpfBrushSet -ProgressColor $script:WpfColorProgressUnplanned
+
+    $win = New-Object System.Windows.Window -Property @{
+        Title                 = $Title
+        SizeToContent         = 'WidthAndHeight'
+        WindowStyle           = 'None'
+        AllowsTransparency    = $true
+        Background            = $brushes.Clear
+        Topmost               = $true
+        WindowStartupLocation = 'CenterScreen'
+    }
+
+    $border = New-Object System.Windows.Controls.Border -Property @{
+        Background      = $brushes.Bg
+        BorderBrush     = $brushes.Stroke
+        BorderThickness = 2
+        CornerRadius    = 10
+        Padding         = '20,16'
+    }
+
+    $row = New-Object System.Windows.Controls.StackPanel -Property @{
+        Orientation         = 'Horizontal'
+        HorizontalAlignment = 'Center'
+        VerticalAlignment   = 'Center'
+    }
+
+    $spinnerRightMargin = New-Object System.Windows.Thickness(0, 0, 10, 0)
+    $spinner = New-WpfSpinnerControl -Brushes $brushes -FontSize 20
+    $spinner.Text.Margin = $spinnerRightMargin
+    $row.Children.Add($spinner.Text) | Out-Null
+
+    $statusText = New-Object System.Windows.Controls.TextBlock -Property @{
+        Text              = $InitialStatus
+        FontSize          = 13
+        Foreground        = $brushes.White
+        VerticalAlignment = 'Center'
+        TextWrapping      = 'Wrap'
+        MaxWidth          = 300
+    }
+    $row.Children.Add($statusText) | Out-Null
+
+    $border.Child = $row
+    $win.Content  = $border
+
+    # Flush the dispatcher to Render priority so a status change paints before the
+    # next synchronous call blocks this (UI) thread - the window has no message
+    # pump of its own (it's shown non-modally, not via ShowDialog).
+    $forceRender = {
+        $win.Dispatcher.Invoke(
+            [action]{},
+            [System.Windows.Threading.DispatcherPriority]::Render
+        )
+    }.GetNewClosure()
+
+    $win.Show()
+    $spinner.Timer.Start()
+    & $forceRender
+
+    $stopped = [ref] $false
+
+    $controller = [PSCustomObject]@{
+        SetStatus = {
+            param([string] $Text)
+
+            $statusText.Text = $Text
+            & $forceRender
+        }.GetNewClosure()
+
+        Suspend = {
+            $win.Hide()
+        }.GetNewClosure()
+
+        Resume = {
+            $win.Show()
+            & $forceRender
+        }.GetNewClosure()
+
+        Stop = {
+            if ($stopped.Value) {
+                return
+            }
+
+            $stopped.Value = $true
+            $spinner.Timer.Stop()
+            $win.Close()
+        }.GetNewClosure()
+    }
+
+    return $controller
+}

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -1020,6 +1020,10 @@ function Show-WpfTimerDebrief {
     # via these knobs, all defaulting to the timer's wording so the timer call
     # site is unchanged:
     #   -PrimaryLabel / -SecondaryLabel - the two field labels.
+    #   -OpenLabel                      - the open-item button's caption, shown
+    #                                     only when -OpenAction is supplied
+    #                                     (unplanned work passes "Open in Azure
+    #                                     DevOps"; the timer keeps the default).
     #   -WindowTitle / -HeaderText      - the window title and the form heading
     #                                     (HeaderText overrides the interrupted/
     #                                     complete default when supplied).
@@ -1048,6 +1052,7 @@ function Show-WpfTimerDebrief {
         [Parameter(Mandatory)] [scriptblock] $SubmitAction,
         [AllowEmptyCollection()] [object[]]  $TeamRoster = @(),
         [scriptblock] $OpenAction,
+        [string] $OpenLabel      = 'Open work item',
         [scriptblock] $CloseAction,
         [string] $WindowTitle    = 'Timer Debrief',
         [string] $HeaderText     = '',
@@ -1142,7 +1147,7 @@ function Show-WpfTimerDebrief {
         Visibility          = [System.Windows.Visibility]::Collapsed
     }
     $btnOpenItem = New-Object System.Windows.Controls.Button -Property @{
-        Content    = 'Open work item'
+        Content    = $OpenLabel
         Width      = 130
         Height     = 24
         Background = $brushes.Button


### PR DESCRIPTION

## Navigation

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #164 |
| [Changes](#changes) | ✅ 4 files |
| [Test Plan](#test-plan-windows-powershell--wpf-cant-run-in-ci) | ✅ 7 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4792433490) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4792450664) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4792438641) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4792442359) |
| 📄 Docs Check | ✅ CURRENT — [View](#issuecomment-4792469124) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4792470761) |
| 📐 AzDO Diagrams Check | ✅ CURRENT — [View](#issuecomment-4792471214) |


<!-- pr-diagram:start -->
## How it works

`az-Start-UnplannedWork` runs the session, then at stop spins up a non-modal WPF progress window that narrates the at-stop `az boards` chain. On the first daily-story creation it now prompts for a parent Feature and links the story under it; later firefights reuse the cached story and skip the prompt. The debrief reuses the shared timer form, re-labelled and given an "Open in Azure DevOps" button.

```mermaid
flowchart TD
    Start([az-Start-UnplannedWork]):::pub
    Prog["New-WpfProgressWindow<br/>spinner + status line<br/>no-op stub off Windows"]:::pub
    Daily[Get-UnplannedWorkDailyStory]
    Cached{cached or existing<br/>story today?}
    NewStory[New-UnplannedWorkStory]
    Parent["Read-UnplannedParentFeature<br/>pick parent Feature"]:::pub
    Orphan["Resolve-AzDevOpsOrphanParent<br/>orphan-safe fallback"]:::priv
    Link[Invoke-AzDevOpsParentLink]:::priv
    Task[create + link firefight Task]
    Debrief[Invoke-UnplannedDebrief]
    Form["Show-WpfTimerDebrief<br/>drops captured-items list<br/>Open in Azure DevOps button"]:::pub
    Open["az-Open-WorkItemById<br/>via -OpenAction / -OpenLabel"]:::io

    Start --> Prog
    Start --> Daily
    Daily --> Cached
    Cached -- yes --> Task
    Cached -- no, first today --> NewStory
    NewStory --> Parent
    Parent --> Orphan
    Parent -.link.-> Link
    NewStory --> Task
    Task --> Debrief
    Debrief -- flush items, close window --> Form
    Form -- click --> Open
    Prog -. per-step status .-> Debrief

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Four refinements to `az-Start-UnplannedWork` (PowerShell/Windows-only), all gated to the unplanned call site so the **shared Pomodoro timer debrief form is unchanged**:

1. **Parent-Feature prompt** — the daily *&#34;Unplanned Work — &#34;* catch-all story is no longer created orphaned. On the **first** creation each day, `New-UnplannedWorkStory` prompts for a parent Feature and links it; cached/existing stories skip the prompt; a skipped/failed pick falls back to parentless without aborting the session.
2. **Trimmed debrief form** — `Invoke-UnplannedDebriefWpf` no longer passes `-Items`, so the redundant read-only &#34;Captured items&#34; list is gone (items already flush to the Task description).
3. **Open-task button** — the form now passes `-OpenAction`, surfacing an **&#34;Open in Azure DevOps&#34;** button that opens the just-created Task (reachable even after a failed post).
4. **Loading spinner** — a new non-modal `New-WpfProgressWindow` wraps the at-stop `az boards` chain (find/create story → create Task → save items) with a per-step status line, so the user isn&#39;t staring at a frozen terminal. No-op stub off Windows, where the existing `Write-Host` lines remain the feedback.

## Issue
Closes #164

## Changes
- `powcuts_by_cli/azdevops_unplanned.ps1` — new `Read-UnplannedParentFeature`; `New-UnplannedWorkStory` parent pick + `Invoke-AzDevOpsParentLink`; `-Progress` threaded through `Get-UnplannedWorkDailyStory` / `Invoke-UnplannedDebrief` / the orchestrator; `Invoke-UnplannedDebriefWpf` drops `-Items`, adds `-OpenAction`/`-OpenLabel`.
- `powcuts_by_cli/pow_common.ps1` — new `New-WpfProgressWindow` (+ private no-op `New-WpfProgressController`).
- `powcuts_by_cli/pow_timer.ps1` — `Show-WpfTimerDebrief` gains a defaulted `-OpenLabel` knob (timer keeps `&#39;Open work item&#39;`; unplanned passes `&#39;Open in Azure DevOps&#39;`).
- `docs/azure-devops-diagrams.md` — section-11 flowchart, dependency map, and prose updated.

## Test Plan (Windows PowerShell — WPF, can&#39;t run in CI)
- [ ] All changed `.ps1` files parse cleanly (`[System.Management.Automation.Language.Parser]::ParseFile(...)`)
- [ ] First firefight of the day prompts for a parent Feature; the daily story is linked under it in Azure DevOps
- [ ] A skipped/failed Feature pick creates the story parentless without aborting
- [ ] A second firefight the same day reuses the cached story with **no** Feature prompt
- [ ] The unplanned debrief form shows **no** &#34;Captured items&#34; list and an **&#34;Open in Azure DevOps&#34;** button that opens the new Task
- [ ] A spinner window with updating status text shows while the at-stop `az boards` jobs run
- [ ] Pomodoro timer debrief (`Start-TimerSession`) is unchanged — no list change, no extra button, no spinner regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKnjPmNLKwW7KiZgkoaNHa)_