### PR TITLE
Fix Feature description: add line break after Summary / Business Value headings

### DIFF
--- a/powcuts_by_cli/azdevops_create_pickers.ps1
+++ b/powcuts_by_cli/azdevops_create_pickers.ps1
@@ -143,8 +143,10 @@ function Read-AzDevOpsFeatureDescription {
     # Business Value - each under a bold HTML heading so they render as bold
     # headings in the AzDO Description field (which stores HTML). Mirrors
     # Read-AzDevOpsUserStoryDescription: each clause is required (re-prompts
-    # until non-empty) and the two are joined with '<br/><br/>' so they render
-    # on separate lines: "<b>Summary</b> <text>" / "<b>Business Value</b> <text>".
+    # until non-empty). Within a section the heading sits on its own line above
+    # its text (joined with '<br/>'), and the two sections are separated by a
+    # blank line ('<br/><br/>'), so the Description renders as:
+    #   "<b>Summary</b>" / "<text>" / "" / "<b>Business Value</b>" / "<text>".
     $summaryHeading       = '<b>Summary</b>'
     $businessValueHeading = '<b>Business Value</b>'
 
@@ -158,11 +160,12 @@ function Read-AzDevOpsFeatureDescription {
         $businessValue = (Read-Host 'Business Value').Trim()
     }
 
-    $clauseBreak = '<br/><br/>'
+    $headingBreak = '<br/>'
+    $clauseBreak  = '<br/><br/>'
 
     $clauses = @(
-        "$summaryHeading $summary"
-        "$businessValueHeading $businessValue"
+        "$summaryHeading$headingBreak$summary"
+        "$businessValueHeading$headingBreak$businessValue"
     )
 
     $description = $clauses -join $clauseBreak


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #166 |
| [Changes](#changes) | ✅ 1 file |
| [Test Plan](#test-plan) | ✅ 3 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4802435851) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4802439219) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4802443908) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4802441402) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4802452016) |
| 📚 Docs Check | ✅ CURRENT (no new files/CLIs) |
| 📐 AzDO Diagrams Check | ✅ CURRENT (body-only change) |
<!-- toc:end -->

## Summary
When creating a Feature via `az-New-AzDevOpsFeature`, the composed Description joined each bold heading to its body with a plain space (`<b>Summary</b> the text`), so AzDO rendered the label and prose on one line. Each heading now sits on its own line above its content, while the blank-line gap between the two sections is preserved.

## Issue
Closes #166

## Changes
- `powcuts_by_cli/azdevops_create_pickers.ps1` → `Read-AzDevOpsFeatureDescription`:
  - Added a named `$headingBreak = '<br/>'` separator and joined each heading to its body with it.
  - Kept `$clauseBreak = '<br/><br/>'` between the Summary and Business Value sections.
  - Updated the function doc comment to describe the new render layout.

Renders as:
> **Summary**
> the text
>
> **Business Value**
> the text

## Test Plan
- [ ] Open a fresh PowerShell terminal (`reinit` or new shell), run `az-New-AzDevOpsFeature`, enter Summary + Business Value
- [ ] Confirm in AzDO that each bold heading renders on its own line above its text, with a blank line between sections
- [ ] `pwsh -NoProfile` parses `powcuts_by_cli/azdevops_create_pickers.ps1` with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)