### PR TITLE
Move Sprint/Iteration selection up front in az-New-AzDevOps* creators

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -422,10 +422,17 @@ flowchart TD
     Hier -- ok --> Title{Title param?}
 
     Title -- no --> ReadTitle["Read-Host 'title'"]
-    Title -- yes --> Desc{Description param?}
+    Title -- yes --> Iter{Iteration param?}
     ReadTitle --> TitleEmpty{empty?}
     TitleEmpty -- yes --> Abort4([abort])
-    TitleEmpty -- no --> Desc
+    TitleEmpty -- no --> Iter
+
+    Iter -- no --> PickIter["Read-AzDevOpsKindPick -Kind 'Iteration'<br/>cache or Invoke-AzDevOpsClassificationLive<br/>→ Read-AzDevOpsGridPick (Out-ConsoleGridView)"]
+    Iter -- yes --> Area{Area param?}
+    PickIter --> Area
+    Area -- no --> PickArea["Read-AzDevOpsKindPick -Kind 'Area'<br/>→ Read-AzDevOpsGridPick (Out-ConsoleGridView)"]
+    Area -- yes --> Desc{Description param?}
+    PickArea --> Desc
 
     Desc -- no --> ReadDesc["Read-AzDevOpsUserStoryDescription<br/>(As-a / I-want / so-that prompts)"]
     Desc -- yes --> Prio{Priority 1-4?}
@@ -440,14 +447,8 @@ flowchart TD
     AC -- yes --> Feat{FeatureId >=0?}
     ReadAC --> Feat
     Feat -- no --> PickFeat["Read-AzDevOpsFeaturePick<br/>(active Features from hierarchy.json)<br/>→ Read-AzDevOpsGridPick (Out-ConsoleGridView)<br/>or numbered menu fallback"]
-    Feat -- yes --> Iter{Iteration param?}
-    PickFeat --> Iter
-    Iter -- no --> PickIter["Read-AzDevOpsKindPick -Kind 'Iteration'<br/>cache or Invoke-AzDevOpsClassificationLive<br/>→ Read-AzDevOpsGridPick (Out-ConsoleGridView)"]
-    Iter -- yes --> Area{Area param?}
-    PickIter --> Area
-    Area -- no --> PickArea["Read-AzDevOpsKindPick -Kind 'Area'<br/>→ Read-AzDevOpsGridPick (Out-ConsoleGridView)"]
-    Area -- yes --> Create
-    PickArea --> Create
+    Feat -- yes --> Create
+    PickFeat --> Create
 
     Create["Invoke-AzDevOpsWorkItemCreate<br/>→ New-AzDevOpsWorkItem<br/>→ az boards work-item create"]
     Create --> CreateOk{Ok?}
@@ -482,8 +483,14 @@ flowchart TD
     Email -- yes --> Hier[Read-AzDevOpsHierarchyCache]
     Hier --> Title{Title param?}
     Title -- no --> ReadTitle["Read-Host 'title'"]
-    Title -- yes --> Desc{Description param?}
-    ReadTitle --> Desc
+    Title -- yes --> Iter{Iteration param?}
+    ReadTitle --> Iter
+    Iter -- no --> PickIter[Read-AzDevOpsKindPick -Kind 'Iteration']
+    Iter -- yes --> Area{Area param?}
+    PickIter --> Area
+    Area -- no --> PickArea[Read-AzDevOpsKindPick -Kind 'Area']
+    Area -- yes --> Desc{Description param?}
+    PickArea --> Desc
     Desc -- no --> ReadDesc["Read-AzDevOpsFeatureDescription<br/>(Summary + Business Value prompts)"]
     Desc -- yes --> Prio{Priority 1-4?}
     ReadDesc --> Prio
@@ -491,14 +498,8 @@ flowchart TD
     Prio -- yes --> Epic{ParentEpicId >= 0?}
     ReadPrio --> Epic
     Epic -- no --> PickEpic["Read-AzDevOpsEpicPick<br/>-> Read-AzDevOpsParentPick<br/>(active Epics from hierarchy.json)"]
-    Epic -- yes --> Iter{Iteration param?}
-    PickEpic --> Iter
-    Iter -- no --> PickIter[Read-AzDevOpsKindPick -Kind 'Iteration']
-    Iter -- yes --> Area{Area param?}
-    PickIter --> Area
-    Area -- no --> PickArea[Read-AzDevOpsKindPick -Kind 'Area']
-    Area -- yes --> Create
-    PickArea --> Create
+    Epic -- yes --> Create
+    PickEpic --> Create
 
     Create["Invoke-AzDevOpsWorkItemCreate -Type 'Feature'<br/>(StoryPoints field omitted)"]
     Create --> CreateOk{Ok?}

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -549,6 +549,13 @@ function az-New-AzDevOpsUserStory {
         return
     }
 
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'USER_STORY'
+    if (-not $resolved.Ok) {
+        return
+    }
+    $Iteration = $resolved.Iteration
+    $Area = $resolved.Area
+
     if (-not $PSBoundParameters.ContainsKey('Description')) {
         $Description = Read-AzDevOpsUserStoryDescription
     }
@@ -574,13 +581,6 @@ function az-New-AzDevOpsUserStory {
             }
         }
     }
-
-    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'USER_STORY'
-    if (-not $resolved.Ok) {
-        return
-    }
-    $Iteration = $resolved.Iteration
-    $Area = $resolved.Area
 
     $tags = Resolve-AzDevOpsTypeTagsOrEmpty   -Type 'USER_STORY'
     $extraFields = Read-AzDevOpsRequiredFields       -Type 'USER_STORY'
@@ -652,6 +652,13 @@ function az-New-Task {
         return
     }
 
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'TASK'
+    if (-not $resolved.Ok) {
+        return
+    }
+    $Iteration = $resolved.Iteration
+    $Area = $resolved.Area
+
     if (-not $PSBoundParameters.ContainsKey('Description')) {
         $Description = Read-Host 'What is the description?'
     }
@@ -663,13 +670,6 @@ function az-New-Task {
     if ($ParentStoryId -lt 0) {
         $ParentStoryId = Read-AzDevOpsStoryPick -Hierarchy $hierarchy -ChildType 'TASK'
     }
-
-    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'TASK'
-    if (-not $resolved.Ok) {
-        return
-    }
-    $Iteration = $resolved.Iteration
-    $Area = $resolved.Area
 
     $tags = Resolve-AzDevOpsTypeTagsOrEmpty -Type 'TASK'
     $extraFields = Read-AzDevOpsRequiredFields     -Type 'TASK'
@@ -745,6 +745,13 @@ function az-New-AzDevOpsFeature {
         return
     }
 
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'FEATURE'
+    if (-not $resolved.Ok) {
+        return
+    }
+    $Iteration = $resolved.Iteration
+    $Area = $resolved.Area
+
     if (-not $PSBoundParameters.ContainsKey('Description')) {
         $Description = Read-AzDevOpsFeatureDescription
     }
@@ -762,13 +769,6 @@ function az-New-AzDevOpsFeature {
             }
         }
     }
-
-    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'FEATURE'
-    if (-not $resolved.Ok) {
-        return
-    }
-    $Iteration = $resolved.Iteration
-    $Area = $resolved.Area
 
     $tags = Resolve-AzDevOpsTypeTagsOrEmpty -Type 'FEATURE'
     $extraFields = Read-AzDevOpsRequiredFields     -Type 'FEATURE'
@@ -844,6 +844,13 @@ function az-New-AzDevOpsEpic {
         return
     }
 
+    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'EPIC'
+    if (-not $resolved.Ok) {
+        return
+    }
+    $Iteration = $resolved.Iteration
+    $Area = $resolved.Area
+
     if (-not $PSBoundParameters.ContainsKey('Description')) {
         $Description = Read-Host 'What is the description?'
     }
@@ -851,13 +858,6 @@ function az-New-AzDevOpsEpic {
     if ($Priority -lt 1 -or $Priority -gt 4) {
         $Priority = Resolve-AzDevOpsTypePriorityOrPrompt -Type 'EPIC'
     }
-
-    $resolved = Resolve-AzDevOpsIterationArea -Iteration $Iteration -Area $Area -Type 'EPIC'
-    if (-not $resolved.Ok) {
-        return
-    }
-    $Iteration = $resolved.Iteration
-    $Area = $resolved.Area
 
     $tags = Resolve-AzDevOpsTypeTagsOrEmpty -Type 'EPIC'
     $extraFields = Read-AzDevOpsRequiredFields     -Type 'EPIC'


### PR DESCRIPTION
<!-- toc:start -->
## Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #168 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | 0/4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4915486762) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4915495367) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4915496572) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4915499387) |
| ✅ Criteria Check | ⚠️ PARTIAL (4 verified, 1 parse-proxied, 2 manual) — [View](#issuecomment-4915518573) |
| 📚 Docs Check | ✅ CURRENT (no README change needed) |
| 🗺️ AzDO Diagrams Check | ✅ SYNCED (Diagrams 7 & 8 reordered to match code) |
<!-- toc:end -->

## Summary
Relocates the `Resolve-AzDevOpsIterationArea` (Sprint/Iteration + Area) prompt to immediately **after the title** in every interactive AzDevOps work-item creator, so the sprint is chosen while the user is still thinking about placement — not near the end of each item's prompt sequence.

## Issue
Closes #168

## Changes
- `powcuts_by_cli/azdevops_create.ps1` — reordered the sprint prompt (no logic change) in `az-New-AzDevOpsUserStory`, `az-New-AzDevOpsFeature`, `az-New-AzDevOpsEpic`, `az-New-Task`. New per-creator order: **Title → Sprint/Iteration + Area → Description → Priority → (Story Points / AC) → Parent pick → create**.
- `docs/azure-devops-diagrams.md` — synced Diagram 7 (`az-New-AzDevOpsUserStory`) and Diagram 8 (`az-New-AzDevOpsFeature`) flowcharts to the new prompt order.

Behavior deliberately preserved:
- **Downward inheritance stays** — `az-New-AzDevOpsFeatureStories` still inherits the Feature's iteration/area with no extra prompt.
- **Parent picks its own sprint** — in the orphan path (Story → "Create a new parent Feature now?"), the spawned parent keeps its own (now up-front) sprint prompt; it does not inherit the child's.
- Non-interactive `-Iteration`/`-Area` parameters still bypass the prompt.

## Test Plan
- [ ] `[System.Management.Automation.Language.Parser]::ParseFile(...)` on `powcuts_by_cli/azdevops_create.ps1` — zero errors (pwsh not on PATH in the build env; brace/paren balance verified: 172/172, 232/232)
- [ ] Fresh PowerShell terminal — `az-New-AzDevOpsUserStory` prompts for Sprint right after the title, before description/priority
- [ ] `az-New-AzDevOpsFeature` → "Add child stories now?" creates the Feature and its stories with a single sprint prompt (children inherit)
- [ ] `az-New-AzDevOpsUserStory -Iteration "Sprint 42" -Area "Team\Backend" -Title "x"` — no sprint prompt (non-interactive bypass intact)