### PR TITLE
Fix az-New-AzDevOpsUserStory: forward slash in an AC item no longer aborts the prompt loop

### DIFF
--- a/powcuts_by_cli/azdevops_create_pickers.ps1
+++ b/powcuts_by_cli/azdevops_create_pickers.ps1
@@ -79,27 +79,39 @@ function Read-AzDevOpsStoryPoints {
 
 
 function Read-AzDevOpsAcceptanceCriteria {
-    # One initial AC, then loop on Y/N. Joins additional ACs with '<br/><br/>'
-    # so they render as separate lines in the work-item editor. The existing
-    # az-create-userstory used `until ($resp -eq 'n')` which loops forever on
-    # any non-'n' reply (empty Enter, 'yes', 'q'); this version exits on
-    # anything that isn't an affirmative yes/y.
-    $first = Read-Host 'Acceptance criterion #1'
+    # Reads acceptance criteria one per line: prompt repeatedly and capture
+    # every non-empty entry as its own AC, stopping on the first blank line.
+    # This replaces an earlier 'More AC? (Y/N)' gate that discarded any reply
+    # which wasn't 'y'/'yes' - so typing a real criterion at that prompt (a
+    # natural thing to do, and one that usually contains a '/', which is just
+    # literal text to Read-Host) ended the loop and silently dropped the entry.
+    # A blank-to-finish loop can never lose an entered criterion. Collected ACs
+    # join with '<br/><br/>' so they render on separate lines in the work-item
+    # editor.
     $dash = '-'
     $break = '<br/><br/>'
-    $ac = "$dash $first"
 
+    $criteria = [System.Collections.Generic.List[string]]::new()
+
+    $index = 1
     while ($true) {
-        $resp = Read-Host 'More AC? (Y/N)'
-        if ($resp -notmatch '^(y|yes)$') {
+        $prompt = if ($index -eq 1) {
+            'Acceptance criterion #1'
+        } else {
+            "Acceptance criterion #$index (blank to finish)"
+        }
+
+        $entry = Read-Host $prompt
+        if (-not $entry) {
             break
         }
 
-        $next = Read-Host 'Enter additional AC'
-        $ac = "$ac $break $dash $next"
+        $criteria.Add($entry)
+        $index++
     }
 
-    return $ac
+    $formatted = ($criteria | ForEach-Object { "$dash $_" }) -join " $break "
+    return $formatted
 }
 
 


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #169 |
| [Changes](#changes) | ✅ 1 file |
| [Test Plan](#test-plan) | ✅ 5 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4915521854) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4915533186) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4915533381) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4915531022) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4915548667) |
| 📚 Docs Check | ✅ CURRENT (ran inline) |
| 📐 AzDO Diagrams Check | ✅ CURRENT (ran inline) |
<!-- toc:end -->

## Summary

`az-New-AzDevOpsUserStory`'s acceptance-criteria prompt could silently drop a criterion. The loop gated continuation on a strict `More AC? (Y/N)` prompt (`^(y|yes)$`), and the only place typed text ended the loop was that Y/N prompt — so when a user typed their next criterion there (a natural thing to do), it failed the y/yes match, broke the loop, and the criterion was discarded. Real criteria commonly contain a forward slash (e.g. `input/output`), which is why it presented as "a slash stops the add-AC process and drops the last item." The slash itself was incidental — `Read-Host` returns it literally.

This replaces the Y/N gate in `Read-AzDevOpsAcceptanceCriteria` with a **blank-line-to-finish** loop: every non-empty line is captured as its own AC, an empty line ends it. No entered criterion can be dropped, and `/`, `<`, `>` are always literal text. The joined output format (`- item <br/><br/> - item`) is byte-for-byte identical to before.

## Issue

Closes #169

## Changes

- `powcuts_by_cli/azdevops_create_pickers.ps1` — rewrote `Read-AzDevOpsAcceptanceCriteria` from a `More AC? (Y/N)` gate to a blank-line-to-finish loop that collects each non-empty entry into a `List[string]` and joins with `<br/><br/>`.

PowerShell-only by design — the bash `az-create-userstory` reads ACs differently and is explicitly out of scope per the issue.

## Test Plan

- [ ] Open a fresh PowerShell terminal — `az-New-AzDevOpsUserStory` runs without parse errors
- [ ] At `Acceptance criterion #1:` enter `validate input/output`
- [ ] At `Acceptance criterion #2 (blank to finish):` enter `check a/b`
- [ ] At `Acceptance criterion #3 (blank to finish):` press Enter to finish
- [ ] Confirm the created User Story's Acceptance Criteria shows both lines with the forward slashes intact