### PR TITLE
Capitalize So that clause and render acceptance criteria as a checklist

### DIFF
--- a/powcuts_by_cli/azdevops_create_pickers.ps1
+++ b/powcuts_by_cli/azdevops_create_pickers.ps1
@@ -85,11 +85,14 @@ function Read-AzDevOpsAcceptanceCriteria {
     # which wasn't 'y'/'yes' - so typing a real criterion at that prompt (a
     # natural thing to do, and one that usually contains a '/', which is just
     # literal text to Read-Host) ended the loop and silently dropped the entry.
-    # A blank-to-finish loop can never lose an entered criterion. Collected ACs
-    # join with '<br/><br/>' so they render on separate lines in the work-item
-    # editor.
-    $dash = '-'
-    $break = '<br/><br/>'
+    # A blank-to-finish loop can never lose an entered criterion. Each collected
+    # AC renders on its own line prefixed with a ballot-box glyph so the
+    # AcceptanceCriteria field (which stores HTML) shows a checklist in the AzDO
+    # work-item UI rather than plain dashes. A leading glyph is used instead of a
+    # raw <input type="checkbox"> because the field's HTML sanitizer strips form
+    # elements.
+    $uncheckedBox = "$([char]0x2610)"   # ballot box (empty checkbox)
+    $break = '<br/>'
 
     $criteria = [System.Collections.Generic.List[string]]::new()
 
@@ -110,8 +113,8 @@ function Read-AzDevOpsAcceptanceCriteria {
         $index++
     }
 
-    $formatted = ($criteria | ForEach-Object { "$dash $_" }) -join " $break "
-    return $formatted
+    $checklist = ($criteria | ForEach-Object { "$uncheckedBox $_" }) -join $break
+    return $checklist
 }
 
 
@@ -120,7 +123,7 @@ function Read-AzDevOpsUserStoryDescription {
     # template. Each clause is required - re-prompts until a non-empty value
     # is entered - then joins them with HTML line breaks so each clause
     # renders on its own line in the AzDO Description field (which stores
-    # HTML): "As a <persona>" / "I want <outcome>" / "so that <benefit>".
+    # HTML): "As a <persona>" / "I want <outcome>" / "So that <benefit>".
     $persona = ''
     while (-not $persona) {
         $persona = (Read-Host 'As a ...').Trim()
@@ -133,7 +136,7 @@ function Read-AzDevOpsUserStoryDescription {
 
     $benefit = ''
     while (-not $benefit) {
-        $benefit = (Read-Host 'so that ...').Trim()
+        $benefit = (Read-Host 'So that ...').Trim()
     }
 
     $clauseBreak = '<br/><br/>'
@@ -141,7 +144,7 @@ function Read-AzDevOpsUserStoryDescription {
     $clauses = @(
         "As a $persona"
         "I want $outcome"
-        "so that $benefit"
+        "So that $benefit"
     )
 
     $description = $clauses -join $clauseBreak


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #172 |
| [Changes](#changes) | ✅ 1 file, 2 functions |
| [Shell Parity](#shell-parity) | ✅ PowerShell-only |
| [Test Plan](#test-plan) | 0/3 |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4928488326) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4928493378) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4928497555) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4928498033) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4928510915) |
| 📚 Docs Check | ✅ CURRENT — (ran inline, no comment) |
<!-- toc:end -->

## Summary
Two polish fixes to the `az-New-AzDevOpsUserStory` create flow so generated Azure DevOps work items look cleaner in the web UI. Both changes are in `powcuts_by_cli/azdevops_create_pickers.ps1`.

## Issue
Closes #172

## Changes
- **`Read-AzDevOpsUserStoryDescription`** — the third clause now renders as `So that <benefit>` so every clause line begins with a capital letter (`As a` / `I want` were already capitalized). The interactive prompt is capitalized to `So that ...` to match its siblings. User-typed text is left exactly as entered.
- **`Read-AzDevOpsAcceptanceCriteria`** — each criterion is now prefixed with a `☐` ballot-box glyph (`[char]0x2610`) and joined with `<br/>`, so the HTML `AcceptanceCriteria` field renders as a visible checklist instead of literal `-` dashes. A glyph is used rather than a raw `<input type="checkbox">` because the field's HTML sanitizer strips form elements, which would otherwise render as plain text.

## Shell Parity
PowerShell-only. The Azure DevOps `az boards` create flow has no bash counterpart, so no `bashcuts_by_cli/` change is needed.

## Test Plan
- [ ] `pwsh` parse: `[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/azdevops_create_pickers.ps1',[ref]$null,[ref]$null)` — zero errors
- [ ] Fresh PowerShell terminal → run `az-New-AzDevOpsUserStory`, enter the three clauses and 2+ acceptance criteria
- [ ] Open the created story in the AzDO web UI — Description shows `So that …`; Acceptance Criteria shows a `☐` checklist, not dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sppH1tksz7xtgsgZZ9apm