### PR TITLE
Recover captured fields on work-item create failure + cap title length

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -423,7 +423,7 @@ flowchart TD
     Hier -- null --> Abort3([abort: cache missing])
     Hier -- ok --> Title{Title param?}
 
-    Title -- no --> ReadTitle["Read-Host 'title'"]
+    Title -- no --> ReadTitle["Read-AzDevOpsTitle<br/>(caps at 255, warns near limit, offers truncate)"]
     Title -- yes --> Iter{Iteration param?}
     ReadTitle --> TitleEmpty{empty?}
     TitleEmpty -- yes --> Abort4([abort])
@@ -454,7 +454,9 @@ flowchart TD
 
     Create["Invoke-AzDevOpsWorkItemCreate<br/>→ New-AzDevOpsWorkItem<br/>→ az boards work-item create"]
     Create --> CreateOk{Ok?}
-    CreateOk -- no --> CreateFail([STEP FAILED])
+    CreateOk -- no --> Recover["Read-AzDevOpsCreateFieldEdit<br/>title-length → Read-AzDevOpsTitle;<br/>else field-edit menu<br/>(untouched fields preserved)"]
+    Recover -- resubmit --> Create
+    Recover -- cancel --> CreateFail([STEP FAILED])
     CreateOk -- yes --> Link{FeatureId > 0?}
     Link -- yes --> InvokeLink["Invoke-AzDevOpsParentLink<br/>→ Add-AzDevOpsWorkItemRelation<br/>→ az boards work-item relation add"]
     InvokeLink --> Open
@@ -484,7 +486,7 @@ flowchart TD
     Email -- no --> Abort2([abort])
     Email -- yes --> Hier[Read-AzDevOpsHierarchyCache]
     Hier --> Title{Title param?}
-    Title -- no --> ReadTitle["Read-Host 'title'"]
+    Title -- no --> ReadTitle["Read-AzDevOpsTitle<br/>(caps at 255, warns near limit, offers truncate)"]
     Title -- yes --> Iter{Iteration param?}
     ReadTitle --> Iter
     Iter -- no --> PickIter[Read-AzDevOpsKindPick -Kind 'Iteration']
@@ -546,7 +548,7 @@ flowchart TD
     PickIter --> PickArea["Read-AzDevOpsKindPick -Kind 'Area'<br/>(skipped if -Area param)"]
     PickArea --> Loop
 
-    Loop[Story loop iteration N] --> ReadTitle["Read-Host 'Story title (Enter to finish batch)'"]
+    Loop[Story loop iteration N] --> ReadTitle["Read-AzDevOpsTitle<br/>'Story title (Enter to finish batch)'<br/>(caps at 255)"]
     ReadTitle --> EmptyTitle{empty?}
     EmptyTitle -- yes --> Summary
     EmptyTitle -- no --> ReadDesc["Read-AzDevOpsUserStoryDescription<br/>(As-a / I-want / so-that prompts)"]
@@ -943,6 +945,15 @@ graph LR
     InvCreate[Invoke-AzDevOpsWorkItemCreate]:::priv
     InvLink[Invoke-AzDevOpsParentLink]:::priv
 
+    %% Title cap + create-failure recovery
+    Title[Read-AzDevOpsTitle]:::priv
+    CrEdit[Read-AzDevOpsCreateFieldEdit]:::priv
+    TitleErr[Test-AzDevOpsTitleLengthError]:::priv
+    EditFields[Get-AzDevOpsEditableFields]:::priv
+    FieldEd[Invoke-AzDevOpsFieldEditor]:::priv
+    FieldPrev[Format-AzDevOpsFieldPreview]:::priv
+    KeepOr[Get-AzDevOpsEnteredOrKept]:::priv
+
     %% Batch-creator helpers (az-New-AzDevOpsFeatureStories)
     ReuseHint[Get-AzDevOpsReuseHint]:::priv
     BatchCont[Read-AzDevOpsBatchContinue]:::priv
@@ -1289,6 +1300,23 @@ graph LR
     CrLink --> InvCreate --> NewWI --> AzJson
     CrLink --> InvLink --> AddRel --> AzJson
     CrLink --> AddHier --> WriteFile
+
+    %% Title cap + create-failure recovery fan-out
+    NewS --> Title
+    NewF --> Title
+    NewTask --> Title
+    NewSB --> Title
+    CrLink --> CrEdit
+    CrEdit --> TitleErr
+    CrEdit --> EditFields
+    CrEdit --> FieldPrev
+    CrEdit --> FieldEd
+    CrEdit --> Title
+    FieldEd --> Title
+    FieldEd --> Pri
+    FieldEd --> Pts
+    FieldEd --> AC
+    FieldEd --> KeepOr
 
     %% Unplanned work sessions
     StartUW --> CGate

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -424,10 +424,26 @@ function Invoke-AzDevOpsCreateAndLink {
     Write-Host "Creating $ChildLabel..." -ForegroundColor Cyan
     $createResult = Invoke-AzDevOpsWorkItemCreate @CreateArgs
 
-    if (-not $createResult.Ok) {
+    # On failure, offer a fix-and-resubmit loop instead of discarding every
+    # captured field. Read-AzDevOpsCreateFieldEdit re-prompts the offending
+    # field (a title-length rejection routes straight to the capped title
+    # reader) and hands back the edited args; a cancel returns the same
+    # {Ok=$false} result callers already handle. Fields the user doesn't touch
+    # are resubmitted verbatim.
+    while (-not $createResult.Ok) {
         Write-Host "STEP FAILED: az boards work-item create" -ForegroundColor Red
         Write-Host "  $($createResult.Error)" -ForegroundColor Red
-        return [PSCustomObject]@{ Ok = $false; Id = 0; Url = $null }
+
+        $decision = Read-AzDevOpsCreateFieldEdit -CreateArgs $CreateArgs -ErrorText $createResult.Error
+        if (-not $decision.Retry) {
+            return [PSCustomObject]@{ Ok = $false; Id = 0; Url = $null }
+        }
+
+        $CreateArgs = $decision.CreateArgs
+
+        Write-Host ""
+        Write-Host "Resubmitting $ChildLabel..." -ForegroundColor Cyan
+        $createResult = Invoke-AzDevOpsWorkItemCreate @CreateArgs
     }
 
     $newId = $createResult.Id
@@ -542,7 +558,7 @@ function az-New-AzDevOpsUserStory {
     }
 
     if (-not $Title) {
-        $Title = Read-Host 'What is the title of the User Story?'
+        $Title = Read-AzDevOpsTitle -PromptText 'What is the title of the User Story?'
     }
     if (-not $Title) {
         Write-Host "Title is required - aborting." -ForegroundColor Red
@@ -645,7 +661,7 @@ function az-New-Task {
     }
 
     if (-not $Title) {
-        $Title = Read-Host 'What is the title of the Task?'
+        $Title = Read-AzDevOpsTitle -PromptText 'What is the title of the Task?'
     }
     if (-not $Title) {
         Write-Host "Title is required - aborting." -ForegroundColor Red
@@ -738,7 +754,7 @@ function az-New-AzDevOpsFeature {
     }
 
     if (-not $Title) {
-        $Title = Read-Host 'What is the title of the Feature?'
+        $Title = Read-AzDevOpsTitle -PromptText 'What is the title of the Feature?'
     }
     if (-not $Title) {
         Write-Host "Title is required - aborting." -ForegroundColor Red
@@ -837,7 +853,7 @@ function az-New-AzDevOpsEpic {
     }
 
     if (-not $Title) {
-        $Title = Read-Host 'What is the title of the Epic?'
+        $Title = Read-AzDevOpsTitle -PromptText 'What is the title of the Epic?'
     }
     if (-not $Title) {
         Write-Host "Title is required - aborting." -ForegroundColor Red
@@ -1001,7 +1017,7 @@ function az-New-AzDevOpsFeatureStories {
         Write-Host ""
         Write-Host ("--- Story #{0} ---" -f $iterationNumber) -ForegroundColor Cyan
 
-        $title = Read-Host 'Story title (Enter to finish batch)'
+        $title = Read-AzDevOpsTitle -PromptText 'Story title (Enter to finish batch)'
         if (-not $title) {
             break
         }

--- a/powcuts_by_cli/azdevops_create_pickers.ps1
+++ b/powcuts_by_cli/azdevops_create_pickers.ps1
@@ -679,6 +679,26 @@ function Format-AzDevOpsFieldPreview {
 }
 
 
+function Get-AzDevOpsEnteredOrKept {
+    # "Enter to keep current" resolver for the free-text edit-menu fields:
+    # returns the freshly entered value when the user typed something, else the
+    # value already on the create args. Collapses the identical empty-check that
+    # the Title and Description editors would otherwise each spell out inline.
+    param(
+        [object] $Entered,
+        [object] $Current
+    )
+
+    $value = if ($Entered) {
+        $Entered
+    } else {
+        $Current
+    }
+
+    return $value
+}
+
+
 function Invoke-AzDevOpsFieldEditor {
     # Re-prompts a single create field, reusing the same reader the creator used
     # originally so validation stays identical. Empty input keeps the current
@@ -692,12 +712,7 @@ function Invoke-AzDevOpsFieldEditor {
     switch ($Key) {
         'Title' {
             $entered = Read-AzDevOpsTitle -PromptText 'New title (Enter to keep current)'
-            $value = if ($entered) {
-                $entered
-            } else {
-                $Current
-            }
-
+            $value = Get-AzDevOpsEnteredOrKept -Entered $entered -Current $Current
             return $value
         }
 
@@ -718,12 +733,7 @@ function Invoke-AzDevOpsFieldEditor {
 
         'Description' {
             $entered = Read-Host 'New description (Enter to keep current)'
-            $value = if ($entered) {
-                $entered
-            } else {
-                $Current
-            }
-
+            $value = Get-AzDevOpsEnteredOrKept -Entered $entered -Current $Current
             return $value
         }
 

--- a/powcuts_by_cli/azdevops_create_pickers.ps1
+++ b/powcuts_by_cli/azdevops_create_pickers.ps1
@@ -8,6 +8,15 @@
 #
 # Loaded by powcuts_home.ps1. See azdevops_auth.ps1 for the master docstring.
 
+# Azure DevOps caps System.Title at 255 characters across the stock Agile /
+# Scrum / CMMI / Basic process templates. Read-AzDevOpsTitle enforces this cap
+# at entry so an over-length title is caught before the `az boards work-item
+# create` round-trip rather than after it. The warn threshold nudges the user
+# as they approach the limit.
+$script:AzDevOpsTitleMaxLength  = 255
+$script:AzDevOpsTitleWarnLength = 230
+
+
 function Get-AzDevOpsReuseHint {
     # Builds the " (Enter to reuse '<value>')" suffix used by batch-flow readers
     # that carry forward the prior loop's answer. Returns '' when Previous has
@@ -544,4 +553,262 @@ function Read-AzDevOpsKindPick {
 
     $picked = Read-AzDevOpsClassificationPick -Kind $Kind -Paths $paths -Default $envFallback
     return $picked
+}
+
+
+function Read-AzDevOpsTitle {
+    # Length-capped replacement for the raw `Read-Host '...title...'` every
+    # creator used to run. Rejects titles over $script:AzDevOpsTitleMaxLength
+    # and re-prompts, showing the running count and an "over by N" delta, and
+    # offers to auto-truncate to the cap with a preview of the result. A title
+    # within a warn band of the limit gets a heads-up but is accepted. Empty
+    # input returns '' unchanged so callers keep their existing semantics:
+    # az-New-AzDevOps* abort on an empty title, and the batch loop treats it as
+    # "finish". -PromptText carries the caller's exact wording so the UX reads
+    # identically to before.
+    param([string] $PromptText = 'What is the title?')
+
+    $max        = $script:AzDevOpsTitleMaxLength
+    $warnAt     = $script:AzDevOpsTitleWarnLength
+    $previewLen = 60
+    $ellipsis   = '...'
+
+    while ($true) {
+        $resp = Read-Host $PromptText
+        if (-not $resp) {
+            return ''
+        }
+
+        $length = $resp.Length
+        if ($length -le $max) {
+            if ($length -ge $warnAt) {
+                Write-Host ("  Heads up: title is {0}/{1} characters." -f $length, $max) -ForegroundColor Yellow
+            }
+
+            return $resp
+        }
+
+        $over = $length - $max
+        Write-Host ("  Title is {0}/{1} characters - over by {2}." -f $length, $max, $over) -ForegroundColor Yellow
+
+        $truncated = $resp.Substring(0, $max)
+        $preview = if ($truncated.Length -gt $previewLen) {
+            $truncated.Substring(0, $previewLen) + $ellipsis
+        } else {
+            $truncated
+        }
+
+        if (Read-AzDevOpsYesNo -Prompt "Truncate to $max chars? Result starts: '$preview'" -DefaultNo) {
+            return $truncated
+        }
+    }
+}
+
+
+function Test-AzDevOpsTitleLengthError {
+    # True when an `az boards work-item create` error text reads like a title
+    # length-limit rejection, so Read-AzDevOpsCreateFieldEdit can route straight
+    # to a title re-prompt. Azure DevOps phrases this several ways
+    # ("...Title... exceeds the maximum length", "LengthExceeded", etc.), so the
+    # test looks for a title mention alongside any length / exceed wording.
+    param([string] $ErrorText)
+
+    if (-not $ErrorText) {
+        return $false
+    }
+
+    $text = $ErrorText.ToLower()
+    $mentionsTitle  = $text -match 'title'
+    $mentionsLength = $text -match 'length|exceed|too long|maxlength|max length'
+
+    $isTitleLength = $mentionsTitle -and $mentionsLength
+    return $isTitleLength
+}
+
+
+function Get-AzDevOpsEditableFields {
+    # Returns the subset of the create-flow catalog whose keys are actually
+    # present in $CreateArgs, in a stable display order. Iteration / Area / Type
+    # / ExtraFields are intentionally excluded - they're picker- or
+    # schema-driven, not free-text fields the user re-enters to clear a create
+    # rejection.
+    param([Parameter(Mandatory)] [hashtable] $CreateArgs)
+
+    $catalog = @(
+        [PSCustomObject]@{ Key = 'Title';              Label = 'Title' }
+        [PSCustomObject]@{ Key = 'Priority';           Label = 'Priority' }
+        [PSCustomObject]@{ Key = 'StoryPoints';        Label = 'Story Points' }
+        [PSCustomObject]@{ Key = 'AcceptanceCriteria'; Label = 'Acceptance Criteria' }
+        [PSCustomObject]@{ Key = 'Description';        Label = 'Description' }
+        [PSCustomObject]@{ Key = 'Tags';               Label = 'Tags' }
+    )
+
+    $present = [System.Collections.Generic.List[object]]::new()
+    foreach ($entry in $catalog) {
+        if ($CreateArgs.ContainsKey($entry.Key)) {
+            $present.Add($entry)
+        }
+    }
+
+    return $present
+}
+
+
+function Format-AzDevOpsFieldPreview {
+    # Renders a create-arg value for the edit menu: joins a tag array, collapses
+    # an empty / null value to '(none)', and truncates long text via the shared
+    # 80-char title truncator so the menu stays one line per field.
+    param([object] $Value)
+
+    if ($null -eq $Value) {
+        return '(none)'
+    }
+
+    $text = if ($Value -is [array]) {
+        ($Value | Where-Object { $_ } | ForEach-Object { [string]$_ }) -join '; '
+    } else {
+        [string]$Value
+    }
+
+    if (-not $text) {
+        return '(none)'
+    }
+
+    $preview = Format-AzDevOpsTruncatedTitle -Title $text
+    return $preview
+}
+
+
+function Invoke-AzDevOpsFieldEditor {
+    # Re-prompts a single create field, reusing the same reader the creator used
+    # originally so validation stays identical. Empty input keeps the current
+    # value for the free-text fields (Title / Description / Tags); Priority and
+    # Story Points flow the current value through -Previous so Enter reuses it.
+    param(
+        [Parameter(Mandatory)] [string] $Key,
+        [object] $Current
+    )
+
+    switch ($Key) {
+        'Title' {
+            $entered = Read-AzDevOpsTitle -PromptText 'New title (Enter to keep current)'
+            $value = if ($entered) {
+                $entered
+            } else {
+                $Current
+            }
+
+            return $value
+        }
+
+        'Priority' {
+            $value = Read-AzDevOpsPriority -Previous ([int]$Current)
+            return $value
+        }
+
+        'StoryPoints' {
+            $value = Read-AzDevOpsStoryPoints -Previous ([int]$Current)
+            return $value
+        }
+
+        'AcceptanceCriteria' {
+            $value = Read-AzDevOpsAcceptanceCriteria
+            return $value
+        }
+
+        'Description' {
+            $entered = Read-Host 'New description (Enter to keep current)'
+            $value = if ($entered) {
+                $entered
+            } else {
+                $Current
+            }
+
+            return $value
+        }
+
+        'Tags' {
+            $entered = Read-Host 'New tags (semicolon-separated, Enter to keep current)'
+            $value = if ($entered) {
+                $parts = $entered -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+                ,$parts
+            } else {
+                $Current
+            }
+
+            return $value
+        }
+
+        default {
+            return $Current
+        }
+    }
+}
+
+
+function Read-AzDevOpsCreateFieldEdit {
+    # Failure-recovery menu for Invoke-AzDevOpsCreateAndLink. Given the
+    # CreateArgs of a create that just failed, lets the user fix one or more
+    # fields and resubmit with everything else preserved verbatim, or cancel.
+    # Works on a copy of CreateArgs so a cancel leaves the caller's hashtable
+    # untouched. When the error reads like a title-length rejection the title
+    # reader runs once up front (the targeted path for the common case); the
+    # menu then still offers further edits, resubmit, or cancel.
+    #
+    # Returns { Retry = <bool>; CreateArgs = <hashtable> }: on Retry the caller
+    # re-runs the create with the returned args; on cancel the caller returns
+    # its standard failure result exactly as before this recovery step existed.
+    param(
+        [Parameter(Mandatory)] [hashtable] $CreateArgs,
+        [string] $ErrorText
+    )
+
+    $edited = @{}
+    foreach ($key in $CreateArgs.Keys) {
+        $edited[$key] = $CreateArgs[$key]
+    }
+
+    if (Test-AzDevOpsTitleLengthError -ErrorText $ErrorText) {
+        Write-Host ""
+        Write-Host "That title exceeds Azure DevOps' $($script:AzDevOpsTitleMaxLength)-character limit." -ForegroundColor Yellow
+        $fixedTitle = Read-AzDevOpsTitle -PromptText 'New title'
+        if ($fixedTitle) {
+            $edited['Title'] = $fixedTitle
+        }
+    }
+
+    $fields = Get-AzDevOpsEditableFields -CreateArgs $edited
+
+    while ($true) {
+        Write-Host ""
+        Write-Host "Edit a field and resubmit, or cancel:" -ForegroundColor Cyan
+        for ($i = 0; $i -lt $fields.Count; $i++) {
+            $field   = $fields[$i]
+            $preview = Format-AzDevOpsFieldPreview -Value $edited[$field.Key]
+            Write-Host ("  {0}. {1,-20}: {2}" -f ($i + 1), $field.Label, $preview)
+        }
+        Write-Host "  r. Resubmit with the values above"
+        Write-Host "  c. Cancel (abort create)"
+
+        $resp    = Read-Host 'Choose'
+        $trimmed = "$resp".Trim().ToLower()
+
+        if ($trimmed -eq 'c') {
+            return [PSCustomObject]@{ Retry = $false; CreateArgs = $edited }
+        }
+
+        if ($trimmed -eq 'r') {
+            return [PSCustomObject]@{ Retry = $true; CreateArgs = $edited }
+        }
+
+        $idx = 0
+        if (-not [int]::TryParse($trimmed, [ref]$idx) -or $idx -lt 1 -or $idx -gt $fields.Count) {
+            Write-Host "  Enter a field number, 'r' to resubmit, or 'c' to cancel." -ForegroundColor Yellow
+            continue
+        }
+
+        $chosen   = $fields[$idx - 1]
+        $newValue = Invoke-AzDevOpsFieldEditor -Key $chosen.Key -Current $edited[$chosen.Key]
+        $edited[$chosen.Key] = $newValue
+    }
 }


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #173 |
| [Changes](#changes) | ✅ 3 files |
| [Shell parity](#shell-parity) | PowerShell-only |
| [Test Plan](#test-plan) | ✅ 4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4928572835) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4928595760) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4928585474) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4928588731) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4928617750) |
| 📚 Docs Check | ✅ CURRENT — no new files/CLIs; both changed files already dot-sourced |
| 📐 AzDO Diagrams Check | ✅ SYNCED — 7 new fns added to Diagrams 7/8/9/12 |
<!-- toc:end -->
<!-- pr-diagram:start -->
## How it works

Every `az-New-AzDevOps*` creator now reads its title through `Read-AzDevOpsTitle` (caps at 255, warns near the limit, offers truncate), then routes the create through `Invoke-AzDevOpsCreateAndLink`. On failure, instead of discarding the entry, `Read-AzDevOpsCreateFieldEdit` classifies the error — a title-length rejection re-prompts the capped title reader; anything else opens a field-edit menu — and resubmits with the untouched fields intact, or cancels back to the original `Ok=$false` result.

```mermaid
flowchart TD
    Creators(["az-New-AzDevOps* creators<br/>UserStory / Task / Feature / Epic / batch"]):::pub
    Title["Read-AzDevOpsTitle<br/>cap 255 · warn near limit · offer truncate"]:::priv
    CrLink[Invoke-AzDevOpsCreateAndLink]:::priv
    Create["az boards work-item create"]:::io
    Ok{Ok?}
    Done([return new id]):::pub
    Recover[Read-AzDevOpsCreateFieldEdit]:::priv
    TitleErr{Test-AzDevOpsTitleLengthError}
    Menu["Get-AzDevOpsEditableFields<br/>+ Format-AzDevOpsFieldPreview"]:::priv
    FieldEd["Invoke-AzDevOpsFieldEditor<br/>→ Get-AzDevOpsEnteredOrKept"]:::priv
    Cancel([STEP FAILED · Ok=false]):::io

    Creators --> Title --> CrLink
    CrLink --> Create --> Ok
    Ok -- yes --> Done
    Ok -- no --> Recover
    Recover --> TitleErr
    TitleErr -- title too long --> Title
    TitleErr -- other error --> Menu
    Menu --> FieldEd
    FieldEd -.edit more.-> Recover
    Recover -- resubmit --> Create
    Recover -- cancel --> Cancel

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
When an Azure DevOps work-item create failed at `az boards work-item create` — most often a "title exceeds the maximum length" rejection — the flow printed `STEP FAILED` and returned, **discarding every field the user had just typed**. There was also no input-side title guard, so an over-cap title only failed *after* the round-trip to `az`.

This PR adds (1) a length-capping title reader and (2) a fix-and-resubmit loop that preserves captured fields.

## Issue
Closes #173

## Changes
**`powcuts_by_cli/azdevops_create_pickers.ps1`**
- `$script:AzDevOpsTitleMaxLength` (255) + `$script:AzDevOpsTitleWarnLength` (230) named constants.
- `Read-AzDevOpsTitle` — caps `System.Title` at entry, warns near the limit, offers auto-truncate with a preview; empty input returns `''` so existing abort / end-batch semantics are unchanged.
- `Read-AzDevOpsCreateFieldEdit` — failure-recovery menu; a detected title-length error routes straight to the capped title reader, any other error opens a field-edit menu over the present `CreateArgs`. Operates on a clone so cancel is side-effect-free.
- Private helpers: `Test-AzDevOpsTitleLengthError`, `Get-AzDevOpsEditableFields`, `Format-AzDevOpsFieldPreview`, `Invoke-AzDevOpsFieldEditor`, `Get-AzDevOpsEnteredOrKept`.

**`powcuts_by_cli/azdevops_create.ps1`**
- `Invoke-AzDevOpsWorkItemCreate` failure now enters a resubmit loop in `Invoke-AzDevOpsCreateAndLink`: fix a field → resubmit with everything else verbatim; cancel returns the same `{Ok=$false}` result callers already handle.
- Raw title `Read-Host` replaced with `Read-AzDevOpsTitle` in `az-New-AzDevOpsUserStory`, `az-New-Task`, `az-New-AzDevOpsFeature`, `az-New-AzDevOpsEpic`, and the `az-New-AzDevOpsFeatureStories` batch loop.

**`docs/azure-devops-diagrams.md`**
- Diagram 7 create flow: title via `Read-AzDevOpsTitle`, create-failure branch loops through `Read-AzDevOpsCreateFieldEdit`; Diagrams 8/9 title node relabelled; Diagram 12 dependency map gains the seven new functions + edges.

The batch creator benefits automatically (same `Invoke-AzDevOpsCreateAndLink` path): a story that fails and is then fixed counts as created, not failed.

## Shell parity
PowerShell-only — the `az boards work-item create` flow has no bash counterpart in `bashcuts_by_cli/`.

## Test Plan
- [ ] Fresh PowerShell terminal: `az-New-AzDevOpsEpic` → paste a 300-char title → expect `Title is 300/255 characters - over by 45.` and a `Truncate to 255 chars?` prompt (decline re-prompts; accept proceeds truncated).
- [ ] Enter a ~240-char title → expect the `Heads up: title is 240/255 characters.` note, then accepted.
- [ ] Force a create failure → expect `STEP FAILED` then the `Edit a field and resubmit, or cancel:` menu; fix the flagged field, press `r`, confirm the item is created **without** re-entering description/priority/AC; press `c` to confirm it aborts unchanged from prior behavior.
- [ ] `pwsh -NoProfile` parse of both changed `.ps1` files (pwsh unavailable in the authoring env — manual review only).