### PR TITLE
Apply code-review DRY fix to az-Find-AzDevOpsItem (follow-up to #175)

### DIFF
--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -1134,7 +1134,7 @@ graph LR
 
     FindItem --> ReadH
     FindItem --> Stale
-    FindItem --> Closed
+    FindItem --> SelAct
     FindItem --> FuzzyMatch --> FuzzyScore
     FindItem --> TitleCol
     FindItem --> GridAvail

--- a/powcuts_by_cli/azdevops_find.ps1
+++ b/powcuts_by_cli/azdevops_find.ps1
@@ -317,12 +317,11 @@ function az-Find-AzDevOpsItem {
 
     Write-AzDevOpsStaleBanner
 
-    $closedStates = Get-AzDevOpsClosedStates
     $pool = if ($IncludeClosed) {
         $items
     }
     else {
-        $items | Where-Object { $_.State -notin $closedStates }
+        Select-AzDevOpsActiveItems -Items $items
     }
 
     if ($Type) {
@@ -381,4 +380,3 @@ function az-Find-AzDevOpsItem {
     $selected = Show-AzDevOpsRows -Rows $rows -Title $titleBar -PassThru
     Invoke-AzDevOpsRowAction -Selected $selected
 }
-


### PR DESCRIPTION
## Summary

Follow-up to the now-merged **#175** (`az-Find-AzDevOpsItem` flat fuzzy work-item search). #175 was merged at its first commit, before the quad code-review fixes landed — this PR carries that improvement to `main`.

The clean-code reviewer raised a MEDIUM: `az-Find-AzDevOpsItem` re-inlined the closed-states filter (`Get-AzDevOpsClosedStates` + `Where-Object { $_.State -notin $closedStates }`) instead of reusing the canonical `Select-AzDevOpsActiveItems` helper already used at 6 view callsites.

## Changes

- **`powcuts_by_cli/azdevops_find.ps1`** — replace the inline open-items filter in `az-Find-AzDevOpsItem` with `Select-AzDevOpsActiveItems -Items $items` (DRY); normalize the trailing newline at EOF.
- **`docs/azure-devops-diagrams.md`** — update the helper-dependency edge to match: `FindItem --> SelAct` (was `--> Closed`).

No behavior change — `Select-AzDevOpsActiveItems` with no `-State` applies the identical closed-states exclusion. The `-IncludeClosed` branch is unchanged.

## Test Plan

- [ ] Parse `azdevops_find.ps1`: `[System.Management.Automation.Language.Parser]::ParseFile(...)` returns no errors
- [ ] `az-Find-AzDevOpsItem login` — open items only (closed excluded), same as before
- [ ] `az-Find-AzDevOpsItem login -IncludeClosed` — closed items now included
- [ ] `az-help` still lists `az-Find-AzDevOpsItem` under DailyRead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1p2R9Gs6kLZrLeWZ6E5Ye)_