### PR TITLE
Add PowerShell Outlook agenda module (`ol-` COM helpers) — show today's calendar + tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,16 @@ With those seven steps done, head to [Azure DevOps work-item shortcuts](#azure-d
 
 ![image](https://github.com/jdschleicher/bashcuts/assets/3968818/87f2fefe-f81f-42a8-b6fc-100e2292703b)
 
+## Outlook day agenda (`ol-`, PowerShell + Windows)
+
+If you run desktop Outlook on Windows, the `ol-` shortcuts (in `powcuts_by_cli/outlook_agenda.ps1`) show your day from the terminal — no alt-tab into Outlook:
+
+- `ol-Show-OutlookDay` (alias `ol-day`) — today's meetings, then the open tasks you're expected to work on (due today or overdue)
+- `ol-Get-OutlookAgenda` / `ol-Get-OutlookTasks` — the same data as objects you can pipe/filter (`ol-Get-OutlookAgenda | Format-List`)
+- `ol-Show-OutlookAgenda` / `ol-Show-OutlookTasks` — the individual tables
+
+These read the Calendar and Tasks folders via Outlook COM automation, so they require **Windows + the desktop Outlook client** (no cloud/Graph auth). On macOS/Linux — or if Outlook can't be reached — every command prints a short hint and exits cleanly.
+
 ## Opening VS Code Snipppets
 
 When using VS Code it is HIGHLY recommend to setup VSCode settings sync: https://code.visualstudio.com/docs/editor/settings-sync

--- a/powcuts_by_cli/outlook_agenda.ps1
+++ b/powcuts_by_cli/outlook_agenda.ps1
@@ -1,0 +1,336 @@
+# ============================================================================
+# Outlook — Day agenda + tasks (desktop COM)
+# ============================================================================
+# Terminal-native "what does today look like?" for Windows desktop Outlook.
+# Reads the default Calendar and Tasks folders through Outlook COM automation
+# (New-Object -ComObject Outlook.Application) — no cloud / Graph auth.
+#
+# Public surface (tab-tab on `ol-`):
+#   ol-Get-OutlookAgenda   -> today's meetings as objects
+#   ol-Show-OutlookAgenda  -> today's meetings as a table
+#   ol-Get-OutlookTasks    -> today's / overdue open tasks as objects
+#   ol-Show-OutlookTasks   -> today's / overdue open tasks as a table
+#   ol-Show-OutlookDay     -> composed day view (agenda + tasks); alias `ol-day`
+#
+# Windows + desktop Outlook only. On any other platform (or when the COM
+# object can't be created) every function fails soft with a yellow hint and
+# never throws. `-Date` is today by default but flows through the Get
+# functions so a future date/range surface is a non-breaking add.
+#
+# Loaded by powcuts_home.ps1.
+
+# --- Constants --------------------------------------------------------------
+# Outlook default-folder ids (OlDefaultFolders enum).
+$script:OutlookFolderCalendar = 9
+$script:OutlookFolderTasks    = 13
+
+# Date format Outlook's Items.Restrict filter expects for [Start] / [DueDate].
+$script:OutlookRestrictDateFormat = 'MM/dd/yyyy hh:mm tt'
+
+# Outlook stores "no due date" as a sentinel far in the future; anything at or
+# beyond this year is treated as unset.
+$script:OutlookNoDateYear = 4000
+
+$script:OutlookIconCalendar = [char]::ConvertFromUtf32(0x1F4C5)   # calendar
+$script:OutlookIconTasks    = [char]::ConvertFromUtf32(0x1F5D2)   # spiral notepad
+$script:OutlookIconParty    = [char]::ConvertFromUtf32(0x1F389)   # party popper
+$script:OutlookIconCheck    = [char]::ConvertFromUtf32(0x2705)    # check mark
+
+
+function Get-OutlookComApplication {
+    # Private. Single point that enforces the Windows + desktop-Outlook
+    # requirement and hands back a live Outlook.Application COM object.
+    # Returns $null (after a one-line yellow hint) when the platform is wrong
+    # or Outlook can't be reached, so every caller shares one guard instead of
+    # repeating the platform branch. Unapproved verb is fine — not user-facing.
+    $isWindows = ($IsWindows -or ($env:OS -eq 'Windows_NT'))
+
+    if (-not $isWindows) {
+        Write-Host "Outlook COM automation requires Windows desktop Outlook." -ForegroundColor Yellow
+        return $null
+    }
+
+    try {
+        $application = New-Object -ComObject Outlook.Application
+        return $application
+    }
+    catch {
+        Write-Host "Could not reach Outlook. Is the desktop client installed?" -ForegroundColor Yellow
+        return $null
+    }
+}
+
+
+function ConvertFrom-OutlookResponseStatus {
+    # Private. Maps an OlResponseStatus int to a readable string.
+    param([int] $Status)
+
+    switch ($Status) {
+        1 {
+            return 'Organizer'
+        }
+
+        2 {
+            return 'Tentative'
+        }
+
+        3 {
+            return 'Accepted'
+        }
+
+        4 {
+            return 'Declined'
+        }
+
+        5 {
+            return 'NotResponded'
+        }
+
+        default {
+            return 'None'
+        }
+    }
+}
+
+
+function ConvertFrom-OutlookTaskStatus {
+    # Private. Maps an OlTaskStatus int to a readable string.
+    param([int] $Status)
+
+    switch ($Status) {
+        1 {
+            return 'InProgress'
+        }
+
+        2 {
+            return 'Complete'
+        }
+
+        3 {
+            return 'Waiting'
+        }
+
+        4 {
+            return 'Deferred'
+        }
+
+        default {
+            return 'NotStarted'
+        }
+    }
+}
+
+
+function ConvertFrom-OutlookImportance {
+    # Private. Maps an OlImportance int to a readable string.
+    param([int] $Importance)
+
+    switch ($Importance) {
+        2 {
+            return 'High'
+        }
+
+        0 {
+            return 'Low'
+        }
+
+        default {
+            return 'Normal'
+        }
+    }
+}
+
+
+function ol-Get-OutlookAgenda {
+    # Today's calendar events (recurrences expanded) as objects. Emits data
+    # only — formatting lives in ol-Show-OutlookAgenda.
+    [CmdletBinding()]
+    param(
+        [datetime] $Date = (Get-Date)
+    )
+
+    $application = Get-OutlookComApplication
+    if ($null -eq $application) {
+        return $null
+    }
+
+    $namespace = $application.GetNamespace('MAPI')
+    $calendar = $namespace.GetDefaultFolder($script:OutlookFolderCalendar)
+
+    $items = $calendar.Items
+    $items.IncludeRecurrences = $true
+    $items.Sort('[Start]')
+
+    $dayStart = $Date.Date
+    $dayEnd = $Date.Date.AddDays(1).AddSeconds(-1)
+
+    $startText = $dayStart.ToString($script:OutlookRestrictDateFormat)
+    $endText = $dayEnd.ToString($script:OutlookRestrictDateFormat)
+    $filter = "[Start] >= '$startText' AND [End] <= '$endText'"
+
+    $restricted = $items.Restrict($filter)
+
+    $events = New-Object System.Collections.Generic.List[object]
+
+    foreach ($appointment in $restricted) {
+        $responseText = ConvertFrom-OutlookResponseStatus -Status ([int]$appointment.ResponseStatus)
+
+        $row = [PSCustomObject]@{
+            Start          = $appointment.Start
+            End            = $appointment.End
+            Subject        = $appointment.Subject
+            Location       = $appointment.Location
+            Organizer      = $appointment.Organizer
+            IsAllDay       = [bool]$appointment.AllDayEvent
+            ResponseStatus = $responseText
+        }
+
+        $events.Add($row)
+    }
+
+    return $events
+}
+
+
+function ol-Show-OutlookAgenda {
+    # Renders today's meetings as a time-sorted table.
+    [CmdletBinding()]
+    param(
+        [datetime] $Date = (Get-Date)
+    )
+
+    $events = ol-Get-OutlookAgenda -Date $Date
+
+    if ($null -eq $events) {
+        return
+    }
+
+    if ($events.Count -eq 0) {
+        Write-Host "No meetings today $script:OutlookIconParty"
+        return
+    }
+
+    $events |
+        Sort-Object Start |
+        Select-Object `
+            @{ Name = 'Time';     Expression = { $_.Start.ToString('HH:mm') } },
+            @{ Name = 'End';      Expression = { $_.End.ToString('HH:mm') } },
+            Subject,
+            Location,
+            Organizer,
+            ResponseStatus |
+        Format-Table -AutoSize |
+        Out-Host
+}
+
+
+function ol-Get-OutlookTasks {
+    # Open tasks that are due today or overdue (the "expected to work on"
+    # items). Completed tasks are excluded. Emits data only.
+    [CmdletBinding()]
+    param(
+        [datetime] $Date = (Get-Date)
+    )
+
+    $application = Get-OutlookComApplication
+    if ($null -eq $application) {
+        return $null
+    }
+
+    $namespace = $application.GetNamespace('MAPI')
+    $taskFolder = $namespace.GetDefaultFolder($script:OutlookFolderTasks)
+
+    $dayEnd = $Date.Date
+
+    $tasks = New-Object System.Collections.Generic.List[object]
+
+    foreach ($task in $taskFolder.Items) {
+        if ([bool]$task.Complete) {
+            continue
+        }
+
+        $dueDate = $task.DueDate
+        if ($null -eq $dueDate -or $dueDate.Year -ge $script:OutlookNoDateYear) {
+            continue
+        }
+
+        if ($dueDate.Date -gt $dayEnd) {
+            continue
+        }
+
+        $statusText = ConvertFrom-OutlookTaskStatus -Status ([int]$task.Status)
+        $importanceText = ConvertFrom-OutlookImportance -Importance ([int]$task.Importance)
+
+        $row = [PSCustomObject]@{
+            Subject         = $task.Subject
+            DueDate         = $dueDate
+            Status          = $statusText
+            Importance      = $importanceText
+            PercentComplete = [int]$task.PercentComplete
+        }
+
+        $tasks.Add($row)
+    }
+
+    return $tasks
+}
+
+
+function ol-Show-OutlookTasks {
+    # Renders today's / overdue open tasks as a table.
+    [CmdletBinding()]
+    param(
+        [datetime] $Date = (Get-Date)
+    )
+
+    $tasks = ol-Get-OutlookTasks -Date $Date
+
+    if ($null -eq $tasks) {
+        return
+    }
+
+    if ($tasks.Count -eq 0) {
+        Write-Host "No tasks due today $script:OutlookIconCheck"
+        return
+    }
+
+    $tasks |
+        Sort-Object DueDate |
+        Select-Object `
+            Subject,
+            @{ Name = 'Due'; Expression = { $_.DueDate.ToString('MM/dd') } },
+            Status,
+            Importance,
+            PercentComplete |
+        Format-Table -AutoSize |
+        Out-Host
+}
+
+
+function ol-Show-OutlookDay {
+    # Composed day view: today's meetings, then the tasks to work on. Both
+    # sections delegate to their own ol-Get-/ol-Show- pair.
+    [CmdletBinding()]
+    param(
+        [datetime] $Date = (Get-Date)
+    )
+
+    $application = Get-OutlookComApplication
+    if ($null -eq $application) {
+        return
+    }
+
+    $header = $Date.ToString('dddd, MMMM d')
+    Write-Host ""
+    Write-Host "$script:OutlookIconCalendar $header" -ForegroundColor Cyan
+
+    ol-Show-OutlookAgenda -Date $Date
+
+    Write-Host ""
+    Write-Host "$script:OutlookIconTasks To work on today" -ForegroundColor Cyan
+
+    ol-Show-OutlookTasks -Date $Date
+}
+
+
+Set-Alias -Name ol-day -Value ol-Show-OutlookDay

--- a/powcuts_by_cli/outlook_agenda.ps1
+++ b/powcuts_by_cli/outlook_agenda.ps1
@@ -27,6 +27,9 @@ $script:OutlookFolderTasks    = 13
 # Date format Outlook's Items.Restrict filter expects for [Start] / [DueDate].
 $script:OutlookRestrictDateFormat = 'MM/dd/yyyy hh:mm tt'
 
+# MAPI is the messaging namespace every Outlook default folder hangs off.
+$script:OutlookMapiNamespace = 'MAPI'
+
 # Outlook stores "no due date" as a sentinel far in the future; anything at or
 # beyond this year is treated as unset.
 $script:OutlookNoDateYear = 4000
@@ -56,6 +59,33 @@ function Get-OutlookComApplication {
     }
     catch {
         Write-Host "Could not reach Outlook. Is the desktop client installed?" -ForegroundColor Yellow
+        return $null
+    }
+}
+
+
+function Get-OutlookDefaultFolder {
+    # Private. Resolves an Outlook default folder (Calendar, Tasks, ...) through
+    # the shared platform guard, wrapping the COM navigation so a transient
+    # fault (Outlook busy, a MAPI security prompt) fails soft as $null instead
+    # of throwing. Centralizes the acquire -> namespace -> folder sequence the
+    # ol-Get- functions would otherwise repeat.
+    param(
+        [Parameter(Mandatory)] [int] $FolderId
+    )
+
+    $application = Get-OutlookComApplication
+    if ($null -eq $application) {
+        return $null
+    }
+
+    try {
+        $namespace = $application.GetNamespace($script:OutlookMapiNamespace)
+        $folder = $namespace.GetDefaultFolder($FolderId)
+        return $folder
+    }
+    catch {
+        Write-Host "Could not read the Outlook folder. Is Outlook busy or blocked by a dialog?" -ForegroundColor Yellow
         return $null
     }
 }
@@ -149,13 +179,10 @@ function ol-Get-OutlookAgenda {
         [datetime] $Date = (Get-Date)
     )
 
-    $application = Get-OutlookComApplication
-    if ($null -eq $application) {
+    $calendar = Get-OutlookDefaultFolder -FolderId $script:OutlookFolderCalendar
+    if ($null -eq $calendar) {
         return $null
     }
-
-    $namespace = $application.GetNamespace('MAPI')
-    $calendar = $namespace.GetDefaultFolder($script:OutlookFolderCalendar)
 
     $items = $calendar.Items
     $items.IncludeRecurrences = $true
@@ -166,7 +193,11 @@ function ol-Get-OutlookAgenda {
 
     $startText = $dayStart.ToString($script:OutlookRestrictDateFormat)
     $endText = $dayEnd.ToString($script:OutlookRestrictDateFormat)
-    $filter = "[Start] >= '$startText' AND [End] <= '$endText'"
+
+    # Bound the window on [Start], not [End]: with IncludeRecurrences the
+    # supported day-range pattern filters on Start, and an all-day event ends at
+    # next-day midnight — an [End] bound would silently drop it.
+    $filter = "[Start] >= '$startText' AND [Start] <= '$endText'"
 
     $restricted = $items.Restrict($filter)
 
@@ -188,7 +219,9 @@ function ol-Get-OutlookAgenda {
         $events.Add($row)
     }
 
-    return $events
+    # Comma-wrap so an empty list survives the return as an empty collection
+    # (a bare `return $events` enumerates to $null, hiding the empty-day path).
+    return ,$events
 }
 
 
@@ -232,13 +265,10 @@ function ol-Get-OutlookTasks {
         [datetime] $Date = (Get-Date)
     )
 
-    $application = Get-OutlookComApplication
-    if ($null -eq $application) {
+    $taskFolder = Get-OutlookDefaultFolder -FolderId $script:OutlookFolderTasks
+    if ($null -eq $taskFolder) {
         return $null
     }
-
-    $namespace = $application.GetNamespace('MAPI')
-    $taskFolder = $namespace.GetDefaultFolder($script:OutlookFolderTasks)
 
     $dayEnd = $Date.Date
 
@@ -250,7 +280,7 @@ function ol-Get-OutlookTasks {
         }
 
         $dueDate = $task.DueDate
-        if ($null -eq $dueDate -or $dueDate.Year -ge $script:OutlookNoDateYear) {
+        if ($dueDate.Year -ge $script:OutlookNoDateYear) {
             continue
         }
 
@@ -272,7 +302,8 @@ function ol-Get-OutlookTasks {
         $tasks.Add($row)
     }
 
-    return $tasks
+    # Comma-wrap so an empty list survives the return (see ol-Get-OutlookAgenda).
+    return ,$tasks
 }
 
 

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -154,6 +154,13 @@ if ($azdevops_help -ne $NULL) {
     Write-Host "no azdevops_help.ps1"
 }
 
+$outlook_agenda = Get-Content "$path_to_bashcuts\powcuts_by_cli\outlook_agenda.ps1"
+if ($outlook_agenda -ne $NULL) {
+ . "$path_to_bashcuts\powcuts_by_cli\outlook_agenda.ps1"
+} else {
+    Write-Host "no outlook_agenda.ps1"
+}
+
 # On shell open: silently refresh the Azure DevOps cache in the background when
 # it's stale. Invoked here (after every azdevops_*.ps1 file is dot-sourced) so
 # Get-AzDevOpsActiveProjectSlug is defined and the staleness check targets the


### PR DESCRIPTION
## Navigation

- [Summary](#summary) · [Flow](#flow) · [Changes](#changes) · [Design notes](#design-notes) · [Regression guard](#regression-guard) · [Test Plan](#test-plan)
- 📄 Reports:
  - [Code Review + Criteria Check — round 1](https://github.com/jdschleicher/bashcuts/pull/181#issuecomment-4970281925) — ✅ review resolved · ✅ criteria met (pwsh parse deferred)
  - [Code Review — round 2 (delta)](https://github.com/jdschleicher/bashcuts/pull/181#issuecomment-4971044397) — ✅ `$env:` false-positive fixed

## Summary

Adds a PowerShell-only module that shows your day from the terminal by reading desktop Outlook over COM automation — meetings and the tasks you're expected to work on, no alt-tab into the Outlook client.

Closes #179
Closes #182

## Flow

```mermaid
flowchart TD
    Day["ol-Show-OutlookDay<br/>(alias ol-day)"] --> ShowA["ol-Show-OutlookAgenda"]
    Day --> ShowT["ol-Show-OutlookTasks"]

    ShowA --> GetA["ol-Get-OutlookAgenda"]
    ShowT --> GetT["ol-Get-OutlookTasks"]

    GetA --> Folder["Get-OutlookDefaultFolder<br/>(private)"]
    GetT --> Folder
    Folder --> Guard["Get-OutlookComApplication<br/>(Windows + Outlook guard, fails soft)"]
    Guard --> COM(["Outlook.Application (COM / MAPI)"])

    COM --> Cal[["Calendar folder (9)<br/>Restrict on [Start], IncludeRecurrences"]]
    COM --> Tasks[["Tasks folder (13)<br/>due-today / overdue, open only"]]

    GetA -. "PSCustomObject rows" .-> ShowA
    GetT -. "PSCustomObject rows" .-> ShowT
    ShowA -. "Format-Table" .-> Out([terminal])
    ShowT -. "Format-Table" .-> Out
```

## Changes

| File | Change |
|------|--------|
| `powcuts_by_cli/outlook_agenda.ps1` | **New** — Outlook COM day module |
| `powcuts_home.ps1` | Dot-source wire-up (after `azdevops_help`, before the background-sync trailer) |
| `README.md` | "Outlook day agenda" subsection under *How to use bashcuts* |
| `tests/no_readonly_automatic_assignments.Tests.ps1` | **New** — jidoka regression guard (see below) |

### Public surface (tab-tab on `ol-`)

- `ol-Show-OutlookDay` (alias `ol-day`) — composed view: today's meetings, then open tasks due-today-or-overdue
- `ol-Get-OutlookAgenda` / `ol-Show-OutlookAgenda` — today's calendar events (recurrences expanded)
- `ol-Get-OutlookTasks` / `ol-Show-OutlookTasks` — open tasks due today or overdue (completed excluded)
- Private: `Get-OutlookComApplication` (Windows + desktop-Outlook guard, fails soft — never throws), `Get-OutlookDefaultFolder` (folder resolver), response/status/importance converters

## Design notes

- `Get-` functions emit `[PSCustomObject]` rows; `Show-` functions render the tables (mirrors the repo's `az-Get-`/`az-Show-` split)
- **Windows + desktop Outlook only.** On macOS/Linux or when Outlook is unreachable, every command prints a one-line hint and returns cleanly
- Read-only; no cloud/Graph auth; no source-time side effects beyond constant + alias definitions

## Regression guard

`tests/no_readonly_automatic_assignments.Tests.ps1` is a **jidoka safety net** for the class of bug in #182: a case-insensitive local (`$isWindows`) that silently aliased the read-only automatic `$IsWindows` and threw at runtime. The Pester spec walks every committed `.ps1` via the PowerShell AST and fails if any assignment targets a read-only / constant automatic variable (`$IsWindows`, `$IsLinux`, `$IsMacOS`, `$true`, `$Host`, `$PID`, …). `$null` and drive-qualified variables (`$env:HOME`) are excluded so only genuine read-only overwrites are flagged; matching is case-insensitive so the exact footgun is caught regardless of casing. It's an **opt-in** developer check (run via `t-run-file` / `Invoke-Pester`) — not wired into profile load, honoring the repo's no-startup-gate convention.

## Test Plan

- [ ] `pwsh` parse (deferred — pwsh not available in the authoring environment): `[System.Management.Automation.Language.Parser]::ParseFile("$path_to_bashcuts\powcuts_by_cli\outlook_agenda.ps1", [ref]$null, [ref]$null)`
- [ ] Fresh **Windows** pwsh terminal with Outlook running: `ol-day` shows meetings + tasks; `ol-Get-OutlookAgenda | Format-List` shows object shape; `ol-Get-OutlookTasks | Format-Table` lists due/overdue
- [ ] Regression (#182): `ol-day` runs without `Cannot overwrite variable IsWindows`
- [ ] Jidoka guard is green: `Invoke-Pester -Output Detailed .\tests\no_readonly_automatic_assignments.Tests.ps1`
- [ ] Verify a **meeting-free day** prints `No meetings today 🎉` (the empty-day path fixed during review)
- [ ] **macOS/Linux** pwsh: `ol-*` prints the Windows-only hint and exits cleanly (no exception)
- [ ] `grep outlook_agenda powcuts_home.ps1` confirms the dot-source wire-up

## Shell Parity

PowerShell-only by design — Outlook COM automation has no bash equivalent (per #179 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjcNBomyYNt7rfnorhdQwe