### PR TITLE
Fix `$IsWindows` read-only crash in Outlook module + add jidoka guard

### DIFF
--- a/powcuts_by_cli/outlook_agenda.ps1
+++ b/powcuts_by_cli/outlook_agenda.ps1
@@ -46,9 +46,9 @@ function Get-OutlookComApplication {
     # Returns $null (after a one-line yellow hint) when the platform is wrong
     # or Outlook can't be reached, so every caller shares one guard instead of
     # repeating the platform branch. Unapproved verb is fine — not user-facing.
-    $isWindows = ($IsWindows -or ($env:OS -eq 'Windows_NT'))
+    $onWindows = ($IsWindows -or ($env:OS -eq 'Windows_NT'))
 
-    if (-not $isWindows) {
+    if (-not $onWindows) {
         Write-Host "Outlook COM automation requires Windows desktop Outlook." -ForegroundColor Yellow
         return $null
     }

--- a/tests/no_readonly_automatic_assignments.Tests.ps1
+++ b/tests/no_readonly_automatic_assignments.Tests.ps1
@@ -44,7 +44,9 @@ Describe 'Read-only automatic variables' {
         function Get-AssignmentTargetName {
             # Unwrap an optional [type] cast and return the bare variable name
             # (scope prefix stripped), or $null when the target isn't a plain
-            # variable (e.g. $env:OS, an index, or a property assignment).
+            # variable: a property ($obj.Prop), an index ($arr[0]), or a
+            # drive-qualified variable ($env:HOME, $function:foo) whose
+            # assignment is legal and must never be flagged.
             param(
                 [Parameter(Mandatory)] $LeftAst
             )
@@ -59,10 +61,18 @@ Describe 'Read-only automatic variables' {
                 return $null
             }
 
+            # $env:HOME / $function:foo parse as variables, but assigning them is
+            # legal; skip drive-qualified paths so an env var whose name collides
+            # with a read-only automatic (e.g. $env:Host) isn't a false positive.
+            if ($target.VariablePath.IsDriveQualified) {
+                return $null
+            }
+
             $userPath = $target.VariablePath.UserPath
             $leaf = ($userPath -split ':')[-1]
             return $leaf
         }
+
 
         function Get-ReadOnlyAssignment {
             # Parse one file and return readable offense strings for every

--- a/tests/no_readonly_automatic_assignments.Tests.ps1
+++ b/tests/no_readonly_automatic_assignments.Tests.ps1
@@ -1,0 +1,129 @@
+# ============================================================================
+# Jidoka guard — no assignment to read-only automatic variables
+# ============================================================================
+# PowerShell variable names are case-insensitive, so a descriptive local like
+# $isWindows silently aliases the built-in read-only $IsWindows automatic
+# variable. Assigning to it throws "Cannot overwrite variable ... because it is
+# read-only or constant" the moment the function runs (issue #182).
+#
+# This Pester spec parses every committed PowerShell file via the AST and fails
+# if any assignment targets a read-only / constant automatic variable, so the
+# regression cannot silently reappear in any file. $null is intentionally
+# excluded: `$null = <expr>` is the sanctioned discard idiom and never throws.
+#
+# This is an opt-in developer check, not a profile-load gate. Run it ad hoc:
+#   t-run-file   (defined in powcuts_by_cli/pester.ps1) -> point it at this file
+#   or:  Invoke-Pester -Output Detailed <path-to-this-file>
+
+Describe 'Read-only automatic variables' {
+
+    BeforeAll {
+        # Automatic variables that are ReadOnly or Constant — assigning to any of
+        # them throws at runtime. $null is deliberately absent ($null = ... is a
+        # legal discard). Matched case-insensitively via -contains below, so the
+        # exact-casing footgun ($isWindows vs $IsWindows) is still caught.
+        $script:ReadOnlyAutomaticVariables = @(
+            'true'
+            'false'
+            'IsWindows'
+            'IsLinux'
+            'IsMacOS'
+            'IsCoreCLR'
+            'PID'
+            'Host'
+            'Home'
+            'PSHome'
+            'PSVersionTable'
+            'PSEdition'
+            'PSCulture'
+            'PSUICulture'
+            'ExecutionContext'
+            'ShellId'
+        )
+
+        function Get-AssignmentTargetName {
+            # Unwrap an optional [type] cast and return the bare variable name
+            # (scope prefix stripped), or $null when the target isn't a plain
+            # variable (e.g. $env:OS, an index, or a property assignment).
+            param(
+                [Parameter(Mandatory)] $LeftAst
+            )
+
+            $target = $LeftAst
+
+            if ($target -is [System.Management.Automation.Language.ConvertExpressionAst]) {
+                $target = $target.Child
+            }
+
+            if ($target -isnot [System.Management.Automation.Language.VariableExpressionAst]) {
+                return $null
+            }
+
+            $userPath = $target.VariablePath.UserPath
+            $leaf = ($userPath -split ':')[-1]
+            return $leaf
+        }
+
+        function Get-ReadOnlyAssignment {
+            # Parse one file and return readable offense strings for every
+            # assignment whose target is a read-only automatic variable.
+            param(
+                [Parameter(Mandatory)] [string] $Path
+            )
+
+            $tokens = $null
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$parseErrors)
+
+            $isAssignment = {
+                param($node)
+                $result = $node -is [System.Management.Automation.Language.AssignmentStatementAst]
+                return $result
+            }
+
+            $assignments = $ast.FindAll($isAssignment, $true)
+
+            $offenses = New-Object System.Collections.Generic.List[string]
+
+            foreach ($assignment in $assignments) {
+                $name = Get-AssignmentTargetName -LeftAst $assignment.Left
+
+                if ($null -eq $name) {
+                    continue
+                }
+
+                if ($script:ReadOnlyAutomaticVariables -contains $name) {
+                    $line = $assignment.Extent.StartLineNumber
+                    $offenses.Add("line ${line}: `$$name")
+                }
+            }
+
+            return ,$offenses
+        }
+
+        $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    }
+
+    It 'no committed PowerShell file assigns to a read-only automatic variable' {
+        $files = New-Object System.Collections.Generic.List[object]
+
+        Get-ChildItem -Path (Join-Path $script:RepoRoot 'powcuts_by_cli') -Filter '*.ps1' -File |
+            ForEach-Object { $files.Add($_) }
+
+        $homeEntry = Get-Item -Path (Join-Path $script:RepoRoot 'powcuts_home.ps1')
+        $files.Add($homeEntry)
+
+        $allOffenses = New-Object System.Collections.Generic.List[string]
+
+        foreach ($file in $files) {
+            $offenses = Get-ReadOnlyAssignment -Path $file.FullName
+
+            foreach ($offense in $offenses) {
+                $allOffenses.Add("$($file.Name) $offense")
+            }
+        }
+
+        $allOffenses |
+            Should -BeNullOrEmpty -Because "assigning to a read-only automatic variable throws at runtime (issue #182). Offenders: $($allOffenses -join '; ')"
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the merged #181 (Outlook agenda module). Three commits landed on the branch **after** #181 was merged, so they never made it into `main` — most importantly the fix for a runtime crash that is **currently live in `main`**. This PR carries them in.

Closes #182

## Why a new PR

PR #181 merged at commit `6ed539c` (Outlook module + round-1 review fixes). The commits below were pushed afterward; a merged PR can't carry new work, so they need their own PR. The branch was rebased onto the current `main` so this PR contains exactly these three commits — nothing already merged.

## Changes

| File | Change |
|------|--------|
| `powcuts_by_cli/outlook_agenda.ps1` | Rename `$isWindows` → `$onWindows` in `Get-OutlookComApplication` |
| `tests/no_readonly_automatic_assignments.Tests.ps1` | **New** — jidoka AST guard against read-only automatic-variable assignments |

### The bug (live in `main` right now) — #182

`Get-OutlookComApplication` assigned to a local `$isWindows`. PowerShell variable names are **case-insensitive**, so that local *is* the built-in read-only automatic `$IsWindows` — the assignment throws `Cannot overwrite variable IsWindows because it is read-only or constant` on the first `ol-*` call. Renamed the local to `$onWindows` (the `$IsWindows` read on the right-hand side is fine).

### The jidoka guard

`tests/no_readonly_automatic_assignments.Tests.ps1` parses every committed `.ps1` via the PowerShell AST and fails if any assignment targets a read-only / constant automatic variable (`$IsWindows`, `$IsLinux`, `$IsMacOS`, `$true`, `$Host`, `$PID`, …). `$null` (legal discard) and drive-qualified vars (`$env:HOME`) are excluded; matching is case-insensitive so the exact footgun is caught regardless of casing. Opt-in developer check via `t-run-file` / `Invoke-Pester` — not wired into profile load.

Both changes were reviewed on #181 before that PR merged (PowerShell/Pester + clean-code + security); the review also caught and fixed a `$env:` false positive in the guard (commit included here).

## Test Plan

- [ ] `pwsh` parse (deferred — pwsh unavailable in the authoring env): `[System.Management.Automation.Language.Parser]::ParseFile("$path_to_bashcuts\powcuts_by_cli\outlook_agenda.ps1", [ref]$null, [ref]$null)`
- [ ] Regression (#182): on a Windows terminal, `ol-day` runs without `Cannot overwrite variable IsWindows`
- [ ] Jidoka guard green: `Invoke-Pester -Output Detailed .\tests\no_readonly_automatic_assignments.Tests.ps1`
- [ ] macOS/Linux pwsh: `ol-*` prints the Windows-only hint and exits cleanly

## Shell Parity

PowerShell-only — Outlook COM automation has no bash equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjcNBomyYNt7rfnorhdQwe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjcNBomyYNt7rfnorhdQwe)_