### PR TITLE
Fix debrief comment truncation at the first page-return in the WPF text-area fields

### DIFF
--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -476,7 +476,7 @@ function Format-UnplannedItemsDescription {
         }
     }
 
-    $body = $lines -join '<br/>'
+    $body = $lines -join $script:AzDevOpsHtmlLineBreak
     return $body
 }
 
@@ -521,7 +521,7 @@ function Format-UnplannedDebriefComment {
 
     $lines += '<em>via bashcuts az-Start-UnplannedWork</em>'
 
-    $body = $lines -join '<br/>'
+    $body = $lines -join $script:AzDevOpsHtmlLineBreak
     return $body
 }
 
@@ -602,7 +602,7 @@ function Format-UnplannedDailyDebrief {
     $lines += ''
     $lines += '<em>via bashcuts New-UnplannedWorkDebrief</em>'
 
-    $body = $lines -join '<br/>'
+    $body = $lines -join $script:AzDevOpsHtmlLineBreak
     return $body
 }
 

--- a/powcuts_by_cli/azdevops_unplanned.ps1
+++ b/powcuts_by_cli/azdevops_unplanned.ps1
@@ -471,7 +471,8 @@ function Format-UnplannedItemsDescription {
         $lines += '(no items captured)'
     } else {
         foreach ($entry in $Items) {
-            $lines += "$bullet [$($entry.Time)] $($entry.Text)"
+            $itemText = ConvertTo-AzDevOpsHtmlLineBreak -Text $entry.Text
+            $lines += "$bullet [$($entry.Time)] $itemText"
         }
     }
 
@@ -502,13 +503,13 @@ function Format-UnplannedDebriefComment {
 
     if ($Debrief) {
         $lines += "$iconMemo Debrief:"
-        $lines += $Debrief
+        $lines += ConvertTo-AzDevOpsHtmlLineBreak -Text $Debrief
         $lines += ''
     }
 
     if ($FutureFeature) {
         $lines += "$iconRocket Future opportunity:"
-        $lines += $FutureFeature
+        $lines += ConvertTo-AzDevOpsHtmlLineBreak -Text $FutureFeature
         $lines += ''
     }
 

--- a/powcuts_by_cli/pow_common.ps1
+++ b/powcuts_by_cli/pow_common.ps1
@@ -83,6 +83,29 @@ function pow_remove_property_from_field {
 }
 
 
+$script:AzDevOpsHtmlLineBreak = '<br/>'
+
+
+function ConvertTo-AzDevOpsHtmlLineBreak {
+    # Normalize any embedded newline (CRLF / CR / LF) in a free-text field to
+    # the Azure DevOps discussion field's HTML <br/> break. Multi-line debrief
+    # text captured from the WPF form's AcceptsReturn boxes would otherwise
+    # reach `az boards ... --discussion` with raw CRLFs, and cmd.exe /c
+    # truncates the argument at the first CRLF - silently dropping everything
+    # the user typed after their first page-return. Converting to <br/> keeps
+    # the whole body on one physical line so it survives the shell hand-off,
+    # and renders as a visible line break in the AzDO UI. Trailing newlines are
+    # trimmed so a field that ends on Enter doesn't leave a dangling <br/>.
+    param([Parameter(Mandatory)] [AllowEmptyString()] [string] $Text)
+
+    $break     = $script:AzDevOpsHtmlLineBreak
+    $trimmed   = $Text -replace '[\r\n]+$', ''
+    $converted = $trimmed -replace '\r\n?|\n', $break
+
+    return $converted
+}
+
+
 function Test-ConsoleGridAvailable {
     # $true iff Out-ConsoleGridView (from Microsoft.PowerShell.ConsoleGuiTools)
     # is loaded. Used by every cross-platform interactive picker - the TUI

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -839,15 +839,18 @@ function Format-TimerCommentBody {
         "$iconCheck Pomodoro complete — $totalDisplay"
     }
 
+    $debriefBody = ConvertTo-AzDevOpsHtmlLineBreak -Text $Debrief
+    $nextBody    = ConvertTo-AzDevOpsHtmlLineBreak -Text $Next
+
     $lines = @(
         $header,
         "<em>$timestamp</em>",
         '',
         "$iconMemo Debrief:",
-        $Debrief,
+        $debriefBody,
         '',
         "$iconRocket Next:",
-        $Next,
+        $nextBody,
         ''
     )
 

--- a/powcuts_by_cli/pow_timer.ps1
+++ b/powcuts_by_cli/pow_timer.ps1
@@ -869,7 +869,7 @@ function Format-TimerCommentBody {
 
     $lines += '<em>via bashcuts Start-TimerSession</em>'
 
-    $body = $lines -join '<br/>'
+    $body = $lines -join $script:AzDevOpsHtmlLineBreak
     return $body
 }
 


### PR DESCRIPTION
<!-- toc:start -->
## Navigation

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #183 |
| [Changes](#changes) | ✅ 3 files |
| [Test Plan](#test-plan) | ✅ 5 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/186#issuecomment-4971707375) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/186#issuecomment-4971717708) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/186#issuecomment-4971721508) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/186#issuecomment-4971720736) |
| 📚 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/186#issuecomment-4971737781) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/186#issuecomment-4971741673) |
| 📊 AzDO Diagrams Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/186#issuecomment-4971743543) |
<!-- toc:end -->

## Summary

Multi-line debrief text from the WPF `AcceptsReturn` boxes (unplanned-work + Pomodoro timer) reached `az boards ... --discussion` with raw CRLFs. On Windows, `az.cmd` runs via `cmd.exe /c`, which truncates the argument at the first CRLF — so everything the user typed after their first page-return was silently dropped.

This adds a shared `ConvertTo-AzDevOpsHtmlLineBreak` helper that normalizes embedded newlines to the AzDO discussion field&#39;s HTML `<br/>` break (trimming trailing newlines), and applies it to every free-text field before the `<br/>`-join so the whole body stays on one physical line and survives the shell hand-off.

## Issue

Closes #183

## Changes

| File | Change |
|------|--------|
| `powcuts_by_cli/pow_common.ps1` | Add `$script:AzDevOpsHtmlLineBreak` constant + `ConvertTo-AzDevOpsHtmlLineBreak` helper |
| `powcuts_by_cli/pow_timer.ps1` | `Format-TimerCommentBody` converts `$Debrief`/`$Next` via named `$debriefBody`/`$nextBody` locals |
| `powcuts_by_cli/azdevops_unplanned.ps1` | `Format-UnplannedDebriefComment` converts `$Debrief`/`$FutureFeature`; `Format-UnplannedItemsDescription` converts each item&#39;s `$Text` |

PowerShell-only by design — the WPF form and the `az boards`/cmd.exe hand-off have no bash counterpart.

## Test Plan

- [ ] Parse `pow_common.ps1`, `pow_timer.ps1`, `azdevops_unplanned.ps1` on Windows — zero errors (pwsh unavailable in CI env)
- [ ] `ConvertTo-AzDevOpsHtmlLineBreak -Text &#34;a`r`nb`r`nc&#34;` → `a<br/>b<br/>c`; trailing-newline input leaves no dangling `<br/>`
- [ ] `az-Start-UnplannedWork` → stop → type a debrief with 3+ page-returns → post → AzDO discussion comment shows **all** lines
- [ ] `az-Start-TimerSession -Minutes 1` → same multi-line debrief posts intact
- [ ] Single-line debrief unchanged (no stray `<br/>`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7fDXjKsT9zUqNzyf9odRQ)_