### PR TITLE
Add grid-pick field mode + JSON field-template config for az-New-AzDevOps* creators

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,12 @@ az-Open-FeaturesWiql     # config/queries/features.wiql
 az-Open-UserStoriesWiql  # config/queries/user-stories.wiql
 ```
 
+Field-templates config (extra `az boards work-item create` fields per type — see "Declaring extra create fields" below):
+
+```powershell
+az-Open-FieldTemplates   # config/field-templates.json  (+ the seeded .example.json)
+```
+
 Schema file (per-org `schema-<slug>.json`, falling back to `schema.json` when `$env:AZ_DEVOPS_ORG` is unset):
 
 ```powershell
@@ -509,6 +515,35 @@ az-New-AzDevOpsUserStory `
 `-FeatureId 0` creates an orphan (no parent link) with no prompt. `-NoOpen` skips the browser launch and just echoes the new work-item URL — handy in scripts.
 
 When you reach the parent-Feature picker interactively and pick `0` / cancel (orphan), the creator asks `Create a new parent Feature now? [y/N]` first. On **yes** it runs the full `az-New-AzDevOpsFeature` walk-through (which can itself chain up to a new Epic), then links your new Story to the Feature it just created — so you can build a fresh Epic → Feature → Story slice in one command. On **no/Enter** it creates the orphan exactly as before. (Passing `-FeatureId 0` explicitly still means "force orphan" and skips this prompt.)
+
+#### Declaring extra create fields (`field-templates.json`)
+
+Every `az-New-AzDevOps*` creator can prompt for extra work-item fields beyond the built-in title / description / priority / etc. — things like a swimlane, a business-value note, or a team tag. Declare them per work-item type in `~/.bashcuts-az-devops-app/config/field-templates.json`, keyed by **Azure DevOps field reference name** (e.g. `Custom.Swimlane`, *not* the display name). Each field's value is one of three shapes:
+
+| Value | Behavior at create time |
+|-------|-------------------------|
+| `{ "mode": "grid", "options": ["Expedite","Standard","Blocked"] }` | Single-select **grid pick** over the static options via `Out-ConsoleGridView` — no typos, sortable / filterable |
+| `{ "mode": "prompt" }` (or the bare string `"prompt"`) | Free-text `Read-Host` |
+| `"SomeLiteral"` | Passed straight through to `--fields` unchanged |
+
+Grid mode never blocks a create: if `Out-ConsoleGridView` isn't installed, the options list is empty, or you cancel/escape the grid, it falls back to a free-text `Read-Host` (an empty answer just skips the field). The config keys are `USER_STORY`, `FEATURE`, `TASK`, and `EPIC`:
+
+```json
+{
+  "USER_STORY": {
+    "Custom.Swimlane": { "mode": "grid", "options": ["Expedite", "Standard", "Blocked"] },
+    "Custom.BusinessValue": { "mode": "prompt" }
+  }
+}
+```
+
+`az-Connect-AzDevOps` (and the first create / `az-Open-FieldTemplates`) seeds an empty `field-templates.json` (`{}`, so nothing extra is prompted until you opt in) plus a `field-templates.example.json` documenting the swimlane example above. Open both for editing with:
+
+```powershell
+az-Open-FieldTemplates
+```
+
+The same shape can also be authored in your `$profile` under `$global:AzDevOpsProjectMap[...].Types.<TYPE>.RequiredFields` — the two sources are merged, and a `RequiredFields` entry **overrides** the `field-templates.json` entry for the same field. This is the project-scoped escape hatch when one board needs a different option set than the machine-wide JSON.
 
 ### Creating a new Feature
 

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -205,7 +205,7 @@ flowchart TD
     S4["Step 4 — az-Confirm-AzDevOpsProjectMap<br/>opt-in $global:AzDevOpsProjectMap<br/>+ optional az-Use-AzDevOpsProject prompt"]
     S5["Step 5 — az-Confirm-AzDevOpsLogin<br/>uses Test-AzDevOpsLoggedIn<br/>+ optional 'az login'"]
     S6["Step 6 — az-Set-AzDevOpsDefaults<br/>'az devops configure --defaults'"]
-    S7["Step 7 — az-Confirm-AzDevOpsQueryFiles<br/>seeds ~/.bashcuts-az-devops-app/config/queries/{epics,features,user-stories}.wiql<br/>via Initialize-AzDevOpsQueryFiles"]
+    S7["Step 7 — az-Confirm-AzDevOpsQueryFiles<br/>seeds ~/.bashcuts-az-devops-app/config/queries/{epics,features,user-stories}.wiql<br/>via Initialize-AzDevOpsQueryFiles<br/>+ field-templates.json / .example.json via Initialize-AzDevOpsFieldTemplates"]
     S8["Step 8 — az-Confirm-AzDevOpsSmokeQuery<br/>uses Invoke-AzDevOpsSmokeQuery"]
 
     Ready([READY])
@@ -462,8 +462,11 @@ flowchart TD
     AC -- yes --> Feat{FeatureId >=0?}
     ReadAC --> Feat
     Feat -- no --> PickFeat["Read-AzDevOpsFeaturePick<br/>(active Features from hierarchy.json)<br/>→ Read-AzDevOpsGridPick (Out-ConsoleGridView)<br/>or numbered menu fallback"]
-    Feat -- yes --> Create
-    PickFeat --> Create
+    Feat -- yes --> ReqF
+    PickFeat --> ReqF
+
+    ReqF["Read-AzDevOpsRequiredFields<br/>(field-templates.json + ProjectMap RequiredFields, merged)<br/>grid → Read-AzDevOpsFieldGridValue → Read-AzDevOpsGridPick;<br/>prompt → Read-Host; literal → passthrough"]
+    ReqF --> Create
 
     Create["Invoke-AzDevOpsWorkItemCreate<br/>→ New-AzDevOpsWorkItem<br/>→ az boards work-item create"]
     Create --> CreateOk{Ok?}
@@ -895,6 +898,13 @@ graph LR
     QNames[Get-AzDevOpsHierarchyQueryNames]:::priv
     InvHier[Invoke-AzDevOpsHierarchyQueries]:::priv
     MkDir[New-AzDevOpsDirectoryIfMissing]:::priv
+
+    %% Field templates (azdevops_paths.ps1)
+    FTInit[Initialize-AzDevOpsFieldTemplates]:::priv
+    FTGet[Get-AzDevOpsFieldTemplates]:::priv
+    FTForType[Get-AzDevOpsFieldTemplateForType]:::priv
+    FTSpec[ConvertTo-AzDevOpsFieldSpec]:::priv
+    ReqGrid[Read-AzDevOpsFieldGridValue]:::priv
 
     %% Data-plane wrappers (azdevops_db.ps1)
     AzJson[Invoke-AzDevOpsAzJson]:::priv
@@ -1570,6 +1580,13 @@ graph LR
     RTags --> TypeCfg
     RTags --> ActCfg
     RReq --> TypeCfg
+    RReq --> FTForType
+    FTForType --> FTGet
+    FTForType --> TypeKey
+    FTGet --> FTInit
+    FTGet --> FTSpec
+    FTInit --> QPaths
+    FTInit --> MkDir
     RPri --> TypeCfg
     RPts --> TypeCfg
     RScope --> TypeCfg
@@ -1583,6 +1600,8 @@ graph LR
     RPtsP --> Pts
     RTagsE --> RTags
     ReadReq --> RReq
+    ReadReq --> ReqGrid
+    ReqGrid --> GridPick
 
     NewS --> RPriP
     NewS --> RPtsP
@@ -1621,6 +1640,7 @@ graph LR
     OpenEpics(["az-Open-EpicsWiql"]):::pub
     OpenFeats(["az-Open-FeaturesWiql"]):::pub
     OpenStories(["az-Open-UserStoriesWiql"]):::pub
+    OpenFieldTmpl(["az-Open-FieldTemplates"]):::pub
     OpenSchema(["az-Open-Schema"]):::pub
 
     %% Path-inspector helper + path-discovery helpers used by the openers above
@@ -1654,6 +1674,11 @@ graph LR
     OpenAsg & OpenMen & OpenHier & OpenIter & OpenAreas & OpenLast & OpenLog --> OpenPath
     OpenEpics & OpenFeats & OpenStories & OpenSchema --> OpenPath
     OpenPath --> OSHandler
+
+    %% az-Open-FieldTemplates seeds via Initialize-AzDevOpsFieldTemplates, then
+    %% Start-Processes each seeded path directly (like az-Open-HierarchyWiqls).
+    OpenFieldTmpl --> FTInit
+    OpenFieldTmpl --> OSHandler
 
     %% Schema management wiring
     GetSchema --> SchemaRead

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -905,6 +905,8 @@ graph LR
     FTForType[Get-AzDevOpsFieldTemplateForType]:::priv
     FTSpec[ConvertTo-AzDevOpsFieldSpec]:::priv
     ReqGrid[Read-AzDevOpsFieldGridValue]:::priv
+    SeedFiles[Initialize-AzDevOpsSeededFiles]:::priv
+    NormKey[Get-AzDevOpsNormalizedTypeKey]:::priv
 
     %% Data-plane wrappers (azdevops_db.ps1)
     AzJson[Invoke-AzDevOpsAzJson]:::priv
@@ -1150,7 +1152,8 @@ graph LR
     InvHier --> Boards
     QInit --> QDefaults
     QInit --> QPaths
-    QInit --> MkDir
+    QInit --> SeedFiles
+    SeedFiles --> MkDir
     OpenHWiql --> QInit
     InvokeDS --> Boards
     InvokeDS --> ClassList
@@ -1582,11 +1585,13 @@ graph LR
     RReq --> TypeCfg
     RReq --> FTForType
     FTForType --> FTGet
-    FTForType --> TypeKey
+    FTForType --> NormKey
     FTGet --> FTInit
     FTGet --> FTSpec
+    FTGet --> NormKey
+    NormKey --> TypeKey
     FTInit --> QPaths
-    FTInit --> MkDir
+    FTInit --> SeedFiles
     RPri --> TypeCfg
     RPts --> TypeCfg
     RScope --> TypeCfg

--- a/powcuts_by_cli/azdevops_auth.ps1
+++ b/powcuts_by_cli/azdevops_auth.ps1
@@ -432,6 +432,18 @@ function az-Confirm-AzDevOpsQueryFiles {
         Write-Host "  OK  Query files at $($init.Paths.QueriesDir)" -ForegroundColor Green
     }
 
+    $templateInit = Initialize-AzDevOpsFieldTemplates
+    $newlyTemplated = @($templateInit.Seeded | Where-Object { $_.Seeded })
+
+    if ($newlyTemplated.Count -gt 0) {
+        foreach ($entry in $newlyTemplated) {
+            Write-Host "  OK  Seeded $($entry.Name) at $($entry.Path)" -ForegroundColor Green
+        }
+        Write-Host "      Declare extra create-time fields in field-templates.json (az-Open-FieldTemplates)." -ForegroundColor DarkGray
+    } else {
+        Write-Host "  OK  Field-template config at $($templateInit.Paths.FieldTemplates)" -ForegroundColor Green
+    }
+
     $stepResult = New-AzDevOpsStepResult -Ok $true
     return $stepResult
 }
@@ -490,7 +502,7 @@ function az-Connect-AzDevOps {
         @{ Num = 4; Name = 'Project map (multi-project)'; Action = { az-Confirm-AzDevOpsProjectMap } },
         @{ Num = 5; Name = 'Azure login session'; Action = { az-Confirm-AzDevOpsLogin } },
         @{ Num = 6; Name = 'Configure az devops defaults'; Action = { az-Set-AzDevOpsDefaults } },
-        @{ Num = 7; Name = 'User-machine query files'; Action = { az-Confirm-AzDevOpsQueryFiles } },
+        @{ Num = 7; Name = 'User-machine query + field-template files'; Action = { az-Confirm-AzDevOpsQueryFiles } },
         @{ Num = 8; Name = 'Smoke test (az boards query)'; Action = { az-Confirm-AzDevOpsSmokeQuery } }
     )
 

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -155,13 +155,52 @@ function Test-AzDevOpsCreateGate {
 }
 
 
+function Read-AzDevOpsFieldGridValue {
+    # Grid picker for a single 'grid'-mode required field. Renders the static
+    # Options through Read-AzDevOpsGridPick (Out-ConsoleGridView, single-select)
+    # and returns the picked value. Falls back to a free-text Read-Host when the
+    # grid is unavailable (Out-ConsoleGridView not installed), when no options
+    # were configured, or when the user cancels/escapes the grid - so a required
+    # field never blocks the create. An empty free-text answer returns '' and the
+    # caller skips the field, matching the 'prompt' behavior.
+    param(
+        [Parameter(Mandatory)] [string] $RefName,
+        [object[]] $Options
+    )
+
+    $choices = @($Options | Where-Object { $_ } | ForEach-Object { [string]$_ })
+
+    $gridReady =
+        ($choices.Count -gt 0) -and
+        (Get-Command Test-AzDevOpsGridAvailable -ErrorAction SilentlyContinue) -and
+        (Test-AzDevOpsGridAvailable) -and
+        (Get-Command Read-AzDevOpsGridPick -ErrorAction SilentlyContinue)
+
+    if ($gridReady) {
+        $rows = $choices | ForEach-Object { [PSCustomObject]@{ Value = $_ } }
+        $picked = Read-AzDevOpsGridPick -Rows $rows -Title "Pick $RefName"
+
+        if ($null -ne $picked) {
+            $value = [string]$picked.Value
+            return $value
+        }
+    }
+
+    $answer = Read-Host "Enter $RefName"
+    return $answer
+}
+
+
 function Read-AzDevOpsRequiredFields {
     # Walks Resolve-AzDevOpsTypeRequiredFields output for the given type and
     # returns a hashtable of <RefName> = <value> ready to feed
-    # Invoke-AzDevOpsWorkItemCreate -ExtraFields. Entries whose value is the
-    # literal 'prompt' (case-insensitive) trigger a Read-Host; any other value
-    # passes through unchanged. Empty input on a 'prompt' entry skips that field
-    # rather than sending an empty string to `az boards work-item create`.
+    # Invoke-AzDevOpsWorkItemCreate -ExtraFields. Each entry's spec resolves as:
+    #   'prompt' string, or @{ Mode = 'prompt' }   -> Read-Host free text
+    #   @{ Mode = 'grid'; Options = @('A','B') }    -> Read-AzDevOpsFieldGridValue
+    #                                                  (grid pick + free-text fallback)
+    #   any other value                             -> literal passthrough
+    # Empty input on a prompt/grid entry skips that field rather than sending an
+    # empty string to `az boards work-item create`.
     param([Parameter(Mandatory)] [string] $Type)
 
     $result = @{}
@@ -176,7 +215,28 @@ function Read-AzDevOpsRequiredFields {
 
     foreach ($refName in $required.Keys) {
         $value = $required[$refName]
-        if ("$value".Trim().ToLower() -eq 'prompt') {
+
+        $mode = $null
+        $options = @()
+        if ($value -is [hashtable]) {
+            if ($value.ContainsKey('Mode')) {
+                $mode = "$($value['Mode'])".Trim().ToLower()
+            }
+            if ($value.ContainsKey('Options')) {
+                $options = @($value['Options'])
+            }
+        }
+        elseif ("$value".Trim().ToLower() -eq 'prompt') {
+            $mode = 'prompt'
+        }
+
+        if ($mode -eq 'grid') {
+            $picked = Read-AzDevOpsFieldGridValue -RefName $refName -Options $options
+            if ($picked) {
+                $result[$refName] = $picked
+            }
+        }
+        elseif ($mode -eq 'prompt') {
             $answer = Read-Host "Enter $refName"
             if ($answer) {
                 $result[$refName] = $answer

--- a/powcuts_by_cli/azdevops_create.ps1
+++ b/powcuts_by_cli/azdevops_create.ps1
@@ -155,6 +155,13 @@ function Test-AzDevOpsCreateGate {
 }
 
 
+# Recognized per-field spec modes for the RequiredFields / field-templates.json
+# mechanism. Named so the mode comparisons below read intent instead of bare
+# string literals.
+$script:AzDevOpsFieldModeGrid   = 'grid'
+$script:AzDevOpsFieldModePrompt = 'prompt'
+
+
 function Read-AzDevOpsFieldGridValue {
     # Grid picker for a single 'grid'-mode required field. Renders the static
     # Options through Read-AzDevOpsGridPick (Out-ConsoleGridView, single-select)
@@ -226,21 +233,27 @@ function Read-AzDevOpsRequiredFields {
                 $options = @($value['Options'])
             }
         }
-        elseif ("$value".Trim().ToLower() -eq 'prompt') {
-            $mode = 'prompt'
+        elseif ("$value".Trim().ToLower() -eq $script:AzDevOpsFieldModePrompt) {
+            $mode = $script:AzDevOpsFieldModePrompt
         }
 
-        if ($mode -eq 'grid') {
+        if ($mode -eq $script:AzDevOpsFieldModeGrid) {
             $picked = Read-AzDevOpsFieldGridValue -RefName $refName -Options $options
             if ($picked) {
                 $result[$refName] = $picked
             }
         }
-        elseif ($mode -eq 'prompt') {
+        elseif ($mode -eq $script:AzDevOpsFieldModePrompt) {
             $answer = Read-Host "Enter $refName"
             if ($answer) {
                 $result[$refName] = $answer
             }
+        }
+        elseif ($value -is [hashtable]) {
+            # A hashtable with no recognized Mode is a malformed spec (e.g. {}
+            # from an empty JSON object) - skip it rather than passing a
+            # hashtable literal to `az boards work-item create --fields`.
+            continue
         }
         else {
             $result[$refName] = $value

--- a/powcuts_by_cli/azdevops_openers.ps1
+++ b/powcuts_by_cli/azdevops_openers.ps1
@@ -141,6 +141,26 @@ function az-Open-UserStoriesWiql {
 }
 
 
+function az-Open-FieldTemplates {
+    # Opens the per-type extra-fields config (field-templates.json). Defensively
+    # seeds field-templates.json (empty {}) and field-templates.example.json (the
+    # swimlane example) via Initialize-AzDevOpsFieldTemplates - mirrors how
+    # az-Open-HierarchyWiqls seeds - so a fresh machine can discover and edit the
+    # config in one step. The example is opened alongside so the shape is visible.
+    $init = Initialize-AzDevOpsFieldTemplates
+
+    foreach ($entry in $init.Seeded) {
+        if ($entry.Seeded) {
+            Write-Host "Wrote default $($entry.Name) to $($entry.Path) - opening for editing" -ForegroundColor Green
+        } else {
+            Write-Host "Opening $($entry.Path)" -ForegroundColor DarkGray
+        }
+
+        Start-Process $entry.Path
+    }
+}
+
+
 # --- Schema file opener (1) ------------------------------------------------
 
 function az-Open-Schema {

--- a/powcuts_by_cli/azdevops_paths.ps1
+++ b/powcuts_by_cli/azdevops_paths.ps1
@@ -226,14 +226,16 @@ function Get-AzDevOpsConfigPaths {
     $queriesDir = Join-Path $configDir 'queries'
 
     return [PSCustomObject]@{
-        Dir              = $configDir
-        QueriesDir       = $queriesDir
-        EpicsQuery       = Join-Path $queriesDir 'epics.wiql'
-        FeaturesQuery    = Join-Path $queriesDir 'features.wiql'
-        UserStoriesQuery = Join-Path $queriesDir 'user-stories.wiql'
-        AssignedQuery    = Join-Path $queriesDir 'assigned.wiql'
-        MentionsQuery    = Join-Path $queriesDir 'mentions.wiql'
-        ActivityQuery    = Join-Path $queriesDir 'activity.wiql'
+        Dir                   = $configDir
+        QueriesDir            = $queriesDir
+        EpicsQuery            = Join-Path $queriesDir 'epics.wiql'
+        FeaturesQuery         = Join-Path $queriesDir 'features.wiql'
+        UserStoriesQuery      = Join-Path $queriesDir 'user-stories.wiql'
+        AssignedQuery         = Join-Path $queriesDir 'assigned.wiql'
+        MentionsQuery         = Join-Path $queriesDir 'mentions.wiql'
+        ActivityQuery         = Join-Path $queriesDir 'activity.wiql'
+        FieldTemplates        = Join-Path $configDir 'field-templates.json'
+        FieldTemplatesExample = Join-Path $configDir 'field-templates.example.json'
     }
 }
 
@@ -319,6 +321,197 @@ function Initialize-AzDevOpsQueryFiles {
 function Get-AzDevOpsHierarchyQueryNames {
     $hierarchyNames = @('epics', 'features', 'user-stories')
     return $hierarchyNames
+}
+
+
+# ---------------------------------------------------------------------------
+# Field templates (extra work-item fields per type)
+#
+# Config file: $HOME/.bashcuts-az-devops-app/config/field-templates.json
+#   Declares extra `az boards work-item create --fields` values per work-item
+#   type (USER_STORY / FEATURE / TASK / EPIC), keyed by Azure DevOps field
+#   reference name (e.g. 'Custom.Swimlane', NOT the display name). Each field's
+#   value is one of:
+#     "prompt"                                  -> free-text Read-Host
+#     { "mode": "prompt" }                      -> same as "prompt"
+#     { "mode": "grid", "options": ["A","B"] }  -> single-select grid pick
+#                                                  (Out-ConsoleGridView) with a
+#                                                  free-text fallback
+#     "SomeLiteral"                             -> passed straight through
+#
+# The seeded field-templates.json ships empty ({}) so a fresh machine prompts
+# for nothing until the user opts in. field-templates.example.json documents
+# the swimlane example. A matching RequiredFields entry in
+# $global:AzDevOpsProjectMap overrides the JSON entry for that field
+# (see Resolve-AzDevOpsTypeRequiredFields).
+# ---------------------------------------------------------------------------
+
+$script:AzDevOpsEmptyFieldTemplatesJson = @"
+{}
+"@
+
+$script:AzDevOpsExampleFieldTemplatesJson = @"
+{
+  "USER_STORY": {
+    "Custom.Swimlane": {
+      "mode": "grid",
+      "options": ["Expedite", "Standard", "Blocked"]
+    },
+    "Custom.BusinessValue": {
+      "mode": "prompt"
+    }
+  }
+}
+"@
+
+
+function Initialize-AzDevOpsFieldTemplates {
+    # Idempotent: creates the config directory if absent and seeds
+    # field-templates.json (empty {}) plus field-templates.example.json (the
+    # documented swimlane example) only when each file does not already exist.
+    # Mirrors Initialize-AzDevOpsQueryFiles: returns the resolved paths plus
+    # per-file Seeded flags so callers can print consistent status lines.
+    $paths = Get-AzDevOpsConfigPaths
+    New-AzDevOpsDirectoryIfMissing -Path $paths.Dir
+
+    $files = @(
+        [PSCustomObject]@{
+            Name    = 'field-templates.json'
+            Path    = $paths.FieldTemplates
+            Default = $script:AzDevOpsEmptyFieldTemplatesJson
+        },
+        [PSCustomObject]@{
+            Name    = 'field-templates.example.json'
+            Path    = $paths.FieldTemplatesExample
+            Default = $script:AzDevOpsExampleFieldTemplatesJson
+        }
+    )
+
+    $seeded = New-Object System.Collections.Generic.List[PSCustomObject]
+
+    foreach ($entry in $files) {
+        $wasSeeded = $false
+        if (-not (Test-Path -LiteralPath $entry.Path)) {
+            Set-Content -LiteralPath $entry.Path -Value $entry.Default -Encoding UTF8
+            $wasSeeded = $true
+        }
+
+        $seeded.Add([PSCustomObject]@{
+            Name   = $entry.Name
+            Path   = $entry.Path
+            Seeded = $wasSeeded
+        })
+    }
+
+    return [PSCustomObject]@{
+        Paths  = $paths
+        Seeded = $seeded
+    }
+}
+
+
+function ConvertTo-AzDevOpsFieldSpec {
+    # Normalize one field-templates.json value into the same shape the
+    # ProjectMap RequiredFields hashtable uses so downstream readers stay
+    # uniform. A plain string (a literal, or 'prompt') passes through unchanged;
+    # a JSON object with mode/options becomes @{ Mode = '...'; Options = @(...) }.
+    param($Raw)
+
+    if ($Raw -is [string]) {
+        return $Raw
+    }
+
+    if ($Raw -is [System.Management.Automation.PSCustomObject]) {
+        $spec = @{}
+
+        $modeProp = $Raw.PSObject.Properties['mode']
+        if ($null -ne $modeProp -and $modeProp.Value) {
+            $spec['Mode'] = [string]$modeProp.Value
+        }
+
+        $optionsProp = $Raw.PSObject.Properties['options']
+        if ($null -ne $optionsProp -and $null -ne $optionsProp.Value) {
+            $spec['Options'] = @($optionsProp.Value | ForEach-Object { [string]$_ })
+        }
+
+        return $spec
+    }
+
+    return $Raw
+}
+
+
+function Get-AzDevOpsFieldTemplates {
+    # Reads field-templates.json (seeding the defaults first, like
+    # Get-AzDevOpsWiql) and returns a hashtable keyed by normalized work-item
+    # type key (USER_STORY / FEATURE / TASK / EPIC) whose values are hashtables
+    # of <RefName> -> field spec. An empty hashtable is returned on any miss,
+    # empty file, or parse failure so a create is never blocked by a malformed
+    # config.
+    $templates = @{}
+
+    $init = Initialize-AzDevOpsFieldTemplates
+    $path = $init.Paths.FieldTemplates
+
+    if (-not (Test-Path -LiteralPath $path)) {
+        return $templates
+    }
+
+    $raw = Get-Content -LiteralPath $path -Raw
+    if (-not $raw -or -not $raw.Trim()) {
+        return $templates
+    }
+
+    try {
+        $parsed = $raw | ConvertFrom-Json
+    }
+    catch {
+        return $templates
+    }
+
+    if ($null -eq $parsed) {
+        return $templates
+    }
+
+    foreach ($typeProp in $parsed.PSObject.Properties) {
+        $typeKey  = ($typeProp.Name.ToUpper() -replace '\s+', '_')
+        $fieldMap = @{}
+
+        $typeValue = $typeProp.Value
+        if ($null -ne $typeValue) {
+            foreach ($fieldProp in $typeValue.PSObject.Properties) {
+                $spec = ConvertTo-AzDevOpsFieldSpec -Raw $fieldProp.Value
+                $fieldMap[$fieldProp.Name] = $spec
+            }
+        }
+
+        $templates[$typeKey] = $fieldMap
+    }
+
+    return $templates
+}
+
+
+function Get-AzDevOpsFieldTemplateForType {
+    # Per-type accessor over Get-AzDevOpsFieldTemplates. Returns the field-spec
+    # hashtable for the given type (empty when the type isn't declared), using
+    # the same case-insensitive type-key normalization the ProjectMap lookups
+    # use so 'User Story', 'user story', and 'USER_STORY' all resolve alike.
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $key = if (Get-Command ConvertTo-AzDevOpsTypeKey -ErrorAction SilentlyContinue) {
+        ConvertTo-AzDevOpsTypeKey -Type $Type
+    } else {
+        ($Type.ToUpper() -replace '\s+', '_')
+    }
+
+    $templates = Get-AzDevOpsFieldTemplates
+    if ($templates.ContainsKey($key)) {
+        $fields = $templates[$key]
+        return $fields
+    }
+
+    return @{}
 }
 
 

--- a/powcuts_by_cli/azdevops_paths.ps1
+++ b/powcuts_by_cli/azdevops_paths.ps1
@@ -285,19 +285,23 @@ function Get-AzDevOpsQueryDefaults {
 }
 
 
-function Initialize-AzDevOpsQueryFiles {
-    # Idempotent: creates the queries directory if absent and seeds each
-    # default .wiql file only when the file does not already exist. Returns
-    # the resolved paths plus per-file Seeded flags so callers (the
-    # az-Connect-AzDevOps step and az-Open-HierarchyWiqls) can print
-    # consistent status lines.
-    $paths = Get-AzDevOpsConfigPaths
-    New-AzDevOpsDirectoryIfMissing -Path $paths.QueriesDir
+function Initialize-AzDevOpsSeededFiles {
+    # Shared seed loop for the config-file initializers. Ensures $Directory
+    # exists, then writes each entry's Default to its Path only when the file is
+    # absent (idempotent). $Files is a list of [PSCustomObject]@{ Name; Path;
+    # Default }. Returns the per-file Seeded flags (Name / Path / Seeded) as a
+    # List[PSCustomObject]. Consumed by Initialize-AzDevOpsQueryFiles and
+    # Initialize-AzDevOpsFieldTemplates so the two never drift.
+    param(
+        [Parameter(Mandatory)] [string]   $Directory,
+        [Parameter(Mandatory)] [object[]] $Files
+    )
 
-    $defaults = Get-AzDevOpsQueryDefaults
+    New-AzDevOpsDirectoryIfMissing -Path $Directory
+
     $seeded = New-Object System.Collections.Generic.List[PSCustomObject]
 
-    foreach ($entry in $defaults) {
+    foreach ($entry in $Files) {
         $wasSeeded = $false
         if (-not (Test-Path -LiteralPath $entry.Path)) {
             Set-Content -LiteralPath $entry.Path -Value $entry.Default -Encoding UTF8
@@ -311,9 +315,24 @@ function Initialize-AzDevOpsQueryFiles {
         })
     }
 
+    return $seeded
+}
+
+
+function Initialize-AzDevOpsQueryFiles {
+    # Idempotent: creates the queries directory if absent and seeds each
+    # default .wiql file only when the file does not already exist. Returns
+    # the resolved paths plus per-file Seeded flags so callers (the
+    # az-Connect-AzDevOps step and az-Open-HierarchyWiqls) can print
+    # consistent status lines.
+    $paths    = Get-AzDevOpsConfigPaths
+    $defaults = Get-AzDevOpsQueryDefaults
+
+    $seeded = Initialize-AzDevOpsSeededFiles -Directory $paths.QueriesDir -Files $defaults
+
     return [PSCustomObject]@{
         Paths  = $paths
-        Seeded = @($seeded)
+        Seeded = $seeded
     }
 }
 
@@ -387,21 +406,7 @@ function Initialize-AzDevOpsFieldTemplates {
         }
     )
 
-    $seeded = New-Object System.Collections.Generic.List[PSCustomObject]
-
-    foreach ($entry in $files) {
-        $wasSeeded = $false
-        if (-not (Test-Path -LiteralPath $entry.Path)) {
-            Set-Content -LiteralPath $entry.Path -Value $entry.Default -Encoding UTF8
-            $wasSeeded = $true
-        }
-
-        $seeded.Add([PSCustomObject]@{
-            Name   = $entry.Name
-            Path   = $entry.Path
-            Seeded = $wasSeeded
-        })
-    }
+    $seeded = Initialize-AzDevOpsSeededFiles -Directory $paths.Dir -Files $files
 
     return [PSCustomObject]@{
         Paths  = $paths
@@ -441,6 +446,24 @@ function ConvertTo-AzDevOpsFieldSpec {
 }
 
 
+function Get-AzDevOpsNormalizedTypeKey {
+    # Single normalizer for work-item type keys in this file. Routes through the
+    # canonical ConvertTo-AzDevOpsTypeKey (azdevops_projects.ps1) when it's
+    # loaded, with an inline fallback for the rare case this file is used on its
+    # own, so both the JSON-key and the lookup paths canonicalize identically
+    # ('User Story' / 'user story' / 'USER_STORY' -> 'USER_STORY').
+    param([Parameter(Mandatory)] [string] $Type)
+
+    $key = if (Get-Command ConvertTo-AzDevOpsTypeKey -ErrorAction SilentlyContinue) {
+        ConvertTo-AzDevOpsTypeKey -Type $Type
+    } else {
+        ($Type.ToUpper() -replace '\s+', '_')
+    }
+
+    return $key
+}
+
+
 function Get-AzDevOpsFieldTemplates {
     # Reads field-templates.json (seeding the defaults first, like
     # Get-AzDevOpsWiql) and returns a hashtable keyed by normalized work-item
@@ -474,7 +497,7 @@ function Get-AzDevOpsFieldTemplates {
     }
 
     foreach ($typeProp in $parsed.PSObject.Properties) {
-        $typeKey  = ($typeProp.Name.ToUpper() -replace '\s+', '_')
+        $typeKey  = Get-AzDevOpsNormalizedTypeKey -Type $typeProp.Name
         $fieldMap = @{}
 
         $typeValue = $typeProp.Value
@@ -499,11 +522,7 @@ function Get-AzDevOpsFieldTemplateForType {
     # use so 'User Story', 'user story', and 'USER_STORY' all resolve alike.
     param([Parameter(Mandatory)] [string] $Type)
 
-    $key = if (Get-Command ConvertTo-AzDevOpsTypeKey -ErrorAction SilentlyContinue) {
-        ConvertTo-AzDevOpsTypeKey -Type $Type
-    } else {
-        ($Type.ToUpper() -replace '\s+', '_')
-    }
+    $key = Get-AzDevOpsNormalizedTypeKey -Type $Type
 
     $templates = Get-AzDevOpsFieldTemplates
     if ($templates.ContainsKey($key)) {

--- a/powcuts_by_cli/azdevops_projects.ps1
+++ b/powcuts_by_cli/azdevops_projects.ps1
@@ -264,27 +264,39 @@ function Resolve-AzDevOpsTypeTags {
 
 
 function Resolve-AzDevOpsTypeRequiredFields {
-    # Returns a hashtable of <RefName> = <value or 'prompt'> for the given
-    # type, or an empty hashtable. Callers walk the entries and, for each
-    # 'prompt' value, Read-Host for input; literal values pass through to
-    # `az boards work-item create --fields ...`.
+    # Returns a hashtable of <RefName> = <spec> for the given type, merging two
+    # sources so both the JSON config and the ProjectMap feed the same reader:
+    #   1. field-templates.json (Get-AzDevOpsFieldTemplateForType) - lower
+    #      precedence, machine-wide extra fields per type.
+    #   2. $global:AzDevOpsProjectMap[...].Types..RequiredFields - higher
+    #      precedence, overriding the JSON entry for any field it names.
+    # Each <spec> is either the literal 'prompt' string, a literal passthrough
+    # value, or a hashtable @{ Mode = 'grid'|'prompt'; Options = @(...) }.
+    # Read-AzDevOpsRequiredFields walks the result and resolves each spec.
     param([Parameter(Mandatory)] [string] $Type)
 
+    $merged = @{}
+
+    if (Get-Command Get-AzDevOpsFieldTemplateForType -ErrorAction SilentlyContinue) {
+        $fromJson = Get-AzDevOpsFieldTemplateForType -Type $Type
+        if ($fromJson -is [hashtable]) {
+            foreach ($refName in $fromJson.Keys) {
+                $merged[$refName] = $fromJson[$refName]
+            }
+        }
+    }
+
     $typeConfig = Get-AzDevOpsTypeConfig -Type $Type
-    if ($null -eq $typeConfig) {
-        return @{}
+    if ($null -ne $typeConfig -and $typeConfig.ContainsKey('RequiredFields')) {
+        $fields = $typeConfig['RequiredFields']
+        if ($fields -is [hashtable]) {
+            foreach ($refName in $fields.Keys) {
+                $merged[$refName] = $fields[$refName]
+            }
+        }
     }
 
-    if (-not $typeConfig.ContainsKey('RequiredFields')) {
-        return @{}
-    }
-
-    $fields = $typeConfig['RequiredFields']
-    if ($null -eq $fields -or $fields -isnot [hashtable]) {
-        return @{}
-    }
-
-    return $fields
+    return $merged
 }
 
 


### PR DESCRIPTION
<!-- toc:start -->
## Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #120 |
| [Changes](#changes) | ✅ 7 files |
| [New Functions](#new-functions) | ✅ 6 public/helper |
| [Test Plan](#test-plan) | 0/6 (manual) |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/187#issuecomment-4972396842) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/187#issuecomment-4972413662) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/187#issuecomment-4972412671) |
| 🧼 Clean-Code Engineer Review | ⚠️→✅ REQUEST CHANGES, resolved in `83cc2c5` — [View](https://github.com/jdschleicher/bashcuts/pull/187#issuecomment-4972413049) |
| ✅ Criteria Check | ✅ PASS (2 items need user pwsh/terminal verify) — [View](https://github.com/jdschleicher/bashcuts/pull/187#issuecomment-4972463728) |
| 📚 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/187#issuecomment-4972456909) |

> **Review note:** the 🧼 clean-code review's 1 HIGH (duplicated seed loop) plus the MEDIUM (type-key duplication) and LOW nits were all addressed in commit `83cc2c5` — extracted `Initialize-AzDevOpsSeededFiles`, added `Get-AzDevOpsNormalizedTypeKey`, named the mode constants, and added an empty-spec guard.
<!-- toc:end -->
<!-- pr-diagram:start -->
## How it works

A creator (`az-New-AzDevOps*`) calls `Read-AzDevOpsRequiredFields`, which asks `Resolve-AzDevOpsTypeRequiredFields` to merge the machine-wide `field-templates.json` with the per-project `RequiredFields` map (ProjectMap wins). Each resolved field is then dispatched by its `Mode` — `grid` renders an `Out-ConsoleGridView` pick (falling back to free-text on cancel/unavailable), `prompt` reads free text, and a literal passes straight through to `az boards work-item create --fields`. `az-Open-FieldTemplates` seeds and opens the config.

```mermaid
flowchart TD
    Creator([az-New-AzDevOps* creators]):::pub
    OpenFT([az-Open-FieldTemplates]):::pub

    ReadReq[Read-AzDevOpsRequiredFields]:::priv
    Resolve[Resolve-AzDevOpsTypeRequiredFields<br/>merge JSON + ProjectMap]:::priv
    ForType[Get-AzDevOpsFieldTemplateForType]:::priv
    GetFT[Get-AzDevOpsFieldTemplates]:::priv
    Spec[ConvertTo-AzDevOpsFieldSpec]:::priv
    NormKey[Get-AzDevOpsNormalizedTypeKey]:::priv
    InitFT[Initialize-AzDevOpsFieldTemplates]:::priv
    SeedFiles[Initialize-AzDevOpsSeededFiles]:::priv

    Mode{spec Mode?}
    Grid[Read-AzDevOpsFieldGridValue<br/>&rarr; Read-AzDevOpsGridPick]:::priv
    Prompt[Read-Host]:::priv
    Literal[literal passthrough]:::priv

    FTJson[(field-templates.json<br/>+ .example.json)]:::io
    ProjMap[($AzDevOpsProjectMap<br/>RequiredFields)]:::io
    AzCli["az boards work-item create --fields"]:::io

    Creator --> ReadReq --> Resolve
    Resolve --> ForType --> GetFT
    GetFT --> Spec
    GetFT --> NormKey
    GetFT --> InitFT --> SeedFiles --> FTJson
    Resolve --> ProjMap
    Resolve --> Mode
    Mode -- grid --> Grid
    Mode -- prompt --> Prompt
    Mode -- literal --> Literal
    Grid -.grid unavailable / cancel.-> Prompt
    Grid --> AzCli
    Prompt --> AzCli
    Literal --> AzCli
    OpenFT --> InitFT

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Enriches the `RequiredFields` mechanism so the `az-New-AzDevOps*` creators can prompt for extra work-item fields (swimlane, business value, etc.) via a sortable `Out-ConsoleGridView` grid pick over a **static options list**, declarable in a new `field-templates.json` config **or** the existing `$global:AzDevOpsProjectMap` `RequiredFields` hashtable. Both sources feed the same resolver; the ProjectMap overrides the JSON per-field.

PowerShell-only — the create flow and `RequiredFields` mechanism live exclusively in `powcuts_by_cli/` (per the issue's Shell Parity Note).

## Issue

Closes #120

## Changes

- **`azdevops_create.ps1`** — `Read-AzDevOpsRequiredFields` now resolves a richer per-field spec:
  - `@{ Mode='grid'; Options=@('A','B') }` → new `Read-AzDevOpsFieldGridValue` (single-select grid via `Read-AzDevOpsGridPick`, with a **free-text `Read-Host` fallback** when the grid is unavailable, has no options, or the user cancels/escapes — so a create is never blocked)
  - `@{ Mode='prompt' }` / bare `'prompt'` string → `Read-Host`
  - any literal → passthrough (unchanged)
- **`azdevops_paths.ps1`** — `field-templates.json` / `field-templates.example.json` paths; `Initialize-AzDevOpsFieldTemplates` (first-run seeding of an inert `{}` file + the swimlane example, mirroring the `.wiql` pattern); `Get-AzDevOpsFieldTemplates` / `Get-AzDevOpsFieldTemplateForType` loaders; `ConvertTo-AzDevOpsFieldSpec` normalizer; shared `Initialize-AzDevOpsSeededFiles` + `Get-AzDevOpsNormalizedTypeKey` helpers (review follow-up).
- **`azdevops_projects.ps1`** — `Resolve-AzDevOpsTypeRequiredFields` merges the JSON templates with the ProjectMap (ProjectMap wins per-field).
- **`azdevops_auth.ps1`** — `az-Connect-AzDevOps` step 7 also seeds the field-template files.
- **`azdevops_openers.ps1`** — new `az-Open-FieldTemplates` opener.
- **`README.md`** — new "Declaring extra create fields" section documenting the `grid`/`prompt` modes + swimlane example; opener list updated.
- **`docs/azure-devops-diagrams.md`** — Connect step 7, create-flow, and function-dependency diagrams refreshed.

## New Functions

| Function | File | Role |
|----------|------|------|
| `Read-AzDevOpsFieldGridValue` | `azdevops_create.ps1` | grid pick for one field + free-text fallback |
| `Get-AzDevOpsFieldTemplates` | `azdevops_paths.ps1` | read/parse `field-templates.json` |
| `Get-AzDevOpsFieldTemplateForType` | `azdevops_paths.ps1` | per-type accessor |
| `Initialize-AzDevOpsFieldTemplates` | `azdevops_paths.ps1` | first-run seeder |
| `ConvertTo-AzDevOpsFieldSpec` | `azdevops_paths.ps1` | JSON→hashtable spec normalizer |
| `az-Open-FieldTemplates` | `azdevops_openers.ps1` | opener for the new config |

## Test Plan

- [ ] `pwsh -NoProfile` parse of the changed `.ps1` files is clean *(could not run in the authoring env — pwsh not on PATH; validated via manual review + brace/paren balance)*
- [ ] `az-Open-FieldTemplates` seeds + opens `field-templates.json` (`{}`) and `field-templates.example.json` (swimlane example)
- [ ] With a `grid` field configured, `az-New-AzDevOpsUserStory` shows an `Out-ConsoleGridView` pick after the Feature step; picked value lands on `--fields`
- [ ] `Esc`/cancel on the grid falls back to free-text `Read-Host` (create not blocked)
- [ ] Existing `'prompt'` string + literal `RequiredFields` configs behave unchanged (back-compat)
- [ ] Same field in both JSON and ProjectMap → ProjectMap spec wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)