### PR TITLE
Merge Azure DevOps assigned work items into the Outlook day view via a day-section registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ If you run desktop Outlook on Windows, the `ol-` shortcuts (in `powcuts_by_cli/o
 
 These read the Calendar and Tasks folders via Outlook COM automation, so they require **Windows + the desktop Outlook client** (no cloud/Graph auth). On macOS/Linux — or if Outlook can't be reached — every command prints a short hint and exits cleanly.
 
+If you also use the Azure DevOps (`az-*`) shortcuts, your assigned work items appear automatically as a **🎯 Azure DevOps** section at the bottom of `ol-Show-OutlookDay` — the active items in your current iteration, sorted by priority. It's read-only and served straight from the existing assigned cache (no extra sync or `az` callout), so run `az-Sync-AzDevOpsCache` if the section says the cache isn't found. Pass `ol-Show-OutlookDay -NoWorkItems` to hide it and show only the built-in agenda + tasks. The Outlook module has no hard dependency on `az-*`: on a machine without the Azure DevOps shortcuts the section simply doesn't appear.
+
 ## Opening VS Code Snipppets
 
 When using VS Code it is HIGHLY recommend to setup VSCode settings sync: https://code.visualstudio.com/docs/editor/settings-sync

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -1025,6 +1025,13 @@ graph LR
     SprintCur[Resolve-AzDevOpsCurrentIteration]:::priv
     SprintBanner[Write-AzDevOpsCurrentSprintBanner]:::priv
     SprintSort[Sort-AzDevOpsByClosedLast]:::priv
+    SelIterRow[Select-AzDevOpsCurrentIterationRow]:::priv
+
+    %% Outlook day-view section (azdevops_views.ps1) — cache-only today-slice
+    DaySection[Show-AzDevOpsDaySection]:::priv
+    DayRows[Get-AzDevOpsDayViewRows]:::priv
+    CurCache[Resolve-AzDevOpsCurrentIterationFromCache]:::priv
+    DaySort[Sort-AzDevOpsByPriority]:::priv
 
     %% az-New-Task picker
     PStory[Read-AzDevOpsStoryPick]:::priv
@@ -1293,6 +1300,24 @@ graph LR
     SprintGrid --> TitleCol
     SprintGrid --> ShowRows
     SprintGrid --> RowAction
+
+    %% Current-iteration bracket test extracted into SelIterRow (shared by
+    %% the live-capable Resolve and the cache-only Resolve...FromCache)
+    SprintCur --> SelIterRow
+
+    %% Outlook day-view section — cache-only today-slice registered into
+    %% ol-Show-OutlookDay (no live az fetch, no auth prompt)
+    DaySection --> Paths
+    DaySection --> Stale
+    DaySection --> DayRows
+    DayRows --> ReadA
+    DayRows --> SelAct
+    DayRows --> CurCache
+    DayRows --> DaySort
+    DayRows --> TitleCol
+    CurCache --> ReadCls
+    CurCache --> ClsRows
+    CurCache --> SelIterRow
 
     %% Post-selection row actions (shared by Tree / Board / Features / Orphans)
     Tree --> RowAction

--- a/powcuts_by_cli/azdevops_views.ps1
+++ b/powcuts_by_cli/azdevops_views.ps1
@@ -1810,30 +1810,42 @@ function Get-AzDevOpsSprintItemPool {
 }
 
 
-function Resolve-AzDevOpsCurrentIteration {
-    # Private. Returns the cached iteration row whose StartDate <= today <=
-    # FinishDate - the same date-range test `az boards iteration team list
-    # --timeframe current` applies (Azure DevOps stores no "is current" flag;
-    # "current" is always derived from the sprint's start/finish dates). The
-    # returned row carries Path / StartDate / FinishDate. Returns $null when no
-    # dated iteration brackets today (e.g. a gap between sprints) so the caller
-    # can fall back to $env:AZ_ITERATION.
-    $rows = Read-AzDevOpsClassificationRows -Kind 'Iteration' -CommandName 'az-Show-CurrentSprint'
-    if ($null -eq $rows -or @($rows).Count -eq 0) {
+function Select-AzDevOpsCurrentIterationRow {
+    # Private. Given flattened iteration rows, returns the one whose StartDate <=
+    # today <= FinishDate - the same date-range test `az boards iteration team
+    # list --timeframe current` applies (Azure DevOps stores no "is current"
+    # flag; "current" is always derived from the sprint's start/finish dates).
+    # Returns $null when the rows are empty or no dated iteration brackets today
+    # (e.g. a gap between sprints). Shared by the live-capable
+    # Resolve-AzDevOpsCurrentIteration and the cache-only
+    # Resolve-AzDevOpsCurrentIterationFromCache so the bracket test lives once.
+    param($Rows)
+
+    if ($null -eq $Rows -or @($Rows).Count -eq 0) {
         return $null
     }
 
     $today = (Get-Date).Date
 
-    $match = $rows | Where-Object {
+    $match = $Rows | Where-Object {
         $_.StartDate -and $_.FinishDate -and
         $_.StartDate.Date -le $today -and $today -le $_.FinishDate.Date
     } | Select-Object -First 1
 
-    if ($null -eq $match) {
-        return $null
-    }
+    return $match
+}
 
+
+function Resolve-AzDevOpsCurrentIteration {
+    # Private. Returns the cached iteration row bracketing today (Path /
+    # StartDate / FinishDate), or $null when no dated iteration brackets today so
+    # the caller can fall back to $env:AZ_ITERATION. Reads through
+    # Read-AzDevOpsClassificationRows, which falls back to a live `az` fetch when
+    # the iteration cache is missing - fine for the interactive sprint views, but
+    # see Resolve-AzDevOpsCurrentIterationFromCache for the callout-free variant
+    # the read-only day view needs.
+    $rows = Read-AzDevOpsClassificationRows -Kind 'Iteration' -CommandName 'az-Show-CurrentSprint'
+    $match = Select-AzDevOpsCurrentIterationRow -Rows $rows
     return $match
 }
 
@@ -1945,4 +1957,140 @@ function az-Show-CurrentSprint {
     Write-AzDevOpsCurrentSprintBanner -Current $current -IterationPath $iterationPath
 
     Show-AzDevOpsSprintGrid -IterationPath $iterationPath -Label $iterationPath
+}
+
+
+# ---------------------------------------------------------------------------
+# Outlook day-view integration
+#
+# Registers an Azure DevOps section into the Outlook day view
+# (ol-Show-OutlookDay), guarded on Register-OutlookDaySection so neither module
+# hard-depends on the other: when the Outlook module isn't loaded the guard
+# skips registration with no error. outlook_agenda.ps1 is dot-sourced before
+# this file in powcuts_home.ps1 so the registry exists at this point.
+#
+# The section is a today-slice of the assigned cache - active items in the
+# current iteration, sorted by Priority then most-recently-changed. Strictly
+# read-only / cache-only: the current-iteration resolve reads the classification
+# cache directly (no live `az` fallback), so the day view never triggers a
+# callout or an auth prompt.
+# ---------------------------------------------------------------------------
+
+$script:AzDevOpsDayEmDash           = "$([char]0x2014)"                                        # em-dash (BMP)
+$script:AzDevOpsDayCacheMissingHint = "Azure DevOps cache not found $script:AzDevOpsDayEmDash run az-Sync-AzDevOpsCache"
+$script:AzDevOpsDayCelebrateIcon    = [char]::ConvertFromUtf32(0x1F389)                        # party popper
+$script:AzDevOpsDaySectionName      = "$([char]::ConvertFromUtf32(0x1F3AF)) Azure DevOps"      # bullseye
+$script:AzDevOpsDaySectionOrder     = 100
+
+
+function Resolve-AzDevOpsCurrentIterationFromCache {
+    # Private. Cache-only current-iteration resolve for the read-only day view:
+    # reads the iteration classification cache directly (NO live `az` fallback,
+    # honoring the section's no-callouts contract), flattens it, and returns the
+    # row bracketing today - or $null when the cache is absent or nothing
+    # brackets today, so the caller falls back to all-active.
+    $tree = Read-AzDevOpsClassificationCache -Kind 'Iteration'
+    if ($null -eq $tree) {
+        return $null
+    }
+
+    $rows = ConvertFrom-AzDevOpsClassificationTree -Tree $tree -Kind 'Iteration'
+    $match = Select-AzDevOpsCurrentIterationRow -Rows $rows
+    return $match
+}
+
+
+function Sort-AzDevOpsByPriority {
+    # Priority ascending (1 = highest) with null priorities pushed last via an
+    # [int]::MaxValue substitution, then most-recently-changed first. Mirrors the
+    # calculated-key shape of Sort-AzDevOpsByDateDesc / Sort-AzDevOpsByClosedLast
+    # so each ordering the views need lives in one named helper.
+    param([Parameter(Mandatory)] $Items)
+
+    $priorityKey = {
+        if ($null -eq $_.Priority) {
+            [int]::MaxValue
+        } else {
+            $_.Priority
+        }
+    }
+
+    $sorted = $Items | Sort-Object `
+        @{ Expression = $priorityKey; Ascending = $true }, `
+        @{ Expression = 'AssignedAt'; Descending = $true }
+
+    return @($sorted)
+}
+
+
+function Get-AzDevOpsDayViewRows {
+    # Private. Today-slice of the assigned cache for the day view: active states,
+    # filtered to the current iteration (falls back to all-active when the
+    # current iteration can't be resolved from cache), sorted by Priority asc
+    # (nulls last) then AssignedAt desc. Returns the projected rows (Id, Type,
+    # State, Priority, Title, Iteration), or $null when the assigned cache is
+    # absent so the renderer can print its dim sync hint.
+    $items = Read-AzDevOpsAssignedCache
+    if ($null -eq $items) {
+        return $null
+    }
+
+    # Normalize to an array up front: Select-AzDevOpsActiveItems collapses an
+    # empty result to $null (empty pipeline), and Sort-AzDevOpsByPriority's
+    # Mandatory -Items rejects $null - the empty-cache path would otherwise throw
+    # instead of yielding the friendly "no active items" state.
+    $active = @(Select-AzDevOpsActiveItems -Items $items)
+
+    $current = Resolve-AzDevOpsCurrentIterationFromCache
+
+    $scoped = if ($null -ne $current) {
+        @($active | Where-Object { $_.Iteration -eq $current.Path })
+    } else {
+        $active
+    }
+
+    if ($scoped.Count -eq 0) {
+        return @()
+    }
+
+    $sorted = Sort-AzDevOpsByPriority -Items $scoped
+
+    $rows = @($sorted | Select-Object Id, Type, State, Priority, (Get-AzDevOpsTitleColumn), Iteration)
+    return $rows
+}
+
+
+function Show-AzDevOpsDaySection {
+    # Renders the Azure DevOps section inside ol-Show-OutlookDay: today's slice
+    # of assigned work (current iteration, active states, priority-sorted). A
+    # view function - Write-Host for display is intended here. Strictly
+    # cache-only: prints a single dim hint when the assigned cache is absent
+    # (instead of the standard multi-line sync warning or an empty grid), a
+    # friendly line when nothing is active, and surfaces staleness through the
+    # shared Write-AzDevOpsStaleBanner path like az-Show-Assigned.
+    $paths = Get-AzDevOpsCachePaths
+
+    if (-not (Test-Path -LiteralPath $paths.Assigned)) {
+        Write-Host $script:AzDevOpsDayCacheMissingHint -ForegroundColor DarkGray
+        return
+    }
+
+    Write-AzDevOpsStaleBanner
+
+    $rows = Get-AzDevOpsDayViewRows
+
+    if ($null -eq $rows -or @($rows).Count -eq 0) {
+        Write-Host "No active work items $script:AzDevOpsDayCelebrateIcon"
+        return
+    }
+
+    $rows | Format-Table -AutoSize | Out-Host
+}
+
+
+if (Get-Command Register-OutlookDaySection -ErrorAction SilentlyContinue) {
+    Register-OutlookDaySection `
+        -Name  $script:AzDevOpsDaySectionName `
+        -Order $script:AzDevOpsDaySectionOrder `
+        -Render { Show-AzDevOpsDaySection }
 }

--- a/powcuts_by_cli/outlook_agenda.ps1
+++ b/powcuts_by_cli/outlook_agenda.ps1
@@ -38,6 +38,16 @@ $script:OutlookIconCalendar = [char]::ConvertFromUtf32(0x1F4C5)   # calendar
 $script:OutlookIconTasks    = [char]::ConvertFromUtf32(0x1F5D2)   # spiral notepad
 $script:OutlookIconParty    = [char]::ConvertFromUtf32(0x1F389)   # party popper
 $script:OutlookIconCheck    = [char]::ConvertFromUtf32(0x2705)    # check mark
+$script:OutlookIconWarning  = [char]::ConvertFromUtf32(0x26A0)    # warning sign
+
+# --- Day-section registry ---------------------------------------------------
+# External modules (Azure DevOps today; Jira / GitHub as trivial follow-ups)
+# register a section here; ol-Show-OutlookDay renders each one after its
+# built-in agenda + tasks, in Order. Mirrors the $script:TimerIntegrations
+# pattern from pow_timer.ps1 — the Outlook module never references az-* symbols,
+# so neither module hard-depends on the other. Registering only appends to this
+# collection: no cache reads, no callouts at source time.
+$script:OutlookDaySections = @()
 
 
 function Get-OutlookComApplication {
@@ -338,12 +348,66 @@ function ol-Show-OutlookTasks {
 }
 
 
-function ol-Show-OutlookDay {
-    # Composed day view: today's meetings, then the tasks to work on. Both
-    # sections delegate to their own ol-Get-/ol-Show- pair.
+function Register-OutlookDaySection {
+    # Registers (or replaces by Name) an external section that ol-Show-OutlookDay
+    # renders after its built-in agenda + tasks. Idempotent by Name so
+    # re-sourcing the profile swaps the entry in place rather than duplicating
+    # it. Render is a scriptblock that prints the section body; it runs only when
+    # the day view runs, never at registration time.
     [CmdletBinding()]
     param(
-        [datetime] $Date = (Get-Date)
+        [Parameter(Mandatory)] [string]      $Name,
+        [Parameter(Mandatory)] [int]         $Order,
+        [Parameter(Mandatory)] [scriptblock] $Render
+    )
+
+    $entry = [PSCustomObject]@{
+        Name   = $Name
+        Order  = $Order
+        Render = $Render
+    }
+
+    $existing = @($script:OutlookDaySections | Where-Object { $_.Name -eq $Name })
+    if ($existing.Count -gt 0) {
+        $script:OutlookDaySections = @($script:OutlookDaySections | Where-Object { $_.Name -ne $Name })
+    }
+
+    $script:OutlookDaySections = @($script:OutlookDaySections) + $entry
+}
+
+
+function Invoke-OutlookDaySections {
+    # Private. Renders every registered external day section in Order (then Name
+    # for a stable tie-break), each behind a try/catch so a failing section
+    # prints a yellow hint and never aborts the rest of the day view. Prints the
+    # section's Name as a Cyan header — the same shape the built-in agenda /
+    # tasks sections use — then invokes its Render body.
+    $sections = @($script:OutlookDaySections | Sort-Object Order, Name)
+
+    foreach ($section in $sections) {
+        Write-Host ""
+        Write-Host $section.Name -ForegroundColor Cyan
+
+        try {
+            & $section.Render
+        }
+        catch {
+            Write-Host "$script:OutlookIconWarning section '$($section.Name)' failed: $_" -ForegroundColor Yellow
+        }
+    }
+}
+
+
+function ol-Show-OutlookDay {
+    # Composed day view: today's meetings, then the tasks to work on, then any
+    # externally-registered sections (e.g. Azure DevOps assigned work). The
+    # built-in sections delegate to their own ol-Get-/ol-Show- pair;
+    # -NoWorkItems suppresses the registered external sections while keeping the
+    # agenda + tasks.
+    [CmdletBinding()]
+    param(
+        [datetime] $Date = (Get-Date),
+        [switch]   $NoWorkItems
     )
 
     $application = Get-OutlookComApplication
@@ -361,6 +425,10 @@ function ol-Show-OutlookDay {
     Write-Host "$script:OutlookIconTasks To work on today" -ForegroundColor Cyan
 
     ol-Show-OutlookTasks -Date $Date
+
+    if (-not $NoWorkItems) {
+        Invoke-OutlookDaySections
+    }
 }
 
 

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -70,6 +70,15 @@ if ($azdevops_sync -ne $NULL) {
     Write-Host "no azdevops_sync.ps1"
 }
 
+# Loaded before azdevops_views.ps1 so its $script:OutlookDaySections registry +
+# Register-OutlookDaySection exist when the AzDO area registers its day section.
+$outlook_agenda = Get-Content "$path_to_bashcuts\powcuts_by_cli\outlook_agenda.ps1"
+if ($outlook_agenda -ne $NULL) {
+ . "$path_to_bashcuts\powcuts_by_cli\outlook_agenda.ps1"
+} else {
+    Write-Host "no outlook_agenda.ps1"
+}
+
 $azdevops_views = Get-Content "$path_to_bashcuts\powcuts_by_cli\azdevops_views.ps1"
 if ($azdevops_views -ne $NULL) {
  . "$path_to_bashcuts\powcuts_by_cli\azdevops_views.ps1"
@@ -166,13 +175,6 @@ if ($azdevops_help -ne $NULL) {
  . "$path_to_bashcuts\powcuts_by_cli\azdevops_help.ps1"
 } else {
     Write-Host "no azdevops_help.ps1"
-}
-
-$outlook_agenda = Get-Content "$path_to_bashcuts\powcuts_by_cli\outlook_agenda.ps1"
-if ($outlook_agenda -ne $NULL) {
- . "$path_to_bashcuts\powcuts_by_cli\outlook_agenda.ps1"
-} else {
-    Write-Host "no outlook_agenda.ps1"
 }
 
 # On shell open: silently refresh the Azure DevOps cache in the background when


### PR DESCRIPTION

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #180 |
| [Changes](#changes) | ✅ 5 files |
| [Test Plan](#test-plan) | 0/5 |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4972706045) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4972720222) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4972716010) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4972722265) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4972744219) |

<!-- pr-diagram:start -->
## How it works

`ol-Show-OutlookDay` prints the built-in agenda + tasks, then (unless `-NoWorkItems`) fans out through `Invoke-OutlookDaySections` to every registered section. The Azure DevOps module registers its `Azure DevOps` section into that registry at load time — guarded on `Register-OutlookDaySection` actually resolving — so the two modules stay decoupled. When invoked, the section renders a **cache-only** today-slice: current-iteration active assigned items, priority-sorted, with no live `az` callout.

```mermaid
flowchart TD
    Entry([ol-Show-OutlookDay]):::pub
    Builtin["built-in agenda + tasks<br/>(ol-Show-OutlookAgenda / ol-Show-OutlookTasks)"]
    GateNWI{-NoWorkItems?}
    Invoke[Invoke-OutlookDaySections]:::priv
    Registry[(OutlookDaySections registry)]:::io
    Register([Register-OutlookDaySection]):::pub
    GuardGate{Register-OutlookDaySection<br/>resolves?}
    Section["Azure DevOps section"]
    Show[Show-AzDevOpsDaySection]:::priv
    GateCache{assigned cache<br/>present?}
    Rows[Get-AzDevOpsDayViewRows]:::priv
    Assigned[Read-AzDevOpsAssignedCache]:::io
    Resolve[Resolve-AzDevOpsCurrentIterationFromCache]:::priv
    Select[Select-AzDevOpsCurrentIterationRow]:::priv
    ClassCache[(classification cache)]:::io
    Sort[Sort-AzDevOpsByPriority]:::priv
    Done([Format-Table today-slice])

    Entry --> Builtin
    Entry --> GateNWI
    GateNWI -- yes --> Done
    GateNWI -- no --> Invoke
    Invoke --> Registry --> Section --> Show

    GuardGate -- yes --> Register -.registers.-> Registry

    Show --> GateCache
    GateCache -- absent --> Done
    GateCache -- present --> Rows
    Rows --> Assigned
    Rows --> Resolve --> Select
    Resolve --> ClassCache
    Rows --> Sort
    Sort --> Done

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Adds a **day-section registry** to the Outlook module (`ol-`) and registers a guarded **🎯 Azure DevOps** section into `ol-Show-OutlookDay`, so one terminal command shows meetings, Outlook tasks, **and** your active Azure DevOps assigned work together. The Outlook module never references `az-*` symbols directly — the coupling is entirely through the registry, mirroring the `$script:TimerIntegrations` pattern.

## Issue

Closes #180

## Changes

- **`powcuts_by_cli/outlook_agenda.ps1`**
  - `$script:OutlookDaySections` + `Register-OutlookDaySection` (idempotent by `Name`)
  - `Invoke-OutlookDaySections` — renders each registered section in `Order` behind a `try/catch` so a failing section prints a yellow hint and never aborts the day view
  - `-NoWorkItems` switch on `ol-Show-OutlookDay` suppresses registered sections (built-in agenda/tasks always show)
- **`powcuts_by_cli/azdevops_views.ps1`**
  - Guarded registration (only when `Register-OutlookDaySection` resolves) of the 🎯 Azure DevOps section
  - Today-slice renderer: active assigned items in the current iteration (falls back to all-active), sorted by `Priority` asc then `AssignedAt` desc, printing `Id / Type / State / Priority / Title / Iteration`
  - **Read-only / cache-only** — current-iteration resolve reads the classification cache directly (no live `az` fallback), so the day view never triggers a callout or auth prompt
  - Single dim hint when the cache is absent, friendly `No active work items 🎉` when nothing matches, stale banner via the existing `Write-AzDevOpsStaleBanner` path
  - Extracted `Select-AzDevOpsCurrentIterationRow` shared by the live + cache-only iteration resolvers
- **`powcuts_home.ps1`** — dot-sources `outlook_agenda.ps1` **before** `azdevops_views.ps1` so the registry exists when the AzDO area registers into it
- **`README.md`** — documents the auto-appearing section and `-NoWorkItems`

**Shell parity:** PowerShell-only — extends the PowerShell-only Outlook surface from #179; no bash counterpart.

## Test Plan

- [ ] Fresh **Windows** pwsh with Outlook + a synced AzDO cache: `ol-day` shows meetings, tasks, then a **🎯 Azure DevOps** section of current-iteration assigned items sorted by priority
- [ ] `ol-Show-OutlookDay -NoWorkItems` hides the AzDO section; agenda + tasks still show
- [ ] Machine **without** the `az-*` shortcuts: day view works, section simply absent (no error)
- [ ] Cache missing → single dim `Azure DevOps cache not found — run az-Sync-AzDevOpsCache` hint; no active items → `No active work items 🎉`
- [ ] `pwsh -NoProfile` parses `outlook_agenda.ps1`, `azdevops_views.ps1`, `powcuts_home.ps1` with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VApKGjCzSu7v1KjQZAdARs)_