### PR TITLE
Daily Viewer: HTML mock foundation + front-end review gate + refactor (#190)

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,20 +1,21 @@
 ---
 name: code-review
-description: Quad code review — senior bash engineer, senior PowerShell engineer, senior security engineer, and senior clean-code engineer run in parallel against the current branch's changes.
+description: Quint code review — senior bash engineer, senior PowerShell engineer, senior security engineer, senior clean-code engineer, and senior front-end engineer run in parallel against the current branch's changes.
 ---
 
-## Quad Review — Four Reviewers in Parallel
+## Quint Review — Five Reviewers in Parallel
 
-This skill runs **four independent code reviews in parallel** using the Agent tool:
+This skill runs **five independent code reviews in parallel** using the Agent tool:
 
 1. **Senior Bash Engineer** — invoke `/senior-bash-engineer`
 2. **Senior PowerShell Engineer** — invoke `/senior-powershell-engineer`
 3. **Senior Security Engineer** — invoke `/security-review` (built-in)
 4. **Senior Clean-Code Engineer** — invoke `/senior-clean-code-engineer` (duplication, function shape, abstraction debt; enforces CLAUDE.md's extract-repeated-branches + breathing-room rules)
+5. **Senior Front-End Engineer** — invoke `/senior-frontend-engineer` (semantic HTML + accessibility, CSS token/specificity/unit hygiene, data-driven rendering, untrusted-data escaping; owns the `daily-viewer/` web surface)
 
-Launch all four as parallel agents. Each independently determines changed files, reads them, and produces its own report. After all complete, present the four reports sequentially — bash first, then PowerShell, then security, then clean-code.
+Launch all five as parallel agents. Each independently determines changed files, reads them, and produces its own report. After all complete, present the five reports sequentially — bash, PowerShell, security, clean-code, then front-end.
 
-**PR comments:** If a PR exists, each review posts its own comment to the PR — four separate comments, clearly labeled with `## 🐚`, `## 💠`, `## 🛡️`, and `## 🧼` headings.
+**PR comments:** If a PR exists, each review posts its own comment to the PR — five separate comments, clearly labeled with `## 🐚`, `## 💠`, `## 🛡️`, `## 🧼`, and `## 🎨` headings.
 
 ---
 
@@ -44,10 +45,11 @@ Categorize the changed files:
 |---|---|
 | `bashcuts_by_cli/*`, `.bcut_home` | Senior Bash Engineer + Senior Clean-Code Engineer |
 | `powcuts_by_cli/*.ps1`, `powcuts_home.ps1` | Senior PowerShell Engineer + Senior Clean-Code Engineer |
+| `daily-viewer/*`, `*.html`, `*.css`, `*.js` | Senior Front-End Engineer (+ Senior PowerShell Engineer for the backend `.ps1`) |
 | `vscode_snippets/*` | (no reviewer; flag for security only) |
 | `README.md` | (no reviewer; flag for `/docs-check`) |
 
-If only one shell's files changed, the other language reviewer will return early with `APPROVE — no <shell> files in this diff`. The clean-code engineer reviews any shell file. That's expected and not a problem.
+Each reviewer returns early with `APPROVE — no <kind> files in this diff` when its files aren't touched (e.g. the front-end engineer on a pure-PowerShell diff, or the bash engineer when only `daily-viewer/` changed). The clean-code and security engineers review broadly. That's expected and not a problem.
 
 ---
 
@@ -63,13 +65,15 @@ Send a single message with four Agent tool calls. For each, pass enough context 
 
 4. **Clean-Code Engineer Agent** — task: "Run the `/senior-clean-code-engineer` review on the current branch's diff against `main`. Read the skill at `.claude/commands/senior-clean-code-engineer.md` and follow it. Focus on duplicated branches across functions, oversized functions, parallel function pairs sharing scaffolding, magic numbers, and the named CLAUDE.md extract-repeated-branches + breathing-room rules. Post the result to the PR if one exists."
 
-Wait for all four to complete before continuing.
+5. **Front-End Engineer Agent** — task: "Run the `/senior-frontend-engineer` review on the current branch's diff against `main`. Read the skill at `.claude/commands/senior-frontend-engineer.md` and follow it. Focus on the `daily-viewer/` web surface: untrusted-data escaping (XSS via innerHTML), semantic HTML + accessibility, CSS token/specificity/unit hygiene, data-driven rendering vs hardcoded markup, CSP-hostile patterns, and secrets never reaching the browser. Post the result to the PR if one exists."
+
+Wait for all five to complete before continuing.
 
 ---
 
 ## Aggregate the Reports
 
-Present the four reports sequentially in the user-facing summary:
+Present the five reports sequentially in the user-facing summary:
 
 ```
 ## 🐚 Senior Bash Engineer
@@ -89,6 +93,11 @@ Present the four reports sequentially in the user-facing summary:
 
 ## 🧼 Senior Clean-Code Engineer
 <report from agent 4>
+
+---
+
+## 🎨 Senior Front-End Engineer
+<report from agent 5>
 ```
 
 Then output a combined verdict:
@@ -102,9 +111,10 @@ Then output a combined verdict:
 | 💠 PowerShell Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
 | 🛡️ Security Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
 | 🧼 Clean-Code Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
+| 🎨 Front-End Engineer | ✅ APPROVE / ❌ REQUEST CHANGES (N issues) |
 
 ### Overall
-✅ APPROVE — all four reviewers passed
+✅ APPROVE — all five reviewers passed
   OR
 ❌ REQUEST CHANGES — <list blocking findings, grouped by reviewer>
 ```
@@ -113,4 +123,4 @@ Then output a combined verdict:
 
 ## Update PR Body ToC
 
-After all four reviewers have posted their comments to the PR, run `/pr-body` to refresh the table of contents so reviewers can navigate to each report from the PR body.
+After all five reviewers have posted their comments to the PR, run `/pr-body` to refresh the table of contents so reviewers can navigate to each report from the PR body.

--- a/.claude/commands/senior-frontend-engineer.md
+++ b/.claude/commands/senior-frontend-engineer.md
@@ -1,0 +1,182 @@
+---
+name: senior-frontend-engineer
+description: Senior front-end engineer review — semantic HTML + accessibility, CSS token/specificity/unit hygiene, data-driven rendering vs hardcoded markup, untrusted-data escaping (XSS), and progressive enhancement across changed HTML/CSS/JS files (the daily-viewer/ surface).
+---
+
+You are a **senior front-end engineer** reviewing changes to bashcuts' web surface — today that is `daily-viewer/` (the Azure DevOps daily viewer: an HTML page that renders from a local cache and, in the live build, is served on `127.0.0.1` by a PowerShell backend). The bash and PowerShell engineers cover shell idioms; the clean-code engineer covers factoring; the security engineer covers attack surface broadly. **You cover whether the browser-facing code is semantic, accessible, well-structured, and safe with untrusted data.**
+
+CLAUDE.md is the source of truth for project conventions. The **Front-End Conventions (daily-viewer/)** section is squarely yours — enforce every rule in it, plus the checks below.
+
+---
+
+## Determine Changed Files
+
+```bash
+git diff main...HEAD --name-only 2>/dev/null \
+  | grep -E "^daily-viewer/|\.html$|\.css$|\.(m?js)$" \
+  || git diff HEAD~1 --name-only \
+       | grep -E "^daily-viewer/|\.html$|\.css$|\.(m?js)$"
+```
+
+If no front-end files changed, skip with verdict `APPROVE — no front-end files in this diff`.
+
+Read each changed file in full. For a single-file mock (inline `<style>`/`<script>`), read the whole document — structure, styles, and behavior all live together.
+
+---
+
+## Check 1 — Untrusted Data → XSS [HIGH]
+
+Azure DevOps titles, discussion text, display names, and area/iteration paths are **user-entered**. The moment the view injects them, escaping is mandatory.
+
+```bash
+git diff main...HEAD -- 'daily-viewer/*' | grep -E "^\+" | grep -v "^+++" \
+  | grep -E "innerHTML|insertAdjacentHTML|outerHTML|document\.write|\.html\(" || true
+```
+
+**Flag [HIGH]** any construction that puts dynamic/cached data into the DOM as **markup** rather than **text**:
+- `el.innerHTML = "…" + item.title` — the classic hole.
+- Template strings interpolating cached fields into an HTML string that is then `innerHTML`-ed.
+- A `<template>` clone whose slots are filled with `innerHTML` instead of `textContent`.
+
+The fix is always the same: build with `textContent` / `createElement` / `.setAttribute`, or a templater that escapes by default. Static literal markup (no interpolation) is fine. This is the one review item that must block merge.
+
+---
+
+## Check 2 — Semantic HTML & Accessibility [HIGH for a11y regressions, else MEDIUM]
+
+The page is operated as much as read. Structure must carry meaning.
+
+Look for:
+- **Non-semantic interactive elements** — `<div onclick>` / `<span role="button">` where a `<button>` belongs. Collapsibles should be `<details>/<summary>` (native keyboard + `aria-expanded`), not JS-toggled divs.
+- **Missing landmarks** — no `<main>`, tiles not wrapped in `<section aria-labelledby>`, toolbar not a `<nav>`/`<header>`. Screen-reader users navigate by landmarks.
+- **Lists that aren't lists** — repeated item rows built as sibling `<div>`s instead of `<ul><li>`.
+- **Machine-unreadable data** — meeting times as plain text instead of `<time datetime="…">`.
+- **Icon-only controls without `aria-label`**; decorative SVGs without `aria-hidden="true"`.
+- **No async status announcement** — a refresh that flips "cached 5m ago" → "cached just now" with no `aria-live="polite"` region is silent to a screen reader.
+- **Focus**: interactive elements must have a visible `:focus-visible` state; nothing should trap or lose focus on collapse/expand.
+- **Motion**: any animation must sit under `@media (prefers-reduced-motion: reduce)`.
+
+```bash
+git diff main...HEAD -- 'daily-viewer/*' | grep -E "^\+" | grep -v "^+++" \
+  | grep -E "onclick=|role=\"button\"|<div[^>]*tabindex|innerHTML" || true
+```
+
+**Flag [HIGH]** a regression that removes keyboard operability or an existing landmark/aria hook; **[MEDIUM]** for missing-but-additive semantics (lists, `<time>`, live region) on new markup.
+
+---
+
+## Check 3 — Data-Driven Rendering vs Hardcoded Markup [MEDIUM]
+
+The view should be a **function of data**, not hand-authored per item. Hardcoded rows are duplication and drift.
+
+Tell-tales:
+- The same work-item / event row structure copy-pasted 3+ times with only the text differing.
+- A count/badge (`<span>6</span>`) that is a **literal** rather than derived from the length of the collection it summarizes — two literals for the same quantity (e.g. a stat-strip number and a tile count) **will** drift.
+- New static rows added to a tile that already has an obvious "list of items" shape.
+
+**Flag [MEDIUM]**: propose the render function or `<template>` + `.map()` that replaces the duplicated markup, and point out any count that should be `items.length`. (During the pure-mock phase, hardcoded content is acceptable — note it as "expected for the mock; convert when data-binding lands" rather than blocking.)
+
+---
+
+## Check 4 — CSS Tokens, Theming & Specificity [MEDIUM]
+
+CLAUDE.md mandates token-based design and dual-theme support.
+
+- **Tokens**: colors, spacing, and type sizes go through CSS custom properties. A raw hex or a bare `14px` padding scattered in a rule (instead of `var(--…)`) is a smell once a token scale exists.
+- **Theming**: light/dark must redefine **only the tokens** (`:root`, `@media (prefers-color-scheme: dark)`, `:root[data-theme=…]`). A component that hardcodes a color inside a theme block — instead of consuming a token — breaks the other theme.
+- **Specificity**: flag `#id` selectors used for **styling**, `!important`, and long descendant chains. Prefer single classes / `data-*` attributes.
+- **Units**: type and spacing in `rem` (scales with user font-size); `px` is fine for borders/hairlines. A wall of `px` font-sizes is an accessibility gap.
+
+```bash
+git diff main...HEAD -- 'daily-viewer/*' | grep -E "^\+" | grep -v "^+++" \
+  | grep -E "!important|^\+\s*#[a-zA-Z][\w-]*\s*\{|#[0-9a-fA-F]{3,8}\b" | head -40
+```
+
+**Flag [MEDIUM]** hardcoded colors inside theme blocks (breaks a theme) and `!important`; **[LOW]** ID-selector styling and px-for-type.
+
+---
+
+## Check 5 — CSP-Hostile Patterns [MEDIUM]
+
+The live app is served locally and should run under a strict Content-Security-Policy (no `unsafe-inline`). Anything that forces `unsafe-inline` or an external fetch is a finding for the real app.
+
+- **Inline event handlers** (`onclick=`, `onload=`) — must be `addEventListener`.
+- **Inline `style="…"`** attributes carrying anything dynamic.
+- **External resource references** — CDN `<script src>`, webfont `<link>`, remote `<img>` — the page must be self-contained / same-origin.
+
+**Flag [MEDIUM]** for the served app; **note (not block)** for the single-file mock/Artifact, where inline `<style>`/`<script>` is required by the Artifact CSP and is the established pattern.
+
+---
+
+## Check 6 — Progressive Enhancement & Framework Restraint [LOW]
+
+- Core content/collapse should degrade gracefully (the `<details>` tiles already work with JS disabled — don't replace them with a JS-only toggle).
+- At this scale (a handful of tiles), **vanilla JS + a render function is the target**. Flag the introduction of a heavyweight framework / build step that breaks the "opens instantly, no build" property unless the issue explicitly calls for it.
+- Flag speculative client-side state stores / routers for four tiles — premature.
+
+**Flag [LOW]**: over-engineering, or a regression in no-JS behavior.
+
+---
+
+## Check 7 — Secrets & Origin Boundary [HIGH if violated]
+
+The browser is untrusted. Secrets stay server-side.
+
+- **Flag [HIGH]** any Azure DevOps PAT, `az` token, connection string, or org secret appearing in HTML/JS/config shipped to the page.
+- The backend (when present in the diff) should bind to `127.0.0.1`/`localhost` only, not `0.0.0.0`. Flag a bind to all interfaces.
+
+```bash
+git diff main...HEAD -- 'daily-viewer/*' | grep -E "^\+" | grep -v "^+++" \
+  | grep -iE "pat|token|secret|password|0\.0\.0\.0|Authorization" || true
+```
+
+---
+
+## Output Format
+
+```
+## 🎨 Code Review — Senior Front-End Engineer
+
+### Summary
+<1–2 sentences: which files changed, overall shape, the headline a11y / XSS / structure issue if any>
+
+### Findings
+
+| Severity | Location | Issue |
+|----------|----------|-------|
+| [HIGH/MEDIUM/LOW] | file:line | description + concrete fix |
+
+### Accessibility Pass
+| Concern | Status |
+|---------|--------|
+| Semantic landmarks (main/section/nav) | OK / missing |
+| Keyboard operable (details/button, focus-visible) | OK / regressed |
+| Icon buttons labelled / decorative svg hidden | OK / gap |
+| Async status announced (aria-live) | OK / silent |
+| prefers-reduced-motion honored | OK / missing |
+
+### Verdict
+APPROVE — semantic, accessible, safe with untrusted data
+  OR
+REQUEST CHANGES — <N> HIGH findings (XSS via innerHTML, secret in the page, keyboard/landmark regression); fix before merge
+```
+
+---
+
+## Severity Calibration
+
+- **HIGH** — untrusted data injected as markup (XSS), a secret shipped to the browser, a backend bound to all interfaces, or a regression that removes keyboard operability / an existing accessibility hook. Block merge.
+- **MEDIUM** — hardcoded color that breaks a theme, `!important`, missing-but-additive semantics on new markup, hardcoded rows that should be data-driven, CSP-hostile inline handler in the served app.
+- **LOW** — ID-selector styling, px-for-type, breathing-room/naming nits, premature abstraction.
+
+Be honest about which is which. During the **mock phase**, inline CSS/JS and hardcoded placeholder content are expected — note them for the data-binding step, don't block on them. XSS, secrets, and keyboard regressions block in **every** phase.
+
+---
+
+## Post to PR (if a PR exists)
+
+```bash
+gh pr view --json number 2>/dev/null --jq '.number'
+```
+
+If a PR number is returned, post the report as a comment with the heading `## 🎨 Code Review — Senior Front-End Engineer`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,14 +199,58 @@ o-sfdx   o-git   o-gh   o-az   o-cci
 │   ├── azdevops_help.ps1               # az-help — guided walkthrough of az-AzDevOps* surface
 │   ├── pester.ps1                      # Pester test helpers
 │   └── jira_automations.ps1
-└── vscode_snippets/                    # VS Code snippets synced via VS Code Settings Sync
-    ├── Apex.code-snippets
-    ├── azure-cli.code-snippets
-    ├── lwc.code-snippets
-    └── powershell.code-snippets
+├── vscode_snippets/                    # VS Code snippets synced via VS Code Settings Sync
+│   ├── Apex.code-snippets
+│   ├── azure-cli.code-snippets
+│   ├── lwc.code-snippets
+│   └── powershell.code-snippets
+└── daily-viewer/                       # Azure DevOps daily viewer — localhost HTML app (front-end surface)
+    ├── index.html                      # Cache-backed 2x2 tile dashboard (mock → live)
+    └── wpf/                            # WPF prototype of the same viewer (reference; the HTML path is primary)
+        ├── DailyViewer.xaml
+        ├── Start-DailyViewer.ps1
+        └── README.md
 ```
 
 Note the asymmetric naming: bash files use a `.<cli>_bashcuts` dotfile pattern, PowerShell uses `<cli>.ps1`. Some bash files have no dedicated PowerShell counterpart and vice-versa (e.g. `.bash_commons` ↔ `pow_common.ps1`, `.support_bashcuts` has no pwsh equivalent). That's intentional — only enforce parity when the issue calls for it or when adding a new CLI wrapper.
+
+## Front-End Conventions (`daily-viewer/`)
+
+`daily-viewer/` is the one browser-facing surface in this repo: an HTML dashboard that renders the Azure DevOps daily agenda from a **local cache** and, in the live build, is served on `127.0.0.1` by a PowerShell backend. It is **operated, not read** — treat it as information design, and hold it to the rules below. `/senior-frontend-engineer` (part of `/code-review`) enforces them.
+
+The shell rules elsewhere in this file still apply in spirit — **match the surrounding style**, **breathing room**, **name your magic values**, **no self-evident comments**, **no premature abstraction**. These add to them for HTML/CSS/JS.
+
+### Security — the browser is untrusted (NO EXCEPTIONS)
+
+- **Escape untrusted data — never build markup from it.** Azure DevOps titles, discussion text, display names, and area/iteration paths are user-entered. Inject them with `textContent` / `createElement` / `setAttribute`, or a templater that escapes by default. **Never** `innerHTML = "…" + item.title` or `innerHTML` a template string with interpolated cached fields — that is the XSS hole this project is most likely to grow. Static literal markup (no interpolation) is fine.
+- **Secrets stay server-side.** No Azure DevOps PAT, `az` token, connection string, or org secret in HTML/JS/config shipped to the page. The token lives in the backend process only.
+- **Bind the local server to `127.0.0.1`/`localhost` only** — never `0.0.0.0`. The browser talks to a same-origin local endpoint; the endpoint holds the credentials.
+
+### Structure & accessibility
+
+- **Semantic first.** Collapsibles are `<details>/<summary>` (native keyboard + `aria-expanded`, works with JS off), not `<div onclick>`. Interactive things are `<button>`. Wrap the page in `<main>` and each tile in a `<section aria-labelledby>`; the toolbar is a `<header>`/`<nav>`. Repeated item rows are `<ul><li>`, not sibling `<div>`s. Meeting times are `<time datetime="…">`.
+- **Label the non-text.** Icon-only buttons get `aria-label`; decorative SVGs get `aria-hidden="true"`.
+- **Announce async change.** A refresh that flips "cached 5m ago" → "cached just now" updates an `aria-live="polite"` region so it isn't silent to a screen reader.
+- **Focus & motion.** Every interactive element has a visible `:focus-visible` state; all animation sits under `@media (prefers-reduced-motion: reduce)`.
+
+### CSS
+
+- **Design tokens via custom properties.** Colors, spacing, and type sizes go through `var(--…)`. Keep a spacing scale (`--space-1…`) — don't scatter ad-hoc `px` paddings.
+- **Theme by redefining tokens only.** Light/dark live in `:root`, `@media (prefers-color-scheme: dark)`, and `:root[data-theme="dark"|"light"]`, and they redefine **only the tokens**. A component that hardcodes a color inside a theme block breaks the other theme. Style both themes with equal care.
+- **`rem` for type and spacing** (scales with the user's font-size); `px` only for borders/hairlines.
+- **Low specificity.** Single classes or `data-*` attributes. No `#id` selectors for styling, no `!important`, no long descendant chains.
+
+### Structure of the code (MVC / separation of concerns)
+
+- **The view is a function of data.** Render tiles from a JS data model (a render function or `<template>` + `.map()`), not hand-authored per-item markup. A count/badge is derived (`items.length`), never a second literal that can drift from the list it summarizes.
+- **Model / View / Controller stay separate.** Model = the cached JSON (+ staleness rules); View = the render layer; Controller = event handlers + the thin local API. Keep the **cheap cache-read** path distinct from the **expensive per-tile refresh** (the `az`/Outlook call) — that split is the whole point of the cache.
+- **CSP-friendly in the served app.** No inline `onclick=`/`style=` (use `addEventListener`), no CDN scripts or webfont links — self-contained / same-origin so the page runs under a strict CSP with no `unsafe-inline`. **Exception:** the single-file mock (`index.html`) and any Artifact preview keep inline `<style>`/`<script>` — that's required by the Artifact CSP and is the established pattern for the mock phase.
+- **Vanilla JS, no framework.** At this scale (a handful of tiles) a render function plus one small state object beats React/Vue and keeps the "opens instantly, no build step" property. Don't add a framework, client router, or state store unless an issue explicitly calls for it — that's premature abstraction.
+- **Progressive enhancement.** Core content and collapse degrade gracefully (the `<details>` tiles already work with JS disabled — don't replace them with a JS-only toggle).
+
+### Externalize when it goes live
+
+The mock is one self-contained `index.html` (fine, and required for Artifact preview). When it becomes a served app, split linked `styles.css` + `app.js` (browser caching, strict CSP, separately testable render functions). Backend `.ps1` under `daily-viewer/` follows the PowerShell rules above and is reviewed by both `/senior-powershell-engineer` and `/senior-frontend-engineer`.
 
 ## Architecture Patterns
 
@@ -291,10 +335,11 @@ This repo defines its own Claude Code slash commands:
 | `/criteria-check` | Verifies issue acceptance criteria against the code |
 | `/docs-check` | Audits README + sourcing wire-up |
 | `/azdevops-diagrams-check` | When AzDO source files change, verifies `docs/azure-devops-diagrams.md` is in sync and proposes targeted mermaid edits |
-| `/code-review` | Runs `senior-bash-engineer` + `senior-powershell-engineer` + `/security-review` + `senior-clean-code-engineer` in parallel |
+| `/code-review` | Runs `senior-bash-engineer` + `senior-powershell-engineer` + `/security-review` + `senior-clean-code-engineer` + `senior-frontend-engineer` in parallel |
 | `/senior-bash-engineer` | Solo bash review (called by `/code-review`) |
 | `/senior-powershell-engineer` | Solo PowerShell review (called by `/code-review`) |
 | `/senior-clean-code-engineer` | Solo clean-code review — duplication, function shape, abstraction debt; enforces CLAUDE.md's extract-repeated-branches + breathing-room rules (called by `/code-review`) |
+| `/senior-frontend-engineer` | Solo front-end review — semantic HTML + a11y, CSS token/specificity/unit hygiene, data-driven rendering, untrusted-data escaping (XSS); owns the `daily-viewer/` web surface (called by `/code-review`) |
 | `/pr-body` | Builds / refreshes the PR body table of contents |
 | `/pr-flow` | Full pipeline: parse-checks → commit → push → PR → code-review → docs-check → criteria-check → azdevops-diagrams-check → pr-body |
 

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -98,8 +98,8 @@ function currentTheme() {
 
 function paintThemeIcon() {
   var dark = currentTheme() === "dark";
-  iconMoon.style.display = dark ? "block" : "none";
-  iconSun.style.display = dark ? "none" : "block";
+  iconMoon.classList.toggle("is-hidden", !dark);
+  iconSun.classList.toggle("is-hidden", dark);
 }
 
 document.getElementById("themeToggle").addEventListener("click", function () {

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -1,0 +1,171 @@
+"use strict";
+
+// Behavior for the daily viewer. Content is still hardcoded in index.html
+// (data-driven rendering lands separately); this wires the controls only.
+
+// Named liveRegion, not `status`: a top-level `var status` in a classic script
+// aliases the built-in window.status string and breaks assignment under strict mode.
+var liveRegion = document.getElementById("sr-status");
+
+function announce(message) {
+  if (liveRegion) {
+    liveRegion.textContent = message;
+  }
+}
+
+
+document.getElementById("expandAll").addEventListener("click", function () {
+  document.querySelectorAll("details").forEach(function (d) { d.open = true; });
+});
+
+document.getElementById("collapseAll").addEventListener("click", function () {
+  document.querySelectorAll(".tile > details").forEach(function (d) { d.open = false; });
+});
+
+
+// Per-tile refresh: the only expensive path. Cheap render is already on screen
+// from cache; this is where the real build would fire that tile's az CLI calls.
+var REFRESH_MS = 900;
+
+function tileNameFromButton(btn) {
+  var label = btn.getAttribute("aria-label") || "This tile";
+  var name = label.replace(/^Refresh\s+/, "");
+  return name;
+}
+
+function refreshTile(btn) {
+  if (btn.disabled) return;
+
+  var stale = btn.parentElement.querySelector(".stale");
+  var label = stale.childNodes[stale.childNodes.length - 1];
+  var name = tileNameFromButton(btn);
+
+  btn.disabled = true;
+  btn.classList.add("spinning");
+  stale.classList.remove("warn");
+  stale.classList.add("busy");
+  label.textContent = "refreshing…";
+  announce("Refreshing " + name + "…");
+
+  window.setTimeout(function () {
+    btn.classList.remove("spinning");
+    btn.disabled = false;
+    stale.classList.remove("busy");
+    label.textContent = "cached just now";
+    announce(name + " updated — cached just now.");
+  }, REFRESH_MS);
+}
+
+document.querySelectorAll(".refresh-btn").forEach(function (btn) {
+  btn.addEventListener("click", function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    refreshTile(btn);
+  });
+});
+
+document.getElementById("refreshAll").addEventListener("click", function () {
+  document.querySelectorAll(".refresh-btn").forEach(refreshTile);
+});
+
+
+// Stat strip: open and scroll to the tile a stat summarizes.
+document.querySelectorAll(".stat").forEach(function (stat) {
+  stat.addEventListener("click", function () {
+    var tile = document.getElementById(stat.dataset.target);
+    if (!tile) return;
+
+    var details = tile.querySelector("details");
+    if (details) {
+      details.open = true;
+    }
+
+    tile.scrollIntoView({ behavior: "smooth", block: "start" });
+  });
+});
+
+
+// Theme toggle: stamp data-theme on <html> so it overrides the OS media query.
+var root = document.documentElement;
+var iconSun = document.getElementById("icon-sun");
+var iconMoon = document.getElementById("icon-moon");
+
+function currentTheme() {
+  var t = root.getAttribute("data-theme");
+  if (t) return t;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function paintThemeIcon() {
+  var dark = currentTheme() === "dark";
+  iconMoon.style.display = dark ? "block" : "none";
+  iconSun.style.display = dark ? "none" : "block";
+}
+
+document.getElementById("themeToggle").addEventListener("click", function () {
+  var next = currentTheme() === "dark" ? "light" : "dark";
+  root.setAttribute("data-theme", next);
+  paintThemeIcon();
+  announce(next === "dark" ? "Dark theme." : "Light theme.");
+});
+
+paintThemeIcon();
+
+
+// Live filter across every work-item and event row. Remembers each tile's
+// open/closed state so clearing the box restores the original layout.
+var allDetails = document.querySelectorAll("details");
+allDetails.forEach(function (d) { d.dataset.open0 = d.open ? "1" : "0"; });
+
+document.querySelectorAll(".tile .body").forEach(function (body) {
+  var note = document.createElement("p");
+  note.className = "nomatch";
+  note.textContent = "No matching items in this tile.";
+  body.appendChild(note);
+});
+
+function applyFilter(raw) {
+  var q = raw.trim().toLowerCase();
+
+  if (q) {
+    allDetails.forEach(function (d) { d.open = true; });
+  } else {
+    allDetails.forEach(function (d) { d.open = d.dataset.open0 === "1"; });
+  }
+
+  var matchTotal = 0;
+
+  document.querySelectorAll(".tile").forEach(function (tile) {
+    var rows = tile.querySelectorAll(".wi, .event");
+    var anyVisible = false;
+
+    rows.forEach(function (row) {
+      var match = !q || row.textContent.toLowerCase().indexOf(q) !== -1;
+      row.classList.toggle("hide", !match);
+      if (match) {
+        anyVisible = true;
+        matchTotal++;
+      }
+    });
+
+    tile.querySelectorAll(".group").forEach(function (group) {
+      var visible = group.querySelectorAll(".wi:not(.hide), .event:not(.hide)").length;
+      group.classList.toggle("hide", !!q && visible === 0);
+    });
+
+    tile.classList.toggle("empty", !!q && !anyVisible);
+  });
+
+  if (q) {
+    announce(matchTotal + (matchTotal === 1 ? " item matches." : " items match."));
+  }
+}
+
+var searchBox = document.getElementById("search");
+searchBox.addEventListener("input", function () { applyFilter(searchBox.value); });
+searchBox.addEventListener("keydown", function (e) {
+  if (e.key === "Escape") {
+    searchBox.value = "";
+    applyFilter("");
+  }
+});

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -4,503 +4,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Daily Viewer — Azure DevOps Agenda</title>
-<style>
-  :root {
-    --bg: #EEF1F6;
-    --surface: #FFFFFF;
-    --surface-2: #F5F7FA;
-    --border: #DCE2EC;
-    --border-strong: #C6CFDC;
-    --text: #1B2430;
-    --text-dim: #5A6675;
-    --text-faint: #8A94A3;
-    --accent: #0E6FCE;
-    --accent-weak: rgba(14,111,206,.10);
-
-    --epic:    #C77700;
-    --feature: #7B49D6;
-    --story:   #1E86BE;
-    --bug:     #D1373A;
-    --task:    #2C9E43;
-
-    --good: #2C9E43;
-    --warn: #B5820A;
-    --crit: #D1373A;
-
-    --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);
-    --radius: 12px;
-
-    --font: "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
-    --mono: "Cascadia Code", "Cascadia Mono", Consolas, "SF Mono", ui-monospace, monospace;
-
-    color-scheme: light;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #0F131A;
-      --surface: #171C25;
-      --surface-2: #1E2531;
-      --border: #29313D;
-      --border-strong: #38424F;
-      --text: #E7ECF3;
-      --text-dim: #97A3B4;
-      --text-faint: #6C7889;
-      --accent: #4AA3F0;
-      --accent-weak: rgba(74,163,240,.14);
-
-      --epic:    #E8A317;
-      --feature: #A47CF0;
-      --story:   #3FB4E8;
-      --bug:     #E5645F;
-      --task:    #4FBF63;
-
-      --good: #4FBF63;
-      --warn: #D9A521;
-      --crit: #E5645F;
-
-      --shadow: 0 1px 2px rgba(0,0,0,.30), 0 8px 24px rgba(0,0,0,.30);
-      color-scheme: dark;
-    }
-  }
-
-  :root[data-theme="dark"] {
-    --bg: #0F131A;
-    --surface: #171C25;
-    --surface-2: #1E2531;
-    --border: #29313D;
-    --border-strong: #38424F;
-    --text: #E7ECF3;
-    --text-dim: #97A3B4;
-    --text-faint: #6C7889;
-    --accent: #4AA3F0;
-    --accent-weak: rgba(74,163,240,.14);
-    --epic: #E8A317; --feature: #A47CF0; --story: #3FB4E8; --bug: #E5645F; --task: #4FBF63;
-    --good: #4FBF63; --warn: #D9A521; --crit: #E5645F;
-    --shadow: 0 1px 2px rgba(0,0,0,.30), 0 8px 24px rgba(0,0,0,.30);
-    color-scheme: dark;
-  }
-  :root[data-theme="light"] {
-    --bg: #EEF1F6;
-    --surface: #FFFFFF;
-    --surface-2: #F5F7FA;
-    --border: #DCE2EC;
-    --border-strong: #C6CFDC;
-    --text: #1B2430;
-    --text-dim: #5A6675;
-    --text-faint: #8A94A3;
-    --accent: #0E6FCE;
-    --accent-weak: rgba(14,111,206,.10);
-    --epic: #C77700; --feature: #7B49D6; --story: #1E86BE; --bug: #D1373A; --task: #2C9E43;
-    --good: #2C9E43; --warn: #B5820A; --crit: #D1373A;
-    --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);
-    color-scheme: light;
-  }
-
-  * { box-sizing: border-box; }
-
-  body {
-    margin: 0;
-    background: var(--bg);
-    color: var(--text);
-    font-family: var(--font);
-    font-size: 15px;
-    line-height: 1.5;
-    -webkit-font-smoothing: antialiased;
-  }
-
-  a { color: var(--accent); text-decoration: none; }
-  a:hover { text-decoration: underline; }
-  a:focus-visible,
-  summary:focus-visible,
-  button:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-    border-radius: 6px;
-  }
-
-  .wrap {
-    max-width: 1180px;
-    margin: 0 auto;
-    padding: 22px 24px 56px;
-  }
-
-  /* ---------- top bar ---------- */
-  .topbar {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 18px;
-    flex-wrap: wrap;
-    padding-bottom: 18px;
-    margin-bottom: 22px;
-    border-bottom: 1px solid var(--border);
-  }
-  .brand h1 {
-    margin: 0;
-    font-size: 22px;
-    font-weight: 650;
-    letter-spacing: -.01em;
-  }
-  .brand .sub {
-    margin-top: 3px;
-    color: var(--text-dim);
-    font-size: 13px;
-  }
-  .brand .date {
-    color: var(--accent);
-    font-weight: 600;
-  }
-
-  .toolbar {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-  }
-  .synced {
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    font-size: 12.5px;
-    color: var(--text-dim);
-    background: var(--surface);
-    border: 1px solid var(--border);
-    padding: 6px 11px;
-    border-radius: 999px;
-  }
-  .synced .dot {
-    width: 8px; height: 8px; border-radius: 50%;
-    background: var(--good);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--good) 22%, transparent);
-  }
-  .btn {
-    font-family: inherit;
-    font-size: 12.5px;
-    color: var(--text-dim);
-    background: var(--surface);
-    border: 1px solid var(--border);
-    padding: 6px 12px;
-    border-radius: 8px;
-    cursor: pointer;
-  }
-  .btn:hover { color: var(--text); border-color: var(--border-strong); }
-  .btn.icon { padding: 6px 8px; display: inline-flex; align-items: center; }
-  .btn.icon svg { width: 15px; height: 15px; }
-
-  .search {
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 5px 10px;
-  }
-  .search:focus-within { border-color: var(--accent); }
-  .search svg { width: 14px; height: 14px; color: var(--text-faint); flex: none; }
-  .search input {
-    border: 0; background: transparent; outline: none;
-    font-family: inherit; font-size: 13px; color: var(--text);
-    width: 148px;
-  }
-  .search input::placeholder { color: var(--text-faint); }
-
-  /* ---------- summary stat strip ---------- */
-  .stats {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 12px;
-    margin-bottom: 20px;
-  }
-  @media (max-width: 820px) { .stats { grid-template-columns: repeat(2, 1fr); } }
-  .stat {
-    font-family: inherit;
-    text-align: left;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    padding: 12px 14px;
-    cursor: pointer;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-  }
-  .stat:hover { border-color: var(--border-strong); box-shadow: var(--shadow); }
-  .stat .n {
-    font-size: 23px;
-    font-weight: 680;
-    line-height: 1;
-    font-variant-numeric: tabular-nums;
-    color: var(--stat, var(--text));
-  }
-  .stat .l { font-size: 12px; color: var(--text-dim); }
-  .stat.a { --stat: var(--accent); }
-  .stat.f { --stat: var(--feature); }
-  .stat.s { --stat: var(--story); }
-  .stat.g { --stat: var(--warn); }
-
-  /* ---------- grid ---------- */
-  .grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 18px;
-  }
-  @media (max-width: 820px) {
-    .grid { grid-template-columns: 1fr; }
-  }
-
-  /* ---------- tile ---------- */
-  .tile {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    box-shadow: var(--shadow);
-    overflow: hidden;
-  }
-  .tile > summary {
-    list-style: none;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 11px;
-    padding: 15px 18px;
-    user-select: none;
-  }
-  .tile > summary::-webkit-details-marker { display: none; }
-  .tile > summary:hover { background: var(--surface-2); }
-
-  .chev {
-    flex: none;
-    width: 16px; height: 16px;
-    color: var(--text-faint);
-    transition: transform .18s ease;
-  }
-  details[open] > summary > .chev { transform: rotate(90deg); }
-
-  .tile .tt {
-    display: flex;
-    align-items: center;
-    gap: 9px;
-    flex: 1;
-    min-width: 0;
-  }
-  .ticon {
-    flex: none;
-    width: 16px; height: 16px;
-    color: var(--tint, var(--accent));
-  }
-  #tile-agenda   { --tint: var(--accent); }
-  #tile-week     { --tint: var(--feature); }
-  #tile-activity { --tint: var(--story); }
-  #tile-focus    { --tint: var(--warn); }
-
-  .wi.hide, .event.hide, .group.hide { display: none; }
-  .nomatch {
-    display: none;
-    padding: 14px 2px 2px;
-    color: var(--text-faint);
-    font-size: 13px;
-  }
-  .tile.empty .nomatch { display: block; }
-  .tile .tt h2 {
-    margin: 0;
-    font-size: 12.5px;
-    font-weight: 700;
-    letter-spacing: .07em;
-    text-transform: uppercase;
-    color: var(--text);
-  }
-  .tile .tt .accent-i { color: var(--accent); }
-  .count {
-    font-family: var(--mono);
-    font-size: 11.5px;
-    color: var(--text-dim);
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    padding: 1px 8px;
-    font-variant-numeric: tabular-nums;
-  }
-
-  /* ---------- per-tile freshness + refresh ---------- */
-  .tile-meta {
-    flex: none;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-  }
-  .stale {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 11.5px;
-    color: var(--text-dim);
-    white-space: nowrap;
-  }
-  .fdot {
-    width: 7px; height: 7px; border-radius: 50%;
-    background: var(--good);
-    flex: none;
-  }
-  .stale.warn .fdot { background: var(--warn); }
-  .stale.busy { color: var(--accent); }
-  .stale.busy .fdot { background: var(--accent); }
-
-  .refresh-btn {
-    flex: none;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px; height: 28px;
-    padding: 0;
-    color: var(--text-dim);
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    cursor: pointer;
-  }
-  .refresh-btn:hover { color: var(--accent); border-color: var(--border-strong); }
-  .refresh-btn:disabled { cursor: default; opacity: .8; }
-  .refresh-btn svg { width: 15px; height: 15px; }
-  .refresh-btn.spinning svg { animation: spin .7s linear infinite; }
-  @keyframes spin { to { transform: rotate(360deg); } }
-  @media (prefers-reduced-motion: reduce) {
-    .refresh-btn.spinning svg { animation: none; }
-    .chev { transition: none; }
-  }
-
-  .tile .body {
-    padding: 4px 18px 18px;
-    border-top: 1px solid var(--border);
-  }
-
-  /* ---------- agenda events ---------- */
-  .event {
-    display: grid;
-    grid-template-columns: 88px 1fr;
-    gap: 14px;
-    padding: 14px 0;
-    border-bottom: 1px dashed var(--border);
-  }
-  .event:last-child { border-bottom: 0; }
-  .event .time {
-    font-family: var(--mono);
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--text);
-    font-variant-numeric: tabular-nums;
-  }
-  .event .time .tz { display: block; color: var(--text-faint); font-weight: 400; font-size: 11px; }
-  .event .etitle { font-weight: 600; margin-bottom: 5px; }
-  .meta { font-size: 13px; color: var(--text-dim); }
-  .meta .k { color: var(--text-faint); }
-  .where {
-    display: inline-flex; align-items: center; gap: 6px;
-    font-weight: 500;
-  }
-  .badge-loc {
-    font-size: 11px; font-weight: 600;
-    padding: 1px 8px; border-radius: 999px;
-    background: var(--accent-weak); color: var(--accent);
-  }
-
-  /* ---------- nested drill-in groups ---------- */
-  .group { border-top: 1px solid var(--border); }
-  .group:first-child { border-top: 0; }
-  .group > summary {
-    list-style: none;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 9px;
-    padding: 12px 0;
-    user-select: none;
-  }
-  .group > summary::-webkit-details-marker { display: none; }
-  .group > summary:hover .glabel { color: var(--accent); }
-  .glabel { font-weight: 600; font-size: 14px; flex: 1; }
-  .group .glist {
-    padding: 0 0 12px 26px;
-    display: flex;
-    flex-direction: column;
-    gap: 9px;
-  }
-
-  /* ---------- work item rows ---------- */
-  .wi {
-    display: flex;
-    align-items: baseline;
-    gap: 9px;
-    flex-wrap: wrap;
-  }
-  .wi .id {
-    font-family: var(--mono);
-    font-size: 12.5px;
-    font-variant-numeric: tabular-nums;
-  }
-  .type {
-    flex: none;
-    display: inline-flex; align-items: center; gap: 6px;
-    font-size: 11px; font-weight: 600;
-    color: var(--text-dim);
-  }
-  .type::before {
-    content: ""; width: 9px; height: 9px; border-radius: 2px;
-    background: var(--dot, var(--text-faint));
-  }
-  .t-epic    { --dot: var(--epic); }
-  .t-feature { --dot: var(--feature); }
-  .t-story   { --dot: var(--story); }
-  .t-bug     { --dot: var(--bug); border-radius: 50%; }
-  .t-task    { --dot: var(--task); }
-  .wi .wtitle { flex: 1; min-width: 140px; }
-  .wi .wtitle a { color: var(--text); }
-  .wi .wtitle a:hover { color: var(--accent); }
-
-  .state {
-    font-size: 10.5px; font-weight: 700; letter-spacing: .03em;
-    padding: 1px 7px; border-radius: 4px;
-    text-transform: uppercase;
-  }
-  .s-active   { color: var(--accent); background: var(--accent-weak); }
-  .s-progress { color: var(--warn);   background: color-mix(in srgb, var(--warn) 15%, transparent); }
-  .s-review   { color: var(--feature);background: color-mix(in srgb, var(--feature) 16%, transparent); }
-  .s-closing  { color: var(--good);   background: color-mix(in srgb, var(--good) 15%, transparent); }
-  .s-new      { color: var(--text-dim); background: var(--surface-2); }
-
-  .note { font-size: 12.5px; color: var(--text-dim); }
-  .check {
-    display: inline-flex; align-items: center; gap: 6px;
-    font-size: 12px; font-weight: 600; color: var(--warn);
-  }
-  .check::before { content: "\25CB"; }        /* open circle = to confirm */
-
-  .primary {
-    display: flex; gap: 12px; align-items: flex-start;
-    padding: 13px 14px; margin: 12px 0 4px;
-    background: var(--accent-weak);
-    border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
-    border-radius: 10px;
-  }
-  .primary .star { color: var(--accent); font-size: 15px; line-height: 1.6; }
-  .primary .ptitle { font-weight: 650; }
-  .primary .psub { font-size: 12.5px; color: var(--text-dim); margin-top: 2px; }
-
-  .footer {
-    margin-top: 26px;
-    font-size: 12px;
-    color: var(--text-faint);
-    text-align: center;
-  }
-  .footer code {
-    font-family: var(--mono);
-    background: var(--surface);
-    border: 1px solid var(--border);
-    padding: 1px 6px; border-radius: 5px;
-    color: var(--text-dim);
-  }
-</style>
+<link rel="stylesheet" href="styles.css">
+<script src="app.js" defer></script>
 </head>
 <body>
 <div class="wrap">
@@ -508,14 +13,14 @@
   <header class="topbar">
     <div class="brand">
       <h1>Daily Viewer</h1>
-      <div class="sub">Azure DevOps agenda &middot; <span class="date">Tuesday, July 14</span></div>
+      <p class="sub">Azure DevOps agenda &middot; <span class="date">Tuesday, July 14</span></p>
     </div>
-    <div class="toolbar">
+    <nav class="toolbar" aria-label="Viewer controls">
       <label class="search">
         <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="4.5" stroke="currentColor" stroke-width="1.5"/><path d="M10.5 10.5L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
         <input id="search" type="search" placeholder="Filter items&hellip;" aria-label="Filter items across tiles" autocomplete="off">
       </label>
-      <span class="synced"><span class="dot"></span>Local cache</span>
+      <span class="synced"><span class="dot" aria-hidden="true"></span>Local cache</span>
       <button class="btn" id="refreshAll" type="button">Refresh all</button>
       <button class="btn" id="collapseAll" type="button">Collapse all</button>
       <button class="btn" id="expandAll" type="button">Expand all</button>
@@ -523,365 +28,255 @@
         <svg id="icon-sun" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="3.2" stroke="currentColor" stroke-width="1.5"/><path d="M8 1v1.6M8 13.4V15M1 8h1.6M13.4 8H15M3 3l1.1 1.1M11.9 11.9L13 13M13 3l-1.1 1.1M4.1 11.9L3 13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
         <svg id="icon-moon" viewBox="0 0 16 16" fill="none" aria-hidden="true" style="display:none"><path d="M13.5 9.5A5.5 5.5 0 1 1 6.5 2.5a4.5 4.5 0 0 0 7 7z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
       </button>
-    </div>
+    </nav>
   </header>
 
-  <div class="stats">
-    <button class="stat a" type="button" data-target="tile-agenda"><span class="n">2</span><span class="l">Meetings today</span></button>
-    <button class="stat f" type="button" data-target="tile-week"><span class="n">3</span><span class="l">Stories due this week</span></button>
-    <button class="stat s" type="button" data-target="tile-activity"><span class="n">6</span><span class="l">Recent updates</span></button>
-    <button class="stat g" type="button" data-target="tile-focus"><span class="n">2</span><span class="l">Support &amp; focus items</span></button>
-  </div>
+  <main>
 
-  <div class="grid">
+    <section class="stats" aria-label="Summary counts">
+      <button class="stat a" type="button" data-target="tile-agenda"><span class="n">2</span><span class="l">Meetings today</span></button>
+      <button class="stat f" type="button" data-target="tile-week"><span class="n">3</span><span class="l">Stories due this week</span></button>
+      <button class="stat s" type="button" data-target="tile-activity"><span class="n">6</span><span class="l">Recent updates</span></button>
+      <button class="stat g" type="button" data-target="tile-focus"><span class="n">2</span><span class="l">Support &amp; focus items</span></button>
+    </section>
 
-    <!-- ============ TODAY'S AGENDA ============ -->
-    <details class="tile" id="tile-agenda" open>
-      <summary>
-        <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h2>Today&rsquo;s Agenda</h2><span class="count">2</span></span>
-        <span class="tile-meta">
-          <span class="stale"><span class="fdot"></span>cached 12m ago</span>
-          <button class="refresh-btn" type="button" data-tile="agenda" aria-label="Refresh Today&rsquo;s Agenda"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-        </span>
-      </summary>
-      <div class="body">
+    <div class="grid">
 
-        <div class="event">
-          <div class="time">9:00 AM<span class="tz">EST</span></div>
-          <div>
-            <div class="etitle">Sprint Planning Sync</div>
-            <div class="meta"><span class="where"><span class="badge-loc">Teams</span> <a href="https://teams.microsoft.com/l/meetup-join/example" target="_blank" rel="noopener">Join meeting &rarr;</a></span></div>
-            <div class="meta"><span class="k">With</span> Platform Team &middot; 6 attendees</div>
-          </div>
-        </div>
-
-        <div class="event">
-          <div class="time">11:00 AM<span class="tz">EST</span></div>
-          <div>
-            <div class="etitle">Architecture Design Review</div>
-            <div class="meta"><span class="where"><span class="badge-loc">In person</span> Room 132</span></div>
-            <div class="meta"><span class="k">Prep</span> <a href="https://dev.azure.com/org/project/_wiki/wikis/project.wiki/42/Design-Review" target="_blank" rel="noopener">Design doc &rarr;</a></div>
-          </div>
-        </div>
-
-      </div>
-    </details>
-
-    <!-- ============ THIS WEEK'S FOCUS ============ -->
-    <details class="tile" id="tile-week" open>
-      <summary>
-        <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h2>This Week&rsquo;s Focus</h2><span class="count">2</span></span>
-        <span class="tile-meta">
-          <span class="stale warn"><span class="fdot"></span>cached 2h ago</span>
-          <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-        </span>
-      </summary>
-      <div class="body">
-
-        <details class="group" open>
+      <!-- Today's Agenda -->
+      <section class="tile" id="tile-agenda" data-tile="agenda" aria-labelledby="h-agenda">
+        <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="glabel">Stories to complete</span>
-            <span class="count">3</span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h2 id="h-agenda">Today&rsquo;s Agenda</h2><span class="count">2</span></span>
+            <span class="tile-meta">
+              <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 12m ago</span>
+              <button class="refresh-btn" type="button" data-tile="agenda" aria-label="Refresh Today&rsquo;s Agenda"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+            </span>
           </summary>
-          <div class="glist">
-            <div class="wi">
-              <span class="type t-story">Story</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">#1234</a>
-              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">Wire agenda tile to az boards query</a></span>
-              <span class="state s-progress">In progress</span>
-            </div>
-            <div class="wi">
-              <span class="type t-story">Story</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">#1240</a>
-              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">Outlook calendar pull for daily events</a></span>
-              <span class="state s-active">Active</span>
-            </div>
-            <div class="wi">
-              <span class="type t-bug">Bug</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">#1251</a>
-              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">Timezone offset on EST agenda rows</a></span>
-              <span class="state s-review">In review</span>
-            </div>
+          <div class="body">
+            <ul class="events">
+              <li class="event">
+                <time class="time" datetime="2026-07-14T09:00:00-05:00">9:00 AM<span class="tz">EST</span></time>
+                <div>
+                  <p class="etitle">Sprint Planning Sync</p>
+                  <p class="meta"><span class="where"><span class="badge-loc">Teams</span> <a href="https://teams.microsoft.com/l/meetup-join/example" target="_blank" rel="noopener">Join meeting &rarr;</a></span></p>
+                  <p class="meta"><span class="k">With</span> Platform Team &middot; 6 attendees</p>
+                </div>
+              </li>
+              <li class="event">
+                <time class="time" datetime="2026-07-14T11:00:00-05:00">11:00 AM<span class="tz">EST</span></time>
+                <div>
+                  <p class="etitle">Architecture Design Review</p>
+                  <p class="meta"><span class="where"><span class="badge-loc">In person</span> Room 132</span></p>
+                  <p class="meta"><span class="k">Prep</span> <a href="https://dev.azure.com/org/project/_wiki/wikis/project.wiki/42/Design-Review" target="_blank" rel="noopener">Design doc &rarr;</a></p>
+                </div>
+              </li>
+            </ul>
           </div>
         </details>
+      </section>
 
-        <details class="group" open>
+      <!-- This Week's Focus -->
+      <section class="tile" id="tile-week" data-tile="week" aria-labelledby="h-week">
+        <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="glabel">Events to prepare for</span>
-            <span class="count">2</span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h2 id="h-week">This Week&rsquo;s Focus</h2><span class="count">2</span></span>
+            <span class="tile-meta">
+              <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 2h ago</span>
+              <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+            </span>
           </summary>
-          <div class="glist">
-            <div class="wi">
-              <span class="check"></span>
-              <span class="wtitle">Confirm demo build is deployed before <strong>Thu review</strong></span>
-            </div>
-            <div class="wi">
-              <span class="check"></span>
-              <span class="wtitle">Send agenda for <a href="https://teams.microsoft.com/l/meetup-join/example2" target="_blank" rel="noopener">Fri sprint retro</a></span>
-            </div>
+          <div class="body">
+
+            <details class="group" open>
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="glabel">Stories to complete</span>
+                <span class="count">3</span>
+              </summary>
+              <ul class="glist">
+                <li class="wi">
+                  <span class="type t-story">Story</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">#1234</a>
+                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">Wire agenda tile to az boards query</a></span>
+                  <span class="state s-progress">In progress</span>
+                </li>
+                <li class="wi">
+                  <span class="type t-story">Story</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">#1240</a>
+                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">Outlook calendar pull for daily events</a></span>
+                  <span class="state s-active">Active</span>
+                </li>
+                <li class="wi">
+                  <span class="type t-bug">Bug</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">#1251</a>
+                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">Timezone offset on EST agenda rows</a></span>
+                  <span class="state s-review">In review</span>
+                </li>
+              </ul>
+            </details>
+
+            <details class="group" open>
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="glabel">Events to prepare for</span>
+                <span class="count">2</span>
+              </summary>
+              <ul class="glist">
+                <li class="wi">
+                  <span class="check" aria-hidden="true"></span>
+                  <span class="wtitle">Confirm demo build is deployed before <strong>Thu review</strong></span>
+                </li>
+                <li class="wi">
+                  <span class="check" aria-hidden="true"></span>
+                  <span class="wtitle">Send agenda for <a href="https://teams.microsoft.com/l/meetup-join/example2" target="_blank" rel="noopener">Fri sprint retro</a></span>
+                </li>
+              </ul>
+            </details>
+
           </div>
         </details>
+      </section>
 
-      </div>
-    </details>
-
-    <!-- ============ RECENT ACTIVITY ============ -->
-    <details class="tile" id="tile-activity" open>
-      <summary>
-        <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 8h3l2-4.5 3 9 2-4.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg><h2>Recent Activity</h2><span class="count">3</span></span>
-        <span class="tile-meta">
-          <span class="stale"><span class="fdot"></span>cached 5m ago</span>
-          <button class="refresh-btn" type="button" data-tile="activity" aria-label="Refresh Recent Activity"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-        </span>
-      </summary>
-      <div class="body">
-
-        <details class="group">
+      <!-- Recent Activity -->
+      <section class="tile" id="tile-activity" data-tile="activity" aria-labelledby="h-activity">
+        <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="glabel">Tagged discussions</span>
-            <span class="count">2</span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 8h3l2-4.5 3 9 2-4.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg><h2 id="h-activity">Recent Activity</h2><span class="count">3</span></span>
+            <span class="tile-meta">
+              <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 5m ago</span>
+              <button class="refresh-btn" type="button" data-tile="activity" aria-label="Refresh Recent Activity"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+            </span>
           </summary>
-          <div class="glist">
-            <div class="wi">
-              <span class="type t-feature">Feature</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1180" target="_blank" rel="noopener">#1180</a>
-              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1180?discussion" target="_blank" rel="noopener">@you &mdash; &ldquo;can you confirm the WIQL scope?&rdquo;</a></span>
-            </div>
-            <div class="wi">
-              <span class="type t-story">Story</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">#1240</a>
-              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1240?discussion" target="_blank" rel="noopener">@you &mdash; &ldquo;ready for review whenever&rdquo;</a></span>
-            </div>
+          <div class="body">
+
+            <details class="group">
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="glabel">Tagged discussions</span>
+                <span class="count">2</span>
+              </summary>
+              <ul class="glist">
+                <li class="wi">
+                  <span class="type t-feature">Feature</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1180" target="_blank" rel="noopener">#1180</a>
+                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1180?discussion" target="_blank" rel="noopener">@you &mdash; &ldquo;can you confirm the WIQL scope?&rdquo;</a></span>
+                </li>
+                <li class="wi">
+                  <span class="type t-story">Story</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">#1240</a>
+                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1240?discussion" target="_blank" rel="noopener">@you &mdash; &ldquo;ready for review whenever&rdquo;</a></span>
+                </li>
+              </ul>
+            </details>
+
+            <details class="group">
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="glabel">Active story updates</span>
+                <span class="count">2</span>
+              </summary>
+              <ul class="glist">
+                <li class="wi">
+                  <span class="type t-story">Story</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">#1234</a>
+                  <span class="wtitle">State &rarr; <strong>In progress</strong> by A. Rivera</span>
+                  <span class="note">2h ago</span>
+                </li>
+                <li class="wi">
+                  <span class="type t-bug">Bug</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">#1251</a>
+                  <span class="wtitle">Moved to <strong>In review</strong></span>
+                  <span class="note">4h ago</span>
+                </li>
+              </ul>
+            </details>
+
+            <details class="group">
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="glabel">Sprint close items</span>
+                <span class="count">2</span>
+              </summary>
+              <ul class="glist">
+                <li class="wi">
+                  <span class="type t-task">Task</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1209" target="_blank" rel="noopener">#1209</a>
+                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1209" target="_blank" rel="noopener">Update release notes</a></span>
+                  <span class="state s-closing">Closing</span>
+                </li>
+                <li class="wi">
+                  <span class="type t-story">Story</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1222" target="_blank" rel="noopener">#1222</a>
+                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1222" target="_blank" rel="noopener">Verify acceptance criteria signed off</a></span>
+                  <span class="state s-closing">Closing</span>
+                </li>
+              </ul>
+            </details>
+
           </div>
         </details>
+      </section>
 
-        <details class="group">
+      <!-- Today's Focus -->
+      <section class="tile" id="tile-focus" data-tile="focus" aria-labelledby="h-focus">
+        <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="glabel">Active story updates</span>
-            <span class="count">2</span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2 id="h-focus">Today&rsquo;s Focus</h2><span class="count">2</span></span>
+            <span class="tile-meta">
+              <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 1h ago</span>
+              <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+            </span>
           </summary>
-          <div class="glist">
-            <div class="wi">
-              <span class="type t-story">Story</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">#1234</a>
-              <span class="wtitle">State &rarr; <strong>In progress</strong> by A. Rivera</span>
-              <span class="note">2h ago</span>
+          <div class="body">
+
+            <div class="primary">
+              <span class="star" aria-hidden="true">&#9733;</span>
+              <div>
+                <p class="ptitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">User Story #1234 &mdash; Wire agenda tile to az boards</a></p>
+                <p class="psub">Primary commitment for today &middot; In progress</p>
+              </div>
             </div>
-            <div class="wi">
-              <span class="type t-bug">Bug</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">#1251</a>
-              <span class="wtitle">Moved to <strong>In review</strong></span>
-              <span class="note">4h ago</span>
-            </div>
+
+            <details class="group" open>
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="glabel">SF devs &mdash; unplanned support</span>
+                <span class="count">2</span>
+              </summary>
+              <ul class="glist">
+                <li class="wi">
+                  <span class="type t-bug">Bug</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1260" target="_blank" rel="noopener">#1260</a>
+                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1260" target="_blank" rel="noopener">Deploy failing on scratch org spin-up</a></span>
+                  <span class="state s-active">Active</span>
+                </li>
+                <li class="wi">
+                  <span class="type t-task">Task</span>
+                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1263" target="_blank" rel="noopener">#1263</a>
+                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1263" target="_blank" rel="noopener">Help triage permission set assignment</a></span>
+                  <span class="state s-new">New</span>
+                </li>
+              </ul>
+            </details>
+
           </div>
         </details>
+      </section>
 
-        <details class="group">
-          <summary>
-            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="glabel">Sprint close items</span>
-            <span class="count">2</span>
-          </summary>
-          <div class="glist">
-            <div class="wi">
-              <span class="type t-task">Task</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1209" target="_blank" rel="noopener">#1209</a>
-              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1209" target="_blank" rel="noopener">Update release notes</a></span>
-              <span class="state s-closing">Closing</span>
-            </div>
-            <div class="wi">
-              <span class="type t-story">Story</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1222" target="_blank" rel="noopener">#1222</a>
-              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1222" target="_blank" rel="noopener">Verify acceptance criteria signed off</a></span>
-              <span class="state s-closing">Closing</span>
-            </div>
-          </div>
-        </details>
+    </div>
+  </main>
 
-      </div>
-    </details>
-
-    <!-- ============ TODAY'S FOCUS ============ -->
-    <details class="tile" id="tile-focus" open>
-      <summary>
-        <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2>Today&rsquo;s Focus</h2><span class="count">2</span></span>
-        <span class="tile-meta">
-          <span class="stale warn"><span class="fdot"></span>cached 1h ago</span>
-          <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-        </span>
-      </summary>
-      <div class="body">
-
-        <div class="primary">
-          <span class="star" aria-hidden="true">&#9733;</span>
-          <div>
-            <div class="ptitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">User Story #1234 &mdash; Wire agenda tile to az boards</a></div>
-            <div class="psub">Primary commitment for today &middot; In progress</div>
-          </div>
-        </div>
-
-        <details class="group" open>
-          <summary>
-            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="glabel">SF devs &mdash; unplanned support</span>
-            <span class="count">2</span>
-          </summary>
-          <div class="glist">
-            <div class="wi">
-              <span class="type t-bug">Bug</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1260" target="_blank" rel="noopener">#1260</a>
-              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1260" target="_blank" rel="noopener">Deploy failing on scratch org spin-up</a></span>
-              <span class="state s-active">Active</span>
-            </div>
-            <div class="wi">
-              <span class="type t-task">Task</span>
-              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1263" target="_blank" rel="noopener">#1263</a>
-              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1263" target="_blank" rel="noopener">Help triage permission set assignment</a></span>
-              <span class="state s-new">New</span>
-            </div>
-          </div>
-        </details>
-
-      </div>
-    </details>
-
-  </div>
-
-  <p class="footer">
+  <footer class="footer">
     Mock &middot; placeholder data. Live build feeds from <code>az boards query</code> + the Outlook PowerShell module.
-  </p>
+  </footer>
 
 </div>
 
-<script>
-  document.getElementById("expandAll").addEventListener("click", function () {
-    document.querySelectorAll("details").forEach(function (d) { d.open = true; });
-  });
-  document.getElementById("collapseAll").addEventListener("click", function () {
-    document.querySelectorAll(".tile").forEach(function (d) { d.open = false; });
-  });
+<div id="sr-status" class="sr-only" role="status" aria-live="polite"></div>
 
-  // Per-tile refresh: the only expensive path. Cheap render is already on screen
-  // from cache; this is where the real build would fire that tile's az CLI calls.
-  var REFRESH_MS = 900;
-
-  function refreshTile(btn) {
-    if (btn.disabled) return;
-
-    var stale = btn.parentElement.querySelector(".stale");
-    var label = stale.childNodes[stale.childNodes.length - 1];
-
-    btn.disabled = true;
-    btn.classList.add("spinning");
-    stale.classList.remove("warn");
-    stale.classList.add("busy");
-    label.textContent = "refreshing…";
-
-    window.setTimeout(function () {
-      btn.classList.remove("spinning");
-      btn.disabled = false;
-      stale.classList.remove("busy");
-      label.textContent = "cached just now";
-    }, REFRESH_MS);
-  }
-
-  document.querySelectorAll(".refresh-btn").forEach(function (btn) {
-    btn.addEventListener("click", function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      refreshTile(btn);
-    });
-  });
-
-  document.getElementById("refreshAll").addEventListener("click", function () {
-    document.querySelectorAll(".refresh-btn").forEach(refreshTile);
-  });
-
-  // Stat strip: jump to (and open) the tile a stat summarizes.
-  document.querySelectorAll(".stat").forEach(function (stat) {
-    stat.addEventListener("click", function () {
-      var tile = document.getElementById(stat.dataset.target);
-      if (!tile) return;
-      tile.open = true;
-      tile.scrollIntoView({ behavior: "smooth", block: "start" });
-    });
-  });
-
-  // Theme toggle: stamp data-theme on <html> so it overrides the OS media query.
-  var root = document.documentElement;
-  var iconSun = document.getElementById("icon-sun");
-  var iconMoon = document.getElementById("icon-moon");
-
-  function currentTheme() {
-    var t = root.getAttribute("data-theme");
-    if (t) return t;
-    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-  }
-  function paintThemeIcon() {
-    var dark = currentTheme() === "dark";
-    iconMoon.style.display = dark ? "block" : "none";
-    iconSun.style.display = dark ? "none" : "block";
-  }
-  document.getElementById("themeToggle").addEventListener("click", function () {
-    var next = currentTheme() === "dark" ? "light" : "dark";
-    root.setAttribute("data-theme", next);
-    paintThemeIcon();
-  });
-  paintThemeIcon();
-
-  // Live filter across every work-item and event row. Remembers each tile's
-  // open/closed state so clearing the box restores the original layout.
-  var allDetails = document.querySelectorAll("details");
-  allDetails.forEach(function (d) { d.dataset.open0 = d.open ? "1" : "0"; });
-
-  document.querySelectorAll(".tile .body").forEach(function (body) {
-    var note = document.createElement("p");
-    note.className = "nomatch";
-    note.textContent = "No matching items in this tile.";
-    body.appendChild(note);
-  });
-
-  function applyFilter(raw) {
-    var q = raw.trim().toLowerCase();
-
-    if (q) {
-      allDetails.forEach(function (d) { d.open = true; });
-    } else {
-      allDetails.forEach(function (d) { d.open = d.dataset.open0 === "1"; });
-    }
-
-    document.querySelectorAll(".tile").forEach(function (tile) {
-      var rows = tile.querySelectorAll(".wi, .event");
-      var anyVisible = false;
-
-      rows.forEach(function (row) {
-        var match = !q || row.textContent.toLowerCase().indexOf(q) !== -1;
-        row.classList.toggle("hide", !match);
-        if (match) anyVisible = true;
-      });
-
-      tile.querySelectorAll(".group").forEach(function (group) {
-        var visible = group.querySelectorAll(".wi:not(.hide), .event:not(.hide)").length;
-        group.classList.toggle("hide", !!q && visible === 0);
-      });
-
-      tile.classList.toggle("empty", !!q && !anyVisible);
-    });
-  }
-
-  var searchBox = document.getElementById("search");
-  searchBox.addEventListener("input", function () { applyFilter(searchBox.value); });
-  searchBox.addEventListener("keydown", function (e) {
-    if (e.key === "Escape") { searchBox.value = ""; applyFilter(""); }
-  });
-</script>
 </body>
 </html>

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -185,6 +185,60 @@
     cursor: pointer;
   }
   .btn:hover { color: var(--text); border-color: var(--border-strong); }
+  .btn.icon { padding: 6px 8px; display: inline-flex; align-items: center; }
+  .btn.icon svg { width: 15px; height: 15px; }
+
+  .search {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 5px 10px;
+  }
+  .search:focus-within { border-color: var(--accent); }
+  .search svg { width: 14px; height: 14px; color: var(--text-faint); flex: none; }
+  .search input {
+    border: 0; background: transparent; outline: none;
+    font-family: inherit; font-size: 13px; color: var(--text);
+    width: 148px;
+  }
+  .search input::placeholder { color: var(--text-faint); }
+
+  /* ---------- summary stat strip ---------- */
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+    margin-bottom: 20px;
+  }
+  @media (max-width: 820px) { .stats { grid-template-columns: repeat(2, 1fr); } }
+  .stat {
+    font-family: inherit;
+    text-align: left;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px 14px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .stat:hover { border-color: var(--border-strong); box-shadow: var(--shadow); }
+  .stat .n {
+    font-size: 23px;
+    font-weight: 680;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+    color: var(--stat, var(--text));
+  }
+  .stat .l { font-size: 12px; color: var(--text-dim); }
+  .stat.a { --stat: var(--accent); }
+  .stat.f { --stat: var(--feature); }
+  .stat.s { --stat: var(--story); }
+  .stat.g { --stat: var(--warn); }
 
   /* ---------- grid ---------- */
   .grid {
@@ -226,11 +280,29 @@
 
   .tile .tt {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 9px;
     flex: 1;
     min-width: 0;
   }
+  .ticon {
+    flex: none;
+    width: 16px; height: 16px;
+    color: var(--tint, var(--accent));
+  }
+  #tile-agenda   { --tint: var(--accent); }
+  #tile-week     { --tint: var(--feature); }
+  #tile-activity { --tint: var(--story); }
+  #tile-focus    { --tint: var(--warn); }
+
+  .wi.hide, .event.hide, .group.hide { display: none; }
+  .nomatch {
+    display: none;
+    padding: 14px 2px 2px;
+    color: var(--text-faint);
+    font-size: 13px;
+  }
+  .tile.empty .nomatch { display: block; }
   .tile .tt h2 {
     margin: 0;
     font-size: 12.5px;
@@ -439,20 +511,35 @@
       <div class="sub">Azure DevOps agenda &middot; <span class="date">Tuesday, July 14</span></div>
     </div>
     <div class="toolbar">
+      <label class="search">
+        <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="4.5" stroke="currentColor" stroke-width="1.5"/><path d="M10.5 10.5L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+        <input id="search" type="search" placeholder="Filter items&hellip;" aria-label="Filter items across tiles" autocomplete="off">
+      </label>
       <span class="synced"><span class="dot"></span>Local cache</span>
       <button class="btn" id="refreshAll" type="button">Refresh all</button>
       <button class="btn" id="collapseAll" type="button">Collapse all</button>
       <button class="btn" id="expandAll" type="button">Expand all</button>
+      <button class="btn icon" id="themeToggle" type="button" aria-label="Toggle light or dark theme">
+        <svg id="icon-sun" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="3.2" stroke="currentColor" stroke-width="1.5"/><path d="M8 1v1.6M8 13.4V15M1 8h1.6M13.4 8H15M3 3l1.1 1.1M11.9 11.9L13 13M13 3l-1.1 1.1M4.1 11.9L3 13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+        <svg id="icon-moon" viewBox="0 0 16 16" fill="none" aria-hidden="true" style="display:none"><path d="M13.5 9.5A5.5 5.5 0 1 1 6.5 2.5a4.5 4.5 0 0 0 7 7z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
+      </button>
     </div>
   </header>
+
+  <div class="stats">
+    <button class="stat a" type="button" data-target="tile-agenda"><span class="n">2</span><span class="l">Meetings today</span></button>
+    <button class="stat f" type="button" data-target="tile-week"><span class="n">3</span><span class="l">Stories due this week</span></button>
+    <button class="stat s" type="button" data-target="tile-activity"><span class="n">6</span><span class="l">Recent updates</span></button>
+    <button class="stat g" type="button" data-target="tile-focus"><span class="n">2</span><span class="l">Support &amp; focus items</span></button>
+  </div>
 
   <div class="grid">
 
     <!-- ============ TODAY'S AGENDA ============ -->
-    <details class="tile" open>
+    <details class="tile" id="tile-agenda" open>
       <summary>
         <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><h2>Today&rsquo;s Agenda</h2><span class="count">2</span></span>
+        <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h2>Today&rsquo;s Agenda</h2><span class="count">2</span></span>
         <span class="tile-meta">
           <span class="stale"><span class="fdot"></span>cached 12m ago</span>
           <button class="refresh-btn" type="button" data-tile="agenda" aria-label="Refresh Today&rsquo;s Agenda"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -482,10 +569,10 @@
     </details>
 
     <!-- ============ THIS WEEK'S FOCUS ============ -->
-    <details class="tile" open>
+    <details class="tile" id="tile-week" open>
       <summary>
         <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><h2>This Week&rsquo;s Focus</h2><span class="count">2</span></span>
+        <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h2>This Week&rsquo;s Focus</h2><span class="count">2</span></span>
         <span class="tile-meta">
           <span class="stale warn"><span class="fdot"></span>cached 2h ago</span>
           <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -543,10 +630,10 @@
     </details>
 
     <!-- ============ RECENT ACTIVITY ============ -->
-    <details class="tile" open>
+    <details class="tile" id="tile-activity" open>
       <summary>
         <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><h2>Recent Activity</h2><span class="count">3</span></span>
+        <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 8h3l2-4.5 3 9 2-4.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg><h2>Recent Activity</h2><span class="count">3</span></span>
         <span class="tile-meta">
           <span class="stale"><span class="fdot"></span>cached 5m ago</span>
           <button class="refresh-btn" type="button" data-tile="activity" aria-label="Refresh Recent Activity"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -622,10 +709,10 @@
     </details>
 
     <!-- ============ TODAY'S FOCUS ============ -->
-    <details class="tile" open>
+    <details class="tile" id="tile-focus" open>
       <summary>
         <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><h2>Today&rsquo;s Focus</h2><span class="count">2</span></span>
+        <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2>Today&rsquo;s Focus</h2><span class="count">2</span></span>
         <span class="tile-meta">
           <span class="stale warn"><span class="fdot"></span>cached 1h ago</span>
           <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -716,6 +803,84 @@
 
   document.getElementById("refreshAll").addEventListener("click", function () {
     document.querySelectorAll(".refresh-btn").forEach(refreshTile);
+  });
+
+  // Stat strip: jump to (and open) the tile a stat summarizes.
+  document.querySelectorAll(".stat").forEach(function (stat) {
+    stat.addEventListener("click", function () {
+      var tile = document.getElementById(stat.dataset.target);
+      if (!tile) return;
+      tile.open = true;
+      tile.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  });
+
+  // Theme toggle: stamp data-theme on <html> so it overrides the OS media query.
+  var root = document.documentElement;
+  var iconSun = document.getElementById("icon-sun");
+  var iconMoon = document.getElementById("icon-moon");
+
+  function currentTheme() {
+    var t = root.getAttribute("data-theme");
+    if (t) return t;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  function paintThemeIcon() {
+    var dark = currentTheme() === "dark";
+    iconMoon.style.display = dark ? "block" : "none";
+    iconSun.style.display = dark ? "none" : "block";
+  }
+  document.getElementById("themeToggle").addEventListener("click", function () {
+    var next = currentTheme() === "dark" ? "light" : "dark";
+    root.setAttribute("data-theme", next);
+    paintThemeIcon();
+  });
+  paintThemeIcon();
+
+  // Live filter across every work-item and event row. Remembers each tile's
+  // open/closed state so clearing the box restores the original layout.
+  var allDetails = document.querySelectorAll("details");
+  allDetails.forEach(function (d) { d.dataset.open0 = d.open ? "1" : "0"; });
+
+  document.querySelectorAll(".tile .body").forEach(function (body) {
+    var note = document.createElement("p");
+    note.className = "nomatch";
+    note.textContent = "No matching items in this tile.";
+    body.appendChild(note);
+  });
+
+  function applyFilter(raw) {
+    var q = raw.trim().toLowerCase();
+
+    if (q) {
+      allDetails.forEach(function (d) { d.open = true; });
+    } else {
+      allDetails.forEach(function (d) { d.open = d.dataset.open0 === "1"; });
+    }
+
+    document.querySelectorAll(".tile").forEach(function (tile) {
+      var rows = tile.querySelectorAll(".wi, .event");
+      var anyVisible = false;
+
+      rows.forEach(function (row) {
+        var match = !q || row.textContent.toLowerCase().indexOf(q) !== -1;
+        row.classList.toggle("hide", !match);
+        if (match) anyVisible = true;
+      });
+
+      tile.querySelectorAll(".group").forEach(function (group) {
+        var visible = group.querySelectorAll(".wi:not(.hide), .event:not(.hide)").length;
+        group.classList.toggle("hide", !!q && visible === 0);
+      });
+
+      tile.classList.toggle("empty", !!q && !anyVisible);
+    });
+  }
+
+  var searchBox = document.getElementById("search");
+  searchBox.addEventListener("input", function () { applyFilter(searchBox.value); });
+  searchBox.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") { searchBox.value = ""; applyFilter(""); }
   });
 </script>
 </body>

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -1,0 +1,626 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Daily Viewer — Azure DevOps Agenda</title>
+<style>
+  :root {
+    --bg: #EEF1F6;
+    --surface: #FFFFFF;
+    --surface-2: #F5F7FA;
+    --border: #DCE2EC;
+    --border-strong: #C6CFDC;
+    --text: #1B2430;
+    --text-dim: #5A6675;
+    --text-faint: #8A94A3;
+    --accent: #0E6FCE;
+    --accent-weak: rgba(14,111,206,.10);
+
+    --epic:    #C77700;
+    --feature: #7B49D6;
+    --story:   #1E86BE;
+    --bug:     #D1373A;
+    --task:    #2C9E43;
+
+    --good: #2C9E43;
+    --warn: #B5820A;
+    --crit: #D1373A;
+
+    --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);
+    --radius: 12px;
+
+    --font: "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+    --mono: "Cascadia Code", "Cascadia Mono", Consolas, "SF Mono", ui-monospace, monospace;
+
+    color-scheme: light;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0F131A;
+      --surface: #171C25;
+      --surface-2: #1E2531;
+      --border: #29313D;
+      --border-strong: #38424F;
+      --text: #E7ECF3;
+      --text-dim: #97A3B4;
+      --text-faint: #6C7889;
+      --accent: #4AA3F0;
+      --accent-weak: rgba(74,163,240,.14);
+
+      --epic:    #E8A317;
+      --feature: #A47CF0;
+      --story:   #3FB4E8;
+      --bug:     #E5645F;
+      --task:    #4FBF63;
+
+      --good: #4FBF63;
+      --warn: #D9A521;
+      --crit: #E5645F;
+
+      --shadow: 0 1px 2px rgba(0,0,0,.30), 0 8px 24px rgba(0,0,0,.30);
+      color-scheme: dark;
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --bg: #0F131A;
+    --surface: #171C25;
+    --surface-2: #1E2531;
+    --border: #29313D;
+    --border-strong: #38424F;
+    --text: #E7ECF3;
+    --text-dim: #97A3B4;
+    --text-faint: #6C7889;
+    --accent: #4AA3F0;
+    --accent-weak: rgba(74,163,240,.14);
+    --epic: #E8A317; --feature: #A47CF0; --story: #3FB4E8; --bug: #E5645F; --task: #4FBF63;
+    --good: #4FBF63; --warn: #D9A521; --crit: #E5645F;
+    --shadow: 0 1px 2px rgba(0,0,0,.30), 0 8px 24px rgba(0,0,0,.30);
+    color-scheme: dark;
+  }
+  :root[data-theme="light"] {
+    --bg: #EEF1F6;
+    --surface: #FFFFFF;
+    --surface-2: #F5F7FA;
+    --border: #DCE2EC;
+    --border-strong: #C6CFDC;
+    --text: #1B2430;
+    --text-dim: #5A6675;
+    --text-faint: #8A94A3;
+    --accent: #0E6FCE;
+    --accent-weak: rgba(14,111,206,.10);
+    --epic: #C77700; --feature: #7B49D6; --story: #1E86BE; --bug: #D1373A; --task: #2C9E43;
+    --good: #2C9E43; --warn: #B5820A; --crit: #D1373A;
+    --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);
+    color-scheme: light;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font);
+    font-size: 15px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  a:focus-visible,
+  summary:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 6px;
+  }
+
+  .wrap {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 22px 24px 56px;
+  }
+
+  /* ---------- top bar ---------- */
+  .topbar {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 18px;
+    flex-wrap: wrap;
+    padding-bottom: 18px;
+    margin-bottom: 22px;
+    border-bottom: 1px solid var(--border);
+  }
+  .brand h1 {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 650;
+    letter-spacing: -.01em;
+  }
+  .brand .sub {
+    margin-top: 3px;
+    color: var(--text-dim);
+    font-size: 13px;
+  }
+  .brand .date {
+    color: var(--accent);
+    font-weight: 600;
+  }
+
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .synced {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 12.5px;
+    color: var(--text-dim);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 6px 11px;
+    border-radius: 999px;
+  }
+  .synced .dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--good);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--good) 22%, transparent);
+  }
+  .btn {
+    font-family: inherit;
+    font-size: 12.5px;
+    color: var(--text-dim);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 6px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+  .btn:hover { color: var(--text); border-color: var(--border-strong); }
+
+  /* ---------- grid ---------- */
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+  }
+  @media (max-width: 820px) {
+    .grid { grid-template-columns: 1fr; }
+  }
+
+  /* ---------- tile ---------- */
+  .tile {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+  }
+  .tile > summary {
+    list-style: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    padding: 15px 18px;
+    user-select: none;
+  }
+  .tile > summary::-webkit-details-marker { display: none; }
+  .tile > summary:hover { background: var(--surface-2); }
+
+  .chev {
+    flex: none;
+    width: 16px; height: 16px;
+    color: var(--text-faint);
+    transition: transform .18s ease;
+  }
+  details[open] > summary > .chev { transform: rotate(90deg); }
+
+  .tile .tt {
+    display: flex;
+    align-items: baseline;
+    gap: 9px;
+    flex: 1;
+    min-width: 0;
+  }
+  .tile .tt h2 {
+    margin: 0;
+    font-size: 12.5px;
+    font-weight: 700;
+    letter-spacing: .07em;
+    text-transform: uppercase;
+    color: var(--text);
+  }
+  .tile .tt .accent-i { color: var(--accent); }
+  .count {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    color: var(--text-dim);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 1px 8px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .tile .body {
+    padding: 4px 18px 18px;
+    border-top: 1px solid var(--border);
+  }
+
+  /* ---------- agenda events ---------- */
+  .event {
+    display: grid;
+    grid-template-columns: 88px 1fr;
+    gap: 14px;
+    padding: 14px 0;
+    border-bottom: 1px dashed var(--border);
+  }
+  .event:last-child { border-bottom: 0; }
+  .event .time {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+  .event .time .tz { display: block; color: var(--text-faint); font-weight: 400; font-size: 11px; }
+  .event .etitle { font-weight: 600; margin-bottom: 5px; }
+  .meta { font-size: 13px; color: var(--text-dim); }
+  .meta .k { color: var(--text-faint); }
+  .where {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-weight: 500;
+  }
+  .badge-loc {
+    font-size: 11px; font-weight: 600;
+    padding: 1px 8px; border-radius: 999px;
+    background: var(--accent-weak); color: var(--accent);
+  }
+
+  /* ---------- nested drill-in groups ---------- */
+  .group { border-top: 1px solid var(--border); }
+  .group:first-child { border-top: 0; }
+  .group > summary {
+    list-style: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 12px 0;
+    user-select: none;
+  }
+  .group > summary::-webkit-details-marker { display: none; }
+  .group > summary:hover .glabel { color: var(--accent); }
+  .glabel { font-weight: 600; font-size: 14px; flex: 1; }
+  .group .glist {
+    padding: 0 0 12px 26px;
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+  }
+
+  /* ---------- work item rows ---------- */
+  .wi {
+    display: flex;
+    align-items: baseline;
+    gap: 9px;
+    flex-wrap: wrap;
+  }
+  .wi .id {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    font-variant-numeric: tabular-nums;
+  }
+  .type {
+    flex: none;
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 11px; font-weight: 600;
+    color: var(--text-dim);
+  }
+  .type::before {
+    content: ""; width: 9px; height: 9px; border-radius: 2px;
+    background: var(--dot, var(--text-faint));
+  }
+  .t-epic    { --dot: var(--epic); }
+  .t-feature { --dot: var(--feature); }
+  .t-story   { --dot: var(--story); }
+  .t-bug     { --dot: var(--bug); border-radius: 50%; }
+  .t-task    { --dot: var(--task); }
+  .wi .wtitle { flex: 1; min-width: 140px; }
+  .wi .wtitle a { color: var(--text); }
+  .wi .wtitle a:hover { color: var(--accent); }
+
+  .state {
+    font-size: 10.5px; font-weight: 700; letter-spacing: .03em;
+    padding: 1px 7px; border-radius: 4px;
+    text-transform: uppercase;
+  }
+  .s-active   { color: var(--accent); background: var(--accent-weak); }
+  .s-progress { color: var(--warn);   background: color-mix(in srgb, var(--warn) 15%, transparent); }
+  .s-review   { color: var(--feature);background: color-mix(in srgb, var(--feature) 16%, transparent); }
+  .s-closing  { color: var(--good);   background: color-mix(in srgb, var(--good) 15%, transparent); }
+  .s-new      { color: var(--text-dim); background: var(--surface-2); }
+
+  .note { font-size: 12.5px; color: var(--text-dim); }
+  .check {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 12px; font-weight: 600; color: var(--warn);
+  }
+  .check::before { content: "\25CB"; }        /* open circle = to confirm */
+
+  .primary {
+    display: flex; gap: 12px; align-items: flex-start;
+    padding: 13px 14px; margin: 12px 0 4px;
+    background: var(--accent-weak);
+    border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
+    border-radius: 10px;
+  }
+  .primary .star { color: var(--accent); font-size: 15px; line-height: 1.6; }
+  .primary .ptitle { font-weight: 650; }
+  .primary .psub { font-size: 12.5px; color: var(--text-dim); margin-top: 2px; }
+
+  .footer {
+    margin-top: 26px;
+    font-size: 12px;
+    color: var(--text-faint);
+    text-align: center;
+  }
+  .footer code {
+    font-family: var(--mono);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1px 6px; border-radius: 5px;
+    color: var(--text-dim);
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="topbar">
+    <div class="brand">
+      <h1>Daily Viewer</h1>
+      <div class="sub">Azure DevOps agenda &middot; <span class="date">Tuesday, July 14</span></div>
+    </div>
+    <div class="toolbar">
+      <span class="synced"><span class="dot"></span>Synced 7:42 AM</span>
+      <button class="btn" id="collapseAll" type="button">Collapse all</button>
+      <button class="btn" id="expandAll" type="button">Expand all</button>
+    </div>
+  </header>
+
+  <div class="grid">
+
+    <!-- ============ TODAY'S AGENDA ============ -->
+    <details class="tile" open>
+      <summary>
+        <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="tt"><h2>Today&rsquo;s Agenda</h2></span>
+        <span class="count">2</span>
+      </summary>
+      <div class="body">
+
+        <div class="event">
+          <div class="time">9:00 AM<span class="tz">EST</span></div>
+          <div>
+            <div class="etitle">Sprint Planning Sync</div>
+            <div class="meta"><span class="where"><span class="badge-loc">Teams</span> <a href="https://teams.microsoft.com/l/meetup-join/example" target="_blank" rel="noopener">Join meeting &rarr;</a></span></div>
+            <div class="meta"><span class="k">With</span> Platform Team &middot; 6 attendees</div>
+          </div>
+        </div>
+
+        <div class="event">
+          <div class="time">11:00 AM<span class="tz">EST</span></div>
+          <div>
+            <div class="etitle">Architecture Design Review</div>
+            <div class="meta"><span class="where"><span class="badge-loc">In person</span> Room 132</span></div>
+            <div class="meta"><span class="k">Prep</span> <a href="https://dev.azure.com/org/project/_wiki/wikis/project.wiki/42/Design-Review" target="_blank" rel="noopener">Design doc &rarr;</a></div>
+          </div>
+        </div>
+
+      </div>
+    </details>
+
+    <!-- ============ THIS WEEK'S FOCUS ============ -->
+    <details class="tile" open>
+      <summary>
+        <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="tt"><h2>This Week&rsquo;s Focus</h2></span>
+        <span class="count">2</span>
+      </summary>
+      <div class="body">
+
+        <details class="group" open>
+          <summary>
+            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span class="glabel">Stories to complete</span>
+            <span class="count">3</span>
+          </summary>
+          <div class="glist">
+            <div class="wi">
+              <span class="type t-story">Story</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">#1234</a>
+              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">Wire agenda tile to az boards query</a></span>
+              <span class="state s-progress">In progress</span>
+            </div>
+            <div class="wi">
+              <span class="type t-story">Story</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">#1240</a>
+              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">Outlook calendar pull for daily events</a></span>
+              <span class="state s-active">Active</span>
+            </div>
+            <div class="wi">
+              <span class="type t-bug">Bug</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">#1251</a>
+              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">Timezone offset on EST agenda rows</a></span>
+              <span class="state s-review">In review</span>
+            </div>
+          </div>
+        </details>
+
+        <details class="group" open>
+          <summary>
+            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span class="glabel">Events to prepare for</span>
+            <span class="count">2</span>
+          </summary>
+          <div class="glist">
+            <div class="wi">
+              <span class="check"></span>
+              <span class="wtitle">Confirm demo build is deployed before <strong>Thu review</strong></span>
+            </div>
+            <div class="wi">
+              <span class="check"></span>
+              <span class="wtitle">Send agenda for <a href="https://teams.microsoft.com/l/meetup-join/example2" target="_blank" rel="noopener">Fri sprint retro</a></span>
+            </div>
+          </div>
+        </details>
+
+      </div>
+    </details>
+
+    <!-- ============ RECENT ACTIVITY ============ -->
+    <details class="tile" open>
+      <summary>
+        <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="tt"><h2>Recent Activity</h2></span>
+        <span class="count">3</span>
+      </summary>
+      <div class="body">
+
+        <details class="group">
+          <summary>
+            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span class="glabel">Tagged discussions</span>
+            <span class="count">2</span>
+          </summary>
+          <div class="glist">
+            <div class="wi">
+              <span class="type t-feature">Feature</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1180" target="_blank" rel="noopener">#1180</a>
+              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1180?discussion" target="_blank" rel="noopener">@you &mdash; &ldquo;can you confirm the WIQL scope?&rdquo;</a></span>
+            </div>
+            <div class="wi">
+              <span class="type t-story">Story</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">#1240</a>
+              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1240?discussion" target="_blank" rel="noopener">@you &mdash; &ldquo;ready for review whenever&rdquo;</a></span>
+            </div>
+          </div>
+        </details>
+
+        <details class="group">
+          <summary>
+            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span class="glabel">Active story updates</span>
+            <span class="count">2</span>
+          </summary>
+          <div class="glist">
+            <div class="wi">
+              <span class="type t-story">Story</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">#1234</a>
+              <span class="wtitle">State &rarr; <strong>In progress</strong> by A. Rivera</span>
+              <span class="note">2h ago</span>
+            </div>
+            <div class="wi">
+              <span class="type t-bug">Bug</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">#1251</a>
+              <span class="wtitle">Moved to <strong>In review</strong></span>
+              <span class="note">4h ago</span>
+            </div>
+          </div>
+        </details>
+
+        <details class="group">
+          <summary>
+            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span class="glabel">Sprint close items</span>
+            <span class="count">2</span>
+          </summary>
+          <div class="glist">
+            <div class="wi">
+              <span class="type t-task">Task</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1209" target="_blank" rel="noopener">#1209</a>
+              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1209" target="_blank" rel="noopener">Update release notes</a></span>
+              <span class="state s-closing">Closing</span>
+            </div>
+            <div class="wi">
+              <span class="type t-story">Story</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1222" target="_blank" rel="noopener">#1222</a>
+              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1222" target="_blank" rel="noopener">Verify acceptance criteria signed off</a></span>
+              <span class="state s-closing">Closing</span>
+            </div>
+          </div>
+        </details>
+
+      </div>
+    </details>
+
+    <!-- ============ TODAY'S FOCUS ============ -->
+    <details class="tile" open>
+      <summary>
+        <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="tt"><h2>Today&rsquo;s Focus</h2></span>
+        <span class="count">2</span>
+      </summary>
+      <div class="body">
+
+        <div class="primary">
+          <span class="star" aria-hidden="true">&#9733;</span>
+          <div>
+            <div class="ptitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">User Story #1234 &mdash; Wire agenda tile to az boards</a></div>
+            <div class="psub">Primary commitment for today &middot; In progress</div>
+          </div>
+        </div>
+
+        <details class="group" open>
+          <summary>
+            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span class="glabel">SF devs &mdash; unplanned support</span>
+            <span class="count">2</span>
+          </summary>
+          <div class="glist">
+            <div class="wi">
+              <span class="type t-bug">Bug</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1260" target="_blank" rel="noopener">#1260</a>
+              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1260" target="_blank" rel="noopener">Deploy failing on scratch org spin-up</a></span>
+              <span class="state s-active">Active</span>
+            </div>
+            <div class="wi">
+              <span class="type t-task">Task</span>
+              <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1263" target="_blank" rel="noopener">#1263</a>
+              <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1263" target="_blank" rel="noopener">Help triage permission set assignment</a></span>
+              <span class="state s-new">New</span>
+            </div>
+          </div>
+        </details>
+
+      </div>
+    </details>
+
+  </div>
+
+  <p class="footer">
+    Mock &middot; placeholder data. Live build feeds from <code>az boards query</code> + the Outlook PowerShell module.
+  </p>
+
+</div>
+
+<script>
+  document.getElementById("expandAll").addEventListener("click", function () {
+    document.querySelectorAll("details").forEach(function (d) { d.open = true; });
+  });
+  document.getElementById("collapseAll").addEventListener("click", function () {
+    document.querySelectorAll(".tile").forEach(function (d) { d.open = false; });
+  });
+</script>
+</body>
+</html>

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -26,7 +26,7 @@
       <button class="btn" id="expandAll" type="button">Expand all</button>
       <button class="btn icon" id="themeToggle" type="button" aria-label="Toggle light or dark theme">
         <svg id="icon-sun" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="3.2" stroke="currentColor" stroke-width="1.5"/><path d="M8 1v1.6M8 13.4V15M1 8h1.6M13.4 8H15M3 3l1.1 1.1M11.9 11.9L13 13M13 3l-1.1 1.1M4.1 11.9L3 13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
-        <svg id="icon-moon" viewBox="0 0 16 16" fill="none" aria-hidden="true" style="display:none"><path d="M13.5 9.5A5.5 5.5 0 1 1 6.5 2.5a4.5 4.5 0 0 0 7 7z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
+        <svg id="icon-moon" class="is-hidden" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 9.5A5.5 5.5 0 1 1 6.5 2.5a4.5 4.5 0 0 0 7 7z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
       </button>
     </nav>
   </header>

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -251,6 +251,53 @@
     font-variant-numeric: tabular-nums;
   }
 
+  /* ---------- per-tile freshness + refresh ---------- */
+  .tile-meta {
+    flex: none;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .stale {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11.5px;
+    color: var(--text-dim);
+    white-space: nowrap;
+  }
+  .fdot {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: var(--good);
+    flex: none;
+  }
+  .stale.warn .fdot { background: var(--warn); }
+  .stale.busy { color: var(--accent); }
+  .stale.busy .fdot { background: var(--accent); }
+
+  .refresh-btn {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px; height: 28px;
+    padding: 0;
+    color: var(--text-dim);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    cursor: pointer;
+  }
+  .refresh-btn:hover { color: var(--accent); border-color: var(--border-strong); }
+  .refresh-btn:disabled { cursor: default; opacity: .8; }
+  .refresh-btn svg { width: 15px; height: 15px; }
+  .refresh-btn.spinning svg { animation: spin .7s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) {
+    .refresh-btn.spinning svg { animation: none; }
+    .chev { transition: none; }
+  }
+
   .tile .body {
     padding: 4px 18px 18px;
     border-top: 1px solid var(--border);
@@ -392,7 +439,8 @@
       <div class="sub">Azure DevOps agenda &middot; <span class="date">Tuesday, July 14</span></div>
     </div>
     <div class="toolbar">
-      <span class="synced"><span class="dot"></span>Synced 7:42 AM</span>
+      <span class="synced"><span class="dot"></span>Local cache</span>
+      <button class="btn" id="refreshAll" type="button">Refresh all</button>
       <button class="btn" id="collapseAll" type="button">Collapse all</button>
       <button class="btn" id="expandAll" type="button">Expand all</button>
     </div>
@@ -404,8 +452,11 @@
     <details class="tile" open>
       <summary>
         <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><h2>Today&rsquo;s Agenda</h2></span>
-        <span class="count">2</span>
+        <span class="tt"><h2>Today&rsquo;s Agenda</h2><span class="count">2</span></span>
+        <span class="tile-meta">
+          <span class="stale"><span class="fdot"></span>cached 12m ago</span>
+          <button class="refresh-btn" type="button" data-tile="agenda" aria-label="Refresh Today&rsquo;s Agenda"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+        </span>
       </summary>
       <div class="body">
 
@@ -434,8 +485,11 @@
     <details class="tile" open>
       <summary>
         <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><h2>This Week&rsquo;s Focus</h2></span>
-        <span class="count">2</span>
+        <span class="tt"><h2>This Week&rsquo;s Focus</h2><span class="count">2</span></span>
+        <span class="tile-meta">
+          <span class="stale warn"><span class="fdot"></span>cached 2h ago</span>
+          <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+        </span>
       </summary>
       <div class="body">
 
@@ -492,8 +546,11 @@
     <details class="tile" open>
       <summary>
         <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><h2>Recent Activity</h2></span>
-        <span class="count">3</span>
+        <span class="tt"><h2>Recent Activity</h2><span class="count">3</span></span>
+        <span class="tile-meta">
+          <span class="stale"><span class="fdot"></span>cached 5m ago</span>
+          <button class="refresh-btn" type="button" data-tile="activity" aria-label="Refresh Recent Activity"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+        </span>
       </summary>
       <div class="body">
 
@@ -568,8 +625,11 @@
     <details class="tile" open>
       <summary>
         <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="tt"><h2>Today&rsquo;s Focus</h2></span>
-        <span class="count">2</span>
+        <span class="tt"><h2>Today&rsquo;s Focus</h2><span class="count">2</span></span>
+        <span class="tile-meta">
+          <span class="stale warn"><span class="fdot"></span>cached 1h ago</span>
+          <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+        </span>
       </summary>
       <div class="body">
 
@@ -620,6 +680,42 @@
   });
   document.getElementById("collapseAll").addEventListener("click", function () {
     document.querySelectorAll(".tile").forEach(function (d) { d.open = false; });
+  });
+
+  // Per-tile refresh: the only expensive path. Cheap render is already on screen
+  // from cache; this is where the real build would fire that tile's az CLI calls.
+  var REFRESH_MS = 900;
+
+  function refreshTile(btn) {
+    if (btn.disabled) return;
+
+    var stale = btn.parentElement.querySelector(".stale");
+    var label = stale.childNodes[stale.childNodes.length - 1];
+
+    btn.disabled = true;
+    btn.classList.add("spinning");
+    stale.classList.remove("warn");
+    stale.classList.add("busy");
+    label.textContent = "refreshing…";
+
+    window.setTimeout(function () {
+      btn.classList.remove("spinning");
+      btn.disabled = false;
+      stale.classList.remove("busy");
+      label.textContent = "cached just now";
+    }, REFRESH_MS);
+  }
+
+  document.querySelectorAll(".refresh-btn").forEach(function (btn) {
+    btn.addEventListener("click", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      refreshTile(btn);
+    });
+  });
+
+  document.getElementById("refreshAll").addEventListener("click", function () {
+    document.querySelectorAll(".refresh-btn").forEach(refreshTile);
   });
 </script>
 </body>

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -1,0 +1,546 @@
+/* Daily Viewer — Azure DevOps agenda. Token-driven, dual-theme, rem-based.
+   Themes redefine only the color tokens; spacing / type / radius scales are
+   theme-independent. px is used only for borders/hairlines. */
+
+:root {
+  --bg: #EEF1F6;
+  --surface: #FFFFFF;
+  --surface-2: #F5F7FA;
+  --border: #DCE2EC;
+  --border-strong: #C6CFDC;
+  --text: #1B2430;
+  --text-dim: #5A6675;
+  --text-faint: #8A94A3;
+  --accent: #0E6FCE;
+  --accent-weak: rgba(14,111,206,.10);
+
+  --epic:    #C77700;
+  --feature: #7B49D6;
+  --story:   #1E86BE;
+  --bug:     #D1373A;
+  --task:    #2C9E43;
+
+  --good: #2C9E43;
+  --warn: #B5820A;
+  --crit: #D1373A;
+
+  --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);
+
+  /* spacing scale */
+  --space-0: 0.125rem;   /*  2px */
+  --space-1: 0.25rem;    /*  4px */
+  --space-2: 0.375rem;   /*  6px */
+  --space-3: 0.5rem;     /*  8px */
+  --space-4: 0.625rem;   /* 10px */
+  --space-5: 0.75rem;    /* 12px */
+  --space-6: 0.875rem;   /* 14px */
+  --space-7: 1.125rem;   /* 18px */
+  --space-8: 1.375rem;   /* 22px */
+  --space-9: 1.5rem;     /* 24px */
+  --space-10: 3.5rem;    /* 56px */
+
+  /* type scale */
+  --fs-2xs:  0.6875rem;  /* 11px */
+  --fs-xs:   0.71875rem; /* 11.5px */
+  --fs-sm:   0.75rem;    /* 12px */
+  --fs-smd:  0.78125rem; /* 12.5px */
+  --fs-md:   0.8125rem;  /* 13px */
+  --fs-lg:   0.875rem;   /* 14px */
+  --fs-base: 0.9375rem;  /* 15px */
+  --fs-h1:   1.375rem;   /* 22px */
+  --fs-stat: 1.4375rem;  /* 23px */
+
+  /* radii */
+  --radius-xs: 0.25rem;  /*  4px */
+  --radius-sm: 0.5rem;   /*  8px */
+  --radius-md: 0.625rem; /* 10px */
+  --radius: 0.75rem;     /* 12px */
+  --radius-pill: 999px;
+
+  --icon: 1rem;          /* 16px */
+
+  --font: "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+  --mono: "Cascadia Code", "Cascadia Mono", Consolas, "SF Mono", ui-monospace, monospace;
+
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0F131A;
+    --surface: #171C25;
+    --surface-2: #1E2531;
+    --border: #29313D;
+    --border-strong: #38424F;
+    --text: #E7ECF3;
+    --text-dim: #97A3B4;
+    --text-faint: #6C7889;
+    --accent: #4AA3F0;
+    --accent-weak: rgba(74,163,240,.14);
+
+    --epic:    #E8A317;
+    --feature: #A47CF0;
+    --story:   #3FB4E8;
+    --bug:     #E5645F;
+    --task:    #4FBF63;
+
+    --good: #4FBF63;
+    --warn: #D9A521;
+    --crit: #E5645F;
+
+    --shadow: 0 1px 2px rgba(0,0,0,.30), 0 8px 24px rgba(0,0,0,.30);
+    color-scheme: dark;
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg: #0F131A;
+  --surface: #171C25;
+  --surface-2: #1E2531;
+  --border: #29313D;
+  --border-strong: #38424F;
+  --text: #E7ECF3;
+  --text-dim: #97A3B4;
+  --text-faint: #6C7889;
+  --accent: #4AA3F0;
+  --accent-weak: rgba(74,163,240,.14);
+  --epic: #E8A317; --feature: #A47CF0; --story: #3FB4E8; --bug: #E5645F; --task: #4FBF63;
+  --good: #4FBF63; --warn: #D9A521; --crit: #E5645F;
+  --shadow: 0 1px 2px rgba(0,0,0,.30), 0 8px 24px rgba(0,0,0,.30);
+  color-scheme: dark;
+}
+
+:root[data-theme="light"] {
+  --bg: #EEF1F6;
+  --surface: #FFFFFF;
+  --surface-2: #F5F7FA;
+  --border: #DCE2EC;
+  --border-strong: #C6CFDC;
+  --text: #1B2430;
+  --text-dim: #5A6675;
+  --text-faint: #8A94A3;
+  --accent: #0E6FCE;
+  --accent-weak: rgba(14,111,206,.10);
+  --epic: #C77700; --feature: #7B49D6; --story: #1E86BE; --bug: #D1373A; --task: #2C9E43;
+  --good: #2C9E43; --warn: #B5820A; --crit: #D1373A;
+  --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);
+  color-scheme: light;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: var(--fs-base);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+a:focus-visible,
+summary:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-xs);
+}
+
+/* visually-hidden but available to assistive tech */
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.wrap {
+  max-width: 73.75rem;
+  margin: 0 auto;
+  padding: var(--space-8) var(--space-9) var(--space-10);
+}
+
+/* ---------- top bar ---------- */
+.topbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-7);
+  flex-wrap: wrap;
+  padding-bottom: var(--space-7);
+  margin-bottom: var(--space-8);
+  border-bottom: 1px solid var(--border);
+}
+.brand h1 {
+  margin: 0;
+  font-size: var(--fs-h1);
+  font-weight: 650;
+  letter-spacing: -.01em;
+}
+.brand .sub {
+  margin-top: var(--space-1);
+  color: var(--text-dim);
+  font-size: var(--fs-md);
+}
+.brand .date {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+.synced {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--fs-smd);
+  color: var(--text-dim);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-pill);
+}
+.synced .dot {
+  width: 0.5rem; height: 0.5rem; border-radius: 50%;
+  background: var(--good);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--good) 22%, transparent);
+}
+.btn {
+  font-family: inherit;
+  font-size: var(--fs-smd);
+  color: var(--text-dim);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.btn:hover { color: var(--text); border-color: var(--border-strong); }
+.btn.icon { padding: var(--space-2) var(--space-3); display: inline-flex; align-items: center; }
+.btn.icon svg { width: 0.9375rem; height: 0.9375rem; }
+
+.search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-4);
+}
+.search:focus-within { border-color: var(--accent); }
+.search svg { width: 0.875rem; height: 0.875rem; color: var(--text-faint); flex: none; }
+.search input {
+  border: 0; background: transparent; outline: none;
+  font-family: inherit; font-size: var(--fs-md); color: var(--text);
+  width: 9.25rem;
+}
+.search input::placeholder { color: var(--text-faint); }
+
+/* ---------- summary stat strip ---------- */
+.stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-5);
+  margin-bottom: var(--space-8);
+}
+.stat {
+  font-family: inherit;
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-5) var(--space-6);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.stat:hover { border-color: var(--border-strong); box-shadow: var(--shadow); }
+.stat .n {
+  font-size: var(--fs-stat);
+  font-weight: 680;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--stat, var(--text));
+}
+.stat .l { font-size: var(--fs-sm); color: var(--text-dim); }
+.stat.a { --stat: var(--accent); }
+.stat.f { --stat: var(--feature); }
+.stat.s { --stat: var(--story); }
+.stat.g { --stat: var(--warn); }
+
+/* ---------- grid ---------- */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-7);
+}
+@media (max-width: 51.25em) {
+  .stats { grid-template-columns: repeat(2, 1fr); }
+  .grid { grid-template-columns: 1fr; }
+}
+
+/* ---------- tile (section = card, details = collapsible) ---------- */
+.tile {
+  display: block;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.tile[data-tile="agenda"]   { --tint: var(--accent); }
+.tile[data-tile="week"]     { --tint: var(--feature); }
+.tile[data-tile="activity"] { --tint: var(--story); }
+.tile[data-tile="focus"]    { --tint: var(--warn); }
+
+.tile > details > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  padding: var(--space-6) var(--space-7);
+  user-select: none;
+}
+.tile > details > summary::-webkit-details-marker { display: none; }
+.tile > details > summary:hover { background: var(--surface-2); }
+
+.chev {
+  flex: none;
+  width: var(--icon); height: var(--icon);
+  color: var(--text-faint);
+  transition: transform .18s ease;
+}
+details[open] > summary > .chev { transform: rotate(90deg); }
+
+.tt {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex: 1;
+  min-width: 0;
+}
+.ticon {
+  flex: none;
+  width: var(--icon); height: var(--icon);
+  color: var(--tint, var(--accent));
+}
+.tt h2 {
+  margin: 0;
+  font-size: var(--fs-smd);
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+.count {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  color: var(--text-dim);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 0 var(--space-3);
+  font-variant-numeric: tabular-nums;
+}
+
+.wi.hide, .event.hide, .group.hide { display: none; }
+.nomatch {
+  display: none;
+  padding: var(--space-6) var(--space-0) var(--space-0);
+  color: var(--text-faint);
+  font-size: var(--fs-md);
+}
+.tile.empty .nomatch { display: block; }
+
+/* ---------- per-tile freshness + refresh ---------- */
+.tile-meta {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+.stale {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--fs-xs);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.fdot {
+  width: 0.4375rem; height: 0.4375rem; border-radius: 50%;
+  background: var(--good);
+  flex: none;
+}
+.stale.warn .fdot { background: var(--warn); }
+.stale.busy { color: var(--accent); }
+.stale.busy .fdot { background: var(--accent); }
+
+.refresh-btn {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem; height: 1.75rem;
+  padding: 0;
+  color: var(--text-dim);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.refresh-btn:hover { color: var(--accent); border-color: var(--border-strong); }
+.refresh-btn:disabled { cursor: default; opacity: .8; }
+.refresh-btn svg { width: 0.9375rem; height: 0.9375rem; }
+.refresh-btn.spinning svg { animation: spin .7s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .refresh-btn.spinning svg { animation: none; }
+  .chev { transition: none; }
+}
+
+.body {
+  padding: var(--space-1) var(--space-7) var(--space-7);
+  border-top: 1px solid var(--border);
+}
+
+/* ---------- agenda events ---------- */
+.events, .glist { list-style: none; margin: 0; padding: 0; }
+.event {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  gap: var(--space-6);
+  padding: var(--space-6) 0;
+  border-bottom: 1px dashed var(--border);
+}
+.event:last-child { border-bottom: 0; }
+.event .time {
+  font-family: var(--mono);
+  font-size: var(--fs-md);
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.event .time .tz { display: block; color: var(--text-faint); font-weight: 400; font-size: var(--fs-2xs); }
+.event .etitle { font-weight: 600; margin-bottom: var(--space-1); }
+.meta { font-size: var(--fs-md); color: var(--text-dim); }
+.meta .k { color: var(--text-faint); }
+.where {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-weight: 500;
+}
+.badge-loc {
+  font-size: var(--fs-2xs); font-weight: 600;
+  padding: 0 var(--space-3); border-radius: var(--radius-pill);
+  background: var(--accent-weak); color: var(--accent);
+}
+
+/* ---------- nested drill-in groups ---------- */
+.group { border-top: 1px solid var(--border); }
+.group:first-child { border-top: 0; }
+.group > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-5) 0;
+  user-select: none;
+}
+.group > summary::-webkit-details-marker { display: none; }
+.group > summary:hover .glabel { color: var(--accent); }
+.glabel { font-weight: 600; font-size: var(--fs-lg); flex: 1; }
+.glist {
+  padding: 0 0 var(--space-5) var(--space-9);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+/* ---------- work item rows ---------- */
+.wi {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+.wi .id {
+  font-family: var(--mono);
+  font-size: var(--fs-smd);
+  font-variant-numeric: tabular-nums;
+}
+.type {
+  flex: none;
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-size: var(--fs-2xs); font-weight: 600;
+  color: var(--text-dim);
+}
+.type::before {
+  content: ""; width: 0.5625rem; height: 0.5625rem; border-radius: 0.125rem;
+  background: var(--dot, var(--text-faint));
+}
+.t-epic    { --dot: var(--epic); }
+.t-feature { --dot: var(--feature); }
+.t-story   { --dot: var(--story); }
+.t-bug     { --dot: var(--bug); }
+.t-bug::before { border-radius: 50%; }
+.t-task    { --dot: var(--task); }
+.wi .wtitle { flex: 1; min-width: 8.75rem; }
+.wi .wtitle a { color: var(--text); }
+.wi .wtitle a:hover { color: var(--accent); }
+
+.state {
+  font-size: var(--fs-2xs); font-weight: 700; letter-spacing: .03em;
+  padding: 0 var(--space-3); border-radius: var(--radius-xs);
+  text-transform: uppercase;
+}
+.s-active   { color: var(--accent); background: var(--accent-weak); }
+.s-progress { color: var(--warn);   background: color-mix(in srgb, var(--warn) 15%, transparent); }
+.s-review   { color: var(--feature);background: color-mix(in srgb, var(--feature) 16%, transparent); }
+.s-closing  { color: var(--good);   background: color-mix(in srgb, var(--good) 15%, transparent); }
+.s-new      { color: var(--text-dim); background: var(--surface-2); }
+
+.note { font-size: var(--fs-smd); color: var(--text-dim); }
+.check {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-size: var(--fs-sm); font-weight: 600; color: var(--warn);
+}
+.check::before { content: "\25CB"; }        /* open circle = to confirm */
+
+.primary {
+  display: flex; gap: var(--space-5); align-items: flex-start;
+  padding: var(--space-5) var(--space-6); margin: var(--space-5) 0 var(--space-1);
+  background: var(--accent-weak);
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
+  border-radius: var(--radius-md);
+}
+.primary .star { color: var(--accent); font-size: var(--fs-base); line-height: 1.6; }
+.primary .ptitle { font-weight: 650; }
+.primary .psub { font-size: var(--fs-smd); color: var(--text-dim); margin-top: var(--space-0); }
+
+.footer {
+  margin-top: var(--space-9);
+  font-size: var(--fs-sm);
+  color: var(--text-faint);
+  text-align: center;
+}
+.footer code {
+  font-family: var(--mono);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 0 var(--space-2); border-radius: var(--radius-xs);
+  color: var(--text-dim);
+}

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -104,8 +104,17 @@
   --text-faint: #6C7889;
   --accent: #4AA3F0;
   --accent-weak: rgba(74,163,240,.14);
-  --epic: #E8A317; --feature: #A47CF0; --story: #3FB4E8; --bug: #E5645F; --task: #4FBF63;
-  --good: #4FBF63; --warn: #D9A521; --crit: #E5645F;
+
+  --epic:    #E8A317;
+  --feature: #A47CF0;
+  --story:   #3FB4E8;
+  --bug:     #E5645F;
+  --task:    #4FBF63;
+
+  --good: #4FBF63;
+  --warn: #D9A521;
+  --crit: #E5645F;
+
   --shadow: 0 1px 2px rgba(0,0,0,.30), 0 8px 24px rgba(0,0,0,.30);
   color-scheme: dark;
 }
@@ -121,8 +130,17 @@
   --text-faint: #8A94A3;
   --accent: #0E6FCE;
   --accent-weak: rgba(14,111,206,.10);
-  --epic: #C77700; --feature: #7B49D6; --story: #1E86BE; --bug: #D1373A; --task: #2C9E43;
-  --good: #2C9E43; --warn: #B5820A; --crit: #D1373A;
+
+  --epic:    #C77700;
+  --feature: #7B49D6;
+  --story:   #1E86BE;
+  --bug:     #D1373A;
+  --task:    #2C9E43;
+
+  --good: #2C9E43;
+  --warn: #B5820A;
+  --crit: #D1373A;
+
   --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);
   color-scheme: light;
 }
@@ -148,6 +166,8 @@ button:focus-visible {
   outline-offset: 2px;
   border-radius: var(--radius-xs);
 }
+
+.is-hidden { display: none; }
 
 /* visually-hidden but available to assistive tech */
 .sr-only {

--- a/daily-viewer/wpf/DailyViewer.xaml
+++ b/daily-viewer/wpf/DailyViewer.xaml
@@ -1,0 +1,428 @@
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Daily Viewer — Azure DevOps Agenda"
+        Width="1080" Height="760"
+        WindowStartupLocation="CenterScreen"
+        UseLayoutRounding="True"
+        TextOptions.TextFormattingMode="Ideal"
+        FontFamily="Segoe UI" FontSize="14">
+
+  <!--
+    WPF translation of daily-viewer/index.html.
+    Palette brushes carry x:Key names the launcher mutates for the light/dark
+    toggle. Work-item type colors stay constant across themes.
+  -->
+  <Window.Resources>
+
+    <SolidColorBrush x:Key="Bg"          Color="#0F131A"/>
+    <SolidColorBrush x:Key="Surface"     Color="#171C25"/>
+    <SolidColorBrush x:Key="Surface2"    Color="#1E2531"/>
+    <SolidColorBrush x:Key="Border"      Color="#29313D"/>
+    <SolidColorBrush x:Key="BorderStrong" Color="#38424F"/>
+    <SolidColorBrush x:Key="Text"        Color="#E7ECF3"/>
+    <SolidColorBrush x:Key="TextDim"     Color="#97A3B4"/>
+    <SolidColorBrush x:Key="TextFaint"   Color="#6C7889"/>
+    <SolidColorBrush x:Key="Accent"      Color="#4AA3F0"/>
+    <SolidColorBrush x:Key="AccentWeak"  Color="#22345066"/>
+
+    <SolidColorBrush x:Key="Feature" Color="#A47CF0"/>
+    <SolidColorBrush x:Key="Story"   Color="#3FB4E8"/>
+    <SolidColorBrush x:Key="Task"    Color="#4FBF63"/>
+    <SolidColorBrush x:Key="Bug"     Color="#E5645F"/>
+    <SolidColorBrush x:Key="Good"    Color="#4FBF63"/>
+    <SolidColorBrush x:Key="Warn"    Color="#D9A521"/>
+
+    <!-- card wrapper -->
+    <Style x:Key="Card" TargetType="Border">
+      <Setter Property="Background" Value="{DynamicResource Surface}"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource Border}"/>
+      <Setter Property="BorderThickness" Value="1"/>
+      <Setter Property="CornerRadius" Value="12"/>
+    </Style>
+
+    <!-- small toolbar / icon button -->
+    <Style x:Key="ToolButton" TargetType="Button">
+      <Setter Property="Background" Value="{DynamicResource Surface}"/>
+      <Setter Property="Foreground" Value="{DynamicResource TextDim}"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource Border}"/>
+      <Setter Property="BorderThickness" Value="1"/>
+      <Setter Property="Padding" Value="10,5"/>
+      <Setter Property="Cursor" Value="Hand"/>
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="Button">
+            <Border Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="8" Padding="{TemplateBinding Padding}">
+              <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
+
+    <!-- pill count badge -->
+    <Style x:Key="Count" TargetType="Border">
+      <Setter Property="Background" Value="{DynamicResource Surface2}"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource Border}"/>
+      <Setter Property="BorderThickness" Value="1"/>
+      <Setter Property="CornerRadius" Value="9"/>
+      <Setter Property="Padding" Value="7,0"/>
+      <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+
+    <Style x:Key="H2" TargetType="TextBlock">
+      <Setter Property="Foreground" Value="{DynamicResource Text}"/>
+      <Setter Property="FontSize" Value="12.5"/>
+      <Setter Property="FontWeight" Value="Bold"/>
+      <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+
+    <Style x:Key="Link" TargetType="Hyperlink">
+      <Setter Property="Foreground" Value="{DynamicResource Accent}"/>
+      <Setter Property="TextDecorations" Value="{x:Null}"/>
+    </Style>
+
+    <!-- native Expander used as the collapsible tile / group -->
+    <Style x:Key="Tile" TargetType="Expander">
+      <Setter Property="IsExpanded" Value="True"/>
+      <Setter Property="Foreground" Value="{DynamicResource Text}"/>
+      <Setter Property="Background" Value="Transparent"/>
+      <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+    </Style>
+
+  </Window.Resources>
+
+  <Border Background="{DynamicResource Bg}">
+    <Grid Margin="22,18,22,22">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto"/>   <!-- top bar -->
+        <RowDefinition Height="Auto"/>   <!-- stat strip -->
+        <RowDefinition Height="*"/>      <!-- tile grid -->
+        <RowDefinition Height="Auto"/>   <!-- footer -->
+      </Grid.RowDefinitions>
+
+      <!-- ============ TOP BAR ============ -->
+      <Grid Grid.Row="0" Margin="0,0,0,18">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*"/>
+          <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <StackPanel Grid.Column="0" VerticalAlignment="Center">
+          <TextBlock Text="Daily Viewer" Foreground="{DynamicResource Text}"
+                     FontSize="22" FontWeight="SemiBold"/>
+          <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+            <TextBlock Text="Azure DevOps agenda · " Foreground="{DynamicResource TextDim}" FontSize="13"/>
+            <TextBlock Text="Tuesday, July 14" Foreground="{DynamicResource Accent}" FontSize="13" FontWeight="SemiBold"/>
+          </StackPanel>
+        </StackPanel>
+
+        <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom">
+          <Border Background="{DynamicResource Surface}" BorderBrush="{DynamicResource Border}"
+                  BorderThickness="1" CornerRadius="14" Padding="11,5" Margin="0,0,8,0"
+                  VerticalAlignment="Center">
+            <StackPanel Orientation="Horizontal">
+              <Ellipse Width="8" Height="8" Fill="{DynamicResource Good}" VerticalAlignment="Center" Margin="0,0,7,0"/>
+              <TextBlock Text="Local cache" Foreground="{DynamicResource TextDim}" FontSize="12.5" VerticalAlignment="Center"/>
+            </StackPanel>
+          </Border>
+          <Button x:Name="RefreshAllButton" Style="{StaticResource ToolButton}" Content="Refresh all" Margin="0,0,8,0"/>
+          <Button x:Name="ThemeButton" Style="{StaticResource ToolButton}" Content="◐" FontSize="15"/>
+        </StackPanel>
+      </Grid>
+
+      <!-- ============ STAT STRIP ============ -->
+      <UniformGrid Grid.Row="1" Columns="4" Margin="0,0,0,18">
+        <Button x:Name="StatAgenda" Tag="TileAgenda" Cursor="Hand" Background="Transparent" BorderThickness="0" Padding="0" Margin="0,0,6,0">
+          <Border Style="{StaticResource Card}" Padding="14,12">
+            <StackPanel>
+              <TextBlock Text="2" Foreground="{DynamicResource Accent}" FontSize="23" FontWeight="Bold"/>
+              <TextBlock Text="Meetings today" Foreground="{DynamicResource TextDim}" FontSize="12" Margin="0,3,0,0"/>
+            </StackPanel>
+          </Border>
+        </Button>
+        <Button x:Name="StatWeek" Tag="TileWeek" Cursor="Hand" Background="Transparent" BorderThickness="0" Padding="0" Margin="3,0,3,0">
+          <Border Style="{StaticResource Card}" Padding="14,12">
+            <StackPanel>
+              <TextBlock Text="3" Foreground="{DynamicResource Feature}" FontSize="23" FontWeight="Bold"/>
+              <TextBlock Text="Stories due this week" Foreground="{DynamicResource TextDim}" FontSize="12" Margin="0,3,0,0"/>
+            </StackPanel>
+          </Border>
+        </Button>
+        <Button x:Name="StatActivity" Tag="TileActivity" Cursor="Hand" Background="Transparent" BorderThickness="0" Padding="0" Margin="3,0,3,0">
+          <Border Style="{StaticResource Card}" Padding="14,12">
+            <StackPanel>
+              <TextBlock Text="6" Foreground="{DynamicResource Story}" FontSize="23" FontWeight="Bold"/>
+              <TextBlock Text="Recent updates" Foreground="{DynamicResource TextDim}" FontSize="12" Margin="0,3,0,0"/>
+            </StackPanel>
+          </Border>
+        </Button>
+        <Button x:Name="StatFocus" Tag="TileFocus" Cursor="Hand" Background="Transparent" BorderThickness="0" Padding="0" Margin="6,0,0,0">
+          <Border Style="{StaticResource Card}" Padding="14,12">
+            <StackPanel>
+              <TextBlock Text="2" Foreground="{DynamicResource Warn}" FontSize="23" FontWeight="Bold"/>
+              <TextBlock Text="Support &amp; focus items" Foreground="{DynamicResource TextDim}" FontSize="12" Margin="0,3,0,0"/>
+            </StackPanel>
+          </Border>
+        </Button>
+      </UniformGrid>
+
+      <!-- ============ TILE GRID (2x2) ============ -->
+      <Grid Grid.Row="2">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*"/>
+          <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="*"/>
+          <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Today's Agenda -->
+        <Border Grid.Row="0" Grid.Column="0" Style="{StaticResource Card}" Margin="0,0,9,9">
+          <Expander x:Name="TileAgenda" Style="{StaticResource Tile}" Padding="14,8,14,12">
+            <Expander.Header>
+              <Grid Margin="6,0,0,0">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="Auto"/>
+                  <ColumnDefinition Width="Auto"/>
+                  <ColumnDefinition Width="Auto"/>
+                  <ColumnDefinition Width="*"/>
+                  <ColumnDefinition Width="Auto"/>
+                  <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Ellipse Grid.Column="0" Width="9" Height="9" Fill="{DynamicResource Accent}" VerticalAlignment="Center" Margin="0,0,9,0"/>
+                <TextBlock Grid.Column="1" Text="TODAY'S AGENDA" Style="{StaticResource H2}"/>
+                <Border Grid.Column="2" Style="{StaticResource Count}" Margin="9,0,0,0">
+                  <TextBlock Text="2" Foreground="{DynamicResource TextDim}" FontSize="11.5"/>
+                </Border>
+                <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,8,0">
+                  <Ellipse Width="7" Height="7" Fill="{DynamicResource Good}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                  <TextBlock x:Name="StaleAgenda" Text="cached 12m ago" Foreground="{DynamicResource TextDim}" FontSize="11.5"/>
+                </StackPanel>
+                <Button Grid.Column="5" x:Name="RefreshAgenda" Style="{StaticResource ToolButton}" Content="↻" FontSize="14" Padding="7,3"/>
+              </Grid>
+            </Expander.Header>
+
+            <StackPanel Margin="6,8,0,0">
+              <StackPanel Margin="0,0,0,12">
+                <StackPanel Orientation="Horizontal">
+                  <TextBlock Text="9:00 AM EST" Foreground="{DynamicResource Text}" FontFamily="Consolas" FontWeight="SemiBold" Width="110"/>
+                  <StackPanel>
+                    <TextBlock Text="Sprint Planning Sync" Foreground="{DynamicResource Text}" FontWeight="SemiBold"/>
+                    <TextBlock Foreground="{DynamicResource TextDim}" FontSize="13" Margin="0,3,0,0">
+                      <Run Text="Teams · "/><Hyperlink Style="{StaticResource Link}" NavigateUri="https://teams.microsoft.com/l/meetup-join/example">Join meeting →</Hyperlink>
+                    </TextBlock>
+                    <TextBlock Text="With Platform Team · 6 attendees" Foreground="{DynamicResource TextDim}" FontSize="13"/>
+                  </StackPanel>
+                </StackPanel>
+              </StackPanel>
+              <StackPanel Orientation="Horizontal">
+                <TextBlock Text="11:00 AM EST" Foreground="{DynamicResource Text}" FontFamily="Consolas" FontWeight="SemiBold" Width="110"/>
+                <StackPanel>
+                  <TextBlock Text="Architecture Design Review" Foreground="{DynamicResource Text}" FontWeight="SemiBold"/>
+                  <TextBlock Text="In person · Room 132" Foreground="{DynamicResource TextDim}" FontSize="13" Margin="0,3,0,0"/>
+                  <TextBlock Foreground="{DynamicResource TextDim}" FontSize="13">
+                    <Run Text="Prep · "/><Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_wiki">Design doc →</Hyperlink>
+                  </TextBlock>
+                </StackPanel>
+              </StackPanel>
+            </StackPanel>
+          </Expander>
+        </Border>
+
+        <!-- This Week's Focus -->
+        <Border Grid.Row="0" Grid.Column="1" Style="{StaticResource Card}" Margin="9,0,0,9">
+          <Expander x:Name="TileWeek" Style="{StaticResource Tile}" Padding="14,8,14,12">
+            <Expander.Header>
+              <Grid Margin="6,0,0,0">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/>
+                  <ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Ellipse Grid.Column="0" Width="9" Height="9" Fill="{DynamicResource Feature}" VerticalAlignment="Center" Margin="0,0,9,0"/>
+                <TextBlock Grid.Column="1" Text="THIS WEEK'S FOCUS" Style="{StaticResource H2}"/>
+                <Border Grid.Column="2" Style="{StaticResource Count}" Margin="9,0,0,0">
+                  <TextBlock Text="2" Foreground="{DynamicResource TextDim}" FontSize="11.5"/>
+                </Border>
+                <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,8,0">
+                  <Ellipse Width="7" Height="7" Fill="{DynamicResource Warn}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                  <TextBlock x:Name="StaleWeek" Text="cached 2h ago" Foreground="{DynamicResource TextDim}" FontSize="11.5"/>
+                </StackPanel>
+                <Button Grid.Column="5" x:Name="RefreshWeek" Style="{StaticResource ToolButton}" Content="↻" FontSize="14" Padding="7,3"/>
+              </Grid>
+            </Expander.Header>
+
+            <StackPanel Margin="6,8,0,0">
+              <Expander Header="Stories to complete" IsExpanded="True" Foreground="{DynamicResource Text}" Margin="0,0,0,6">
+                <StackPanel Margin="20,6,0,6">
+                  <Grid Margin="0,0,0,8">
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,9,0">
+                      <Rectangle Width="9" Height="9" Fill="{DynamicResource Story}" RadiusX="2" RadiusY="2" Margin="0,0,6,0"/>
+                      <TextBlock Text="Story" Foreground="{DynamicResource TextDim}" FontSize="11"/>
+                    </StackPanel>
+                    <TextBlock Grid.Column="1" FontFamily="Consolas" FontSize="12.5" VerticalAlignment="Center" Margin="0,0,9,0">
+                      <Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1234">#1234</Hyperlink>
+                    </TextBlock>
+                    <TextBlock Grid.Column="2" Text="Wire agenda tile to az boards query" Foreground="{DynamicResource Text}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                    <Border Grid.Column="3" Background="#33D9A521" CornerRadius="4" Padding="7,1" VerticalAlignment="Center">
+                      <TextBlock Text="IN PROGRESS" Foreground="{DynamicResource Warn}" FontSize="10.5" FontWeight="Bold"/>
+                    </Border>
+                  </Grid>
+                  <Grid>
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,9,0">
+                      <Rectangle Width="9" Height="9" Fill="{DynamicResource Story}" RadiusX="2" RadiusY="2" Margin="0,0,6,0"/>
+                      <TextBlock Text="Story" Foreground="{DynamicResource TextDim}" FontSize="11"/>
+                    </StackPanel>
+                    <TextBlock Grid.Column="1" FontFamily="Consolas" FontSize="12.5" VerticalAlignment="Center" Margin="0,0,9,0">
+                      <Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1240">#1240</Hyperlink>
+                    </TextBlock>
+                    <TextBlock Grid.Column="2" Text="Outlook calendar pull for daily events" Foreground="{DynamicResource Text}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                    <Border Grid.Column="3" Background="{DynamicResource AccentWeak}" CornerRadius="4" Padding="7,1" VerticalAlignment="Center">
+                      <TextBlock Text="ACTIVE" Foreground="{DynamicResource Accent}" FontSize="10.5" FontWeight="Bold"/>
+                    </Border>
+                  </Grid>
+                </StackPanel>
+              </Expander>
+
+              <Expander Header="Events to prepare for" IsExpanded="True" Foreground="{DynamicResource Text}">
+                <StackPanel Margin="20,6,0,6">
+                  <TextBlock Foreground="{DynamicResource Text}" Margin="0,0,0,6">
+                    <Run Text="○ " Foreground="#D9A521"/><Run Text="Confirm demo build is deployed before Thu review"/>
+                  </TextBlock>
+                  <TextBlock Foreground="{DynamicResource Text}">
+                    <Run Text="○ " Foreground="#D9A521"/><Run Text="Send agenda for "/><Hyperlink Style="{StaticResource Link}" NavigateUri="https://teams.microsoft.com/l/meetup-join/example2">Fri sprint retro</Hyperlink>
+                  </TextBlock>
+                </StackPanel>
+              </Expander>
+            </StackPanel>
+          </Expander>
+        </Border>
+
+        <!-- Recent Activity -->
+        <Border Grid.Row="1" Grid.Column="0" Style="{StaticResource Card}" Margin="0,9,9,0">
+          <Expander x:Name="TileActivity" Style="{StaticResource Tile}" Padding="14,8,14,12">
+            <Expander.Header>
+              <Grid Margin="6,0,0,0">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/>
+                  <ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Ellipse Grid.Column="0" Width="9" Height="9" Fill="{DynamicResource Story}" VerticalAlignment="Center" Margin="0,0,9,0"/>
+                <TextBlock Grid.Column="1" Text="RECENT ACTIVITY" Style="{StaticResource H2}"/>
+                <Border Grid.Column="2" Style="{StaticResource Count}" Margin="9,0,0,0">
+                  <TextBlock Text="3" Foreground="{DynamicResource TextDim}" FontSize="11.5"/>
+                </Border>
+                <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,8,0">
+                  <Ellipse Width="7" Height="7" Fill="{DynamicResource Good}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                  <TextBlock x:Name="StaleActivity" Text="cached 5m ago" Foreground="{DynamicResource TextDim}" FontSize="11.5"/>
+                </StackPanel>
+                <Button Grid.Column="5" x:Name="RefreshActivity" Style="{StaticResource ToolButton}" Content="↻" FontSize="14" Padding="7,3"/>
+              </Grid>
+            </Expander.Header>
+
+            <StackPanel Margin="6,8,0,0">
+              <Expander Header="Tagged discussions" Foreground="{DynamicResource Text}" Margin="0,0,0,4">
+                <StackPanel Margin="20,6,0,6">
+                  <TextBlock Foreground="{DynamicResource Text}" Margin="0,0,0,6" TextWrapping="Wrap">
+                    <Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1180">#1180</Hyperlink><Run Text="  @you — “can you confirm the WIQL scope?”"/>
+                  </TextBlock>
+                  <TextBlock Foreground="{DynamicResource Text}" TextWrapping="Wrap">
+                    <Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1240">#1240</Hyperlink><Run Text="  @you — “ready for review whenever”"/>
+                  </TextBlock>
+                </StackPanel>
+              </Expander>
+
+              <Expander Header="Active story updates" Foreground="{DynamicResource Text}" Margin="0,0,0,4">
+                <StackPanel Margin="20,6,0,6">
+                  <TextBlock Foreground="{DynamicResource TextDim}" Margin="0,0,0,6" TextWrapping="Wrap">
+                    <Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1234">#1234</Hyperlink><Run Text="  State → In progress by A. Rivera · 2h ago"/>
+                  </TextBlock>
+                  <TextBlock Foreground="{DynamicResource TextDim}" TextWrapping="Wrap">
+                    <Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1251">#1251</Hyperlink><Run Text="  Moved to In review · 4h ago"/>
+                  </TextBlock>
+                </StackPanel>
+              </Expander>
+
+              <Expander Header="Sprint close items" Foreground="{DynamicResource Text}">
+                <StackPanel Margin="20,6,0,6">
+                  <TextBlock Foreground="{DynamicResource Text}" Margin="0,0,0,6" TextWrapping="Wrap">
+                    <Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1209">#1209</Hyperlink><Run Text="  Update release notes"/>
+                  </TextBlock>
+                  <TextBlock Foreground="{DynamicResource Text}" TextWrapping="Wrap">
+                    <Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1222">#1222</Hyperlink><Run Text="  Verify acceptance criteria signed off"/>
+                  </TextBlock>
+                </StackPanel>
+              </Expander>
+            </StackPanel>
+          </Expander>
+        </Border>
+
+        <!-- Today's Focus -->
+        <Border Grid.Row="1" Grid.Column="1" Style="{StaticResource Card}" Margin="9,9,0,0">
+          <Expander x:Name="TileFocus" Style="{StaticResource Tile}" Padding="14,8,14,12">
+            <Expander.Header>
+              <Grid Margin="6,0,0,0">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/>
+                  <ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Ellipse Grid.Column="0" Width="9" Height="9" Fill="{DynamicResource Warn}" VerticalAlignment="Center" Margin="0,0,9,0"/>
+                <TextBlock Grid.Column="1" Text="TODAY'S FOCUS" Style="{StaticResource H2}"/>
+                <Border Grid.Column="2" Style="{StaticResource Count}" Margin="9,0,0,0">
+                  <TextBlock Text="2" Foreground="{DynamicResource TextDim}" FontSize="11.5"/>
+                </Border>
+                <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,8,0">
+                  <Ellipse Width="7" Height="7" Fill="{DynamicResource Warn}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                  <TextBlock x:Name="StaleFocus" Text="cached 1h ago" Foreground="{DynamicResource TextDim}" FontSize="11.5"/>
+                </StackPanel>
+                <Button Grid.Column="5" x:Name="RefreshFocus" Style="{StaticResource ToolButton}" Content="↻" FontSize="14" Padding="7,3"/>
+              </Grid>
+            </Expander.Header>
+
+            <StackPanel Margin="6,8,0,0">
+              <Border Background="{DynamicResource AccentWeak}" BorderBrush="{DynamicResource Accent}" BorderThickness="1"
+                      CornerRadius="10" Padding="13,11" Margin="0,0,0,10">
+                <StackPanel Orientation="Horizontal">
+                  <TextBlock Text="★" Foreground="{DynamicResource Accent}" FontSize="15" Margin="0,0,10,0"/>
+                  <StackPanel>
+                    <TextBlock>
+                      <Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1234"><Run Text="User Story #1234 — Wire agenda tile to az boards" FontWeight="SemiBold"/></Hyperlink>
+                    </TextBlock>
+                    <TextBlock Text="Primary commitment for today · In progress" Foreground="{DynamicResource TextDim}" FontSize="12.5" Margin="0,2,0,0"/>
+                  </StackPanel>
+                </StackPanel>
+              </Border>
+
+              <Expander Header="SF devs — unplanned support" IsExpanded="True" Foreground="{DynamicResource Text}">
+                <StackPanel Margin="20,6,0,6">
+                  <TextBlock Foreground="{DynamicResource Text}" Margin="0,0,0,6" TextWrapping="Wrap">
+                    <Run Text="● " Foreground="#E5645F"/><Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1260">#1260</Hyperlink><Run Text="  Deploy failing on scratch org spin-up"/>
+                  </TextBlock>
+                  <TextBlock Foreground="{DynamicResource Text}" TextWrapping="Wrap">
+                    <Run Text="■ " Foreground="#4FBF63"/><Hyperlink Style="{StaticResource Link}" NavigateUri="https://dev.azure.com/org/project/_workitems/edit/1263">#1263</Hyperlink><Run Text="  Help triage permission set assignment"/>
+                  </TextBlock>
+                </StackPanel>
+              </Expander>
+            </StackPanel>
+          </Expander>
+        </Border>
+
+      </Grid>
+
+      <!-- ============ FOOTER ============ -->
+      <TextBlock Grid.Row="3" Margin="0,16,0,0" HorizontalAlignment="Center"
+                 Foreground="{DynamicResource TextFaint}" FontSize="12"
+                 Text="Mock · placeholder data. Live build feeds from az boards query + the Outlook PowerShell module."/>
+
+    </Grid>
+  </Border>
+</Window>

--- a/daily-viewer/wpf/README.md
+++ b/daily-viewer/wpf/README.md
@@ -1,0 +1,38 @@
+# Daily Viewer — WPF prototype
+
+A Windows-native (WPF) twin of the HTML mock in `../index.html`. Same four-tile
+layout, same cache-first / refresh-on-demand model — rendered with native WPF
+controls instead of a browser.
+
+## Run it
+
+```powershell
+# From this folder, on Windows:
+powershell.exe -ExecutionPolicy Bypass -File .\Start-DailyViewer.ps1
+```
+
+`pwsh` (PowerShell 7) also works — the script detects its MTA thread and
+relaunches itself under Windows PowerShell (which WPF needs for STA).
+
+## What maps to what
+
+| HTML mock | WPF equivalent |
+|---|---|
+| `<details>` collapsible tile | native `Expander` (built-in chevron + collapse) |
+| Nested `<details>` groups | nested `Expander` |
+| `<a target="_blank">` | `Hyperlink` + `RequestNavigate` → `Start-Process` (default browser) |
+| Per-tile "cached … / refresh" | header `Button` + `DispatcherTimer` |
+| CSS custom-property tokens | keyed `SolidColorBrush` resources, mutated for the theme toggle |
+| `prefers-color-scheme` | manual light/dark toggle (`◐` button) |
+| Summary stat strip | `UniformGrid` of `Button` cards that expand + scroll to their tile |
+
+## Files
+
+- `DailyViewer.xaml` — layout, styles, and placeholder content
+- `Start-DailyViewer.ps1` — loads the XAML with `XamlReader` and wires interactions
+
+## Wiring real data
+
+Content is placeholder. In the live build each tile reads from a local cache
+file, and its refresh button runs that tile's `az boards query` (or the Outlook
+calendar pull), rewrites the cache, and re-renders — identical to the HTML plan.

--- a/daily-viewer/wpf/Start-DailyViewer.ps1
+++ b/daily-viewer/wpf/Start-DailyViewer.ps1
@@ -1,0 +1,221 @@
+#requires -Version 5.1
+
+<#
+.SYNOPSIS
+    Launches the WPF prototype of the Azure DevOps daily viewer.
+
+.DESCRIPTION
+    Loads DailyViewer.xaml (the visual twin of daily-viewer/index.html) and wires
+    the interactions: per-tile refresh, refresh-all, light/dark toggle, stat-strip
+    jump-to-tile, and links that open in the default browser.
+
+    Windows / WPF only — PresentationFramework is not available on macOS or Linux.
+    Content is placeholder; the live build would populate tiles from a local cache
+    written by `az boards query` and the Outlook PowerShell module.
+
+.EXAMPLE
+    pwsh -File .\Start-DailyViewer.ps1
+#>
+
+Add-Type -AssemblyName PresentationFramework
+Add-Type -AssemblyName PresentationCore
+Add-Type -AssemblyName WindowsBase
+
+
+# WPF ShowDialog requires an STA thread. Windows PowerShell 5.1 is STA by default;
+# pwsh 7 defaults to MTA, so relaunch this script under Windows PowerShell there.
+$apartment = [System.Threading.Thread]::CurrentThread.GetApartmentState()
+
+if ($apartment -ne [System.Threading.ApartmentState]::STA) {
+    $windowsPowerShell = Join-Path -Path $env:SystemRoot -ChildPath 'System32\WindowsPowerShell\v1.0\powershell.exe'
+
+    if (Test-Path -LiteralPath $windowsPowerShell) {
+        & $windowsPowerShell -Sta -ExecutionPolicy Bypass -File $PSCommandPath
+    } else {
+        Write-Warning 'This UI needs an STA thread; relaunch with Windows PowerShell (powershell.exe).'
+    }
+
+    return
+}
+
+
+$script:RefreshDelay = [TimeSpan]::FromMilliseconds(900)
+
+
+function Get-DailyViewerPalette {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('Dark', 'Light')]
+        [string]$Theme
+    )
+
+    if ($Theme -eq 'Dark') {
+        $palette = @{
+            Bg           = '#0F131A'
+            Surface      = '#171C25'
+            Surface2     = '#1E2531'
+            Border       = '#29313D'
+            BorderStrong = '#38424F'
+            Text         = '#E7ECF3'
+            TextDim      = '#97A3B4'
+            TextFaint    = '#6C7889'
+            Accent       = '#4AA3F0'
+            AccentWeak   = '#22345066'
+        }
+    } else {
+        $palette = @{
+            Bg           = '#EEF1F6'
+            Surface      = '#FFFFFF'
+            Surface2     = '#F5F7FA'
+            Border       = '#DCE2EC'
+            BorderStrong = '#C6CFDC'
+            Text         = '#1B2430'
+            TextDim      = '#5A6675'
+            TextFaint    = '#8A94A3'
+            Accent       = '#0E6FCE'
+            AccentWeak   = '#1A0E6FCE'
+        }
+    }
+
+    return $palette
+}
+
+
+function Set-DailyViewerTheme {
+    param(
+        [Parameter(Mandatory)]
+        [System.Windows.Window]$Window,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Dark', 'Light')]
+        [string]$Theme
+    )
+
+    $palette = Get-DailyViewerPalette -Theme $Theme
+
+    foreach ($key in $palette.Keys) {
+        $brush = $Window.Resources[$key]
+
+        if ($null -ne $brush) {
+            $brush.Color = [System.Windows.Media.ColorConverter]::ConvertFromString($palette[$key])
+        }
+    }
+}
+
+
+function Register-DailyViewerRefresh {
+    param(
+        [Parameter(Mandatory)]
+        [System.Windows.Controls.Button]$Button,
+
+        [Parameter(Mandatory)]
+        [System.Windows.Controls.TextBlock]$Stale
+    )
+
+    $handler = {
+        if ($Button.IsEnabled -eq $false) {
+            return
+        }
+
+        $Button.IsEnabled = $false
+        $Stale.Text = 'refreshing…'
+
+        $timer = New-Object System.Windows.Threading.DispatcherTimer
+        $timer.Interval = $script:RefreshDelay
+
+        $tick = {
+            $Stale.Text = 'cached just now'
+            $Button.IsEnabled = $true
+            $timer.Stop()
+        }.GetNewClosure()
+
+        $timer.Add_Tick($tick)
+        $timer.Start()
+    }.GetNewClosure()
+
+    $Button.Add_Click($handler)
+}
+
+
+function Start-DailyViewer {
+    $xamlPath = Join-Path -Path $PSScriptRoot -ChildPath 'DailyViewer.xaml'
+
+    if (-not (Test-Path -LiteralPath $xamlPath)) {
+        throw "DailyViewer.xaml not found next to this script at '$xamlPath'."
+    }
+
+    $xaml = Get-Content -LiteralPath $xamlPath -Raw
+    $reader = New-Object System.Xml.XmlNodeReader ([xml]$xaml)
+    $window = [System.Windows.Markup.XamlReader]::Load($reader)
+
+    # Links open in the default browser (routed Hyperlink event, handled once).
+    $navHandler = [System.Windows.Navigation.RequestNavigateEventHandler] {
+        param($sender, $e)
+
+        Start-Process $e.Uri.AbsoluteUri
+        $e.Handled = $true
+    }
+    $window.AddHandler([System.Windows.Documents.Hyperlink]::RequestNavigateEvent, $navHandler)
+
+    # Per-tile refresh — the only expensive path in the real build.
+    $tiles = @(
+        @{ Button = 'RefreshAgenda';   Stale = 'StaleAgenda' }
+        @{ Button = 'RefreshWeek';     Stale = 'StaleWeek' }
+        @{ Button = 'RefreshActivity'; Stale = 'StaleActivity' }
+        @{ Button = 'RefreshFocus';    Stale = 'StaleFocus' }
+    )
+
+    foreach ($tile in $tiles) {
+        $button = $window.FindName($tile.Button)
+        $stale = $window.FindName($tile.Stale)
+        Register-DailyViewerRefresh -Button $button -Stale $stale
+    }
+
+    $refreshAll = $window.FindName('RefreshAllButton')
+    $refreshAll.Add_Click({
+        foreach ($tile in $tiles) {
+            $button = $window.FindName($tile.Button)
+            $button.RaiseEvent((New-Object System.Windows.RoutedEventArgs ([System.Windows.Controls.Button]::ClickEvent)))
+        }
+    }.GetNewClosure())
+
+    # Stat strip: open and scroll to the tile a stat summarizes.
+    $stats = @('StatAgenda', 'StatWeek', 'StatActivity', 'StatFocus')
+
+    foreach ($statName in $stats) {
+        $stat = $window.FindName($statName)
+
+        $statHandler = {
+            $targetName = $this.Tag
+            $target = $window.FindName($targetName)
+
+            if ($null -ne $target) {
+                $target.IsExpanded = $true
+                $target.BringIntoView()
+            }
+        }.GetNewClosure()
+
+        $stat.Add_Click($statHandler)
+    }
+
+    # Light / dark toggle.
+    $script:currentTheme = 'Dark'
+    $themeButton = $window.FindName('ThemeButton')
+
+    $themeHandler = {
+        if ($script:currentTheme -eq 'Dark') {
+            $script:currentTheme = 'Light'
+        } else {
+            $script:currentTheme = 'Dark'
+        }
+
+        Set-DailyViewerTheme -Window $window -Theme $script:currentTheme
+    }.GetNewClosure()
+
+    $themeButton.Add_Click($themeHandler)
+
+    $null = $window.ShowDialog()
+}
+
+
+Start-DailyViewer


### PR DESCRIPTION
## Summary

Stands up the **Azure DevOps Daily Viewer** front-end surface (`daily-viewer/`) and the tooling to hold it to a bar — the foundation for epic #189. Four collapsible tiles (Today's Agenda, This Week's Focus, Recent Activity, Today's Focus) that render from a local cache and refresh per-tile, plus a WPF reference prototype, a new front-end code-review gate, and the #190 refactor that makes the mock semantic/tokenized/split.

## Issue

Closes #190. Part of epic #189.

## Changes

**Daily viewer (HTML — the primary path)**
- `daily-viewer/index.html` — semantic 2×2 dashboard: `<main>`, a `<section aria-labelledby>` per tile, `<ul>/<li>` rows, `<time datetime>`, `<header>/<nav>` toolbar, `aria-live` status region.
- `daily-viewer/styles.css` — token-driven, dual-theme; `--space-*` / type / radius scales; `rem` for type + spacing, `px` only for borders/hairlines; `[data-tile]` selectors (no `#id` styling, no `!important`).
- `daily-viewer/app.js` — collapse, per-tile refresh (with screen-reader announcements), refresh-all, live filter, light/dark toggle, stat-jump.

**WPF reference prototype** (`daily-viewer/wpf/`) — `DailyViewer.xaml` + `Start-DailyViewer.ps1` + README. Reference only; the HTML path is primary.

**Front-end review gate**
- `.claude/commands/senior-frontend-engineer.md` — new reviewer: XSS/untrusted-data escaping, semantic HTML + a11y, CSS token/specificity/unit hygiene, data-driven rendering, CSP, secrets boundary.
- `.claude/commands/code-review.md` — wired the reviewer in as a fifth parallel pass (quad → quint).
- `CLAUDE.md` — new **Front-End Conventions (`daily-viewer/`)** section; project tree + command tables updated.

## Test Plan

- [ ] Open `daily-viewer/index.html` directly in a browser (no server) — tiles collapse/expand, per-tile refresh flips "cached …" → "cached just now", "Refresh all", live filter, and light/dark toggle all work.
- [ ] Keyboard-only: Tab reaches every control; `:focus-visible` ring shows; `<details>` toggles with Enter/Space.
- [ ] Screen reader announces refresh + filter results via the live region.
- [ ] WPF (Windows): `powershell.exe -ExecutionPolicy Bypass -File daily-viewer/wpf/Start-DailyViewer.ps1` opens the window; links open in the browser.

_Behavior verified end-to-end in headless Chromium (collapse, refresh + announcements, filter, theme, stat-jump — zero console errors). Content is placeholder; data-driven rendering and the localhost backend are tracked in #191–#194._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LP3dQkjwiSAJvEVWs6sUC2)_