### PR TITLE
Daily Viewer: data-driven view layer (render tiles from a JS model, derived counts, escaping helper)

### DIFF
--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -157,11 +157,35 @@ function chevron() {
   return tpl.content.firstElementChild.cloneNode(true);
 }
 
+// textContent protects a title's text, but an href does not — a javascript:
+// URL still executes on click. Once live Azure DevOps data flows in, a link
+// field is untrusted too, so gate the scheme and drop the href otherwise.
+var SAFE_URL_SCHEMES = { "http:": true, "https:": true, "mailto:": true };
+
+function safeUrl(url) {
+  try {
+    var parsed = new URL(url, window.location.href);
+    if (SAFE_URL_SCHEMES[parsed.protocol]) {
+      return parsed.href;
+    }
+  } catch (err) {
+    return null;
+  }
+
+  return null;
+}
+
 function externalLink(text, url, className) {
-  var opts = { href: url, target: "_blank", rel: "noopener", text: text };
+  var opts = { target: "_blank", rel: "noopener noreferrer", text: text };
+
+  var href = safeUrl(url);
+  if (href) {
+    opts.href = href;
+  }
   if (className) {
     opts["class"] = className;
   }
+
   return el("a", opts);
 }
 

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -1,7 +1,351 @@
 "use strict";
 
-// Behavior for the daily viewer. Content is still hardcoded in index.html
-// (data-driven rendering lands separately); this wires the controls only.
+// Behavior + view layer for the daily viewer. The tiles are a function of the
+// MODEL below: one render pass builds every row, count badges and stat numbers
+// are derived from collection length (they can't drift), and every model string
+// reaches the DOM through `el()` (textContent / setAttribute) so untrusted Azure
+// DevOps text is escaped by construction — there is no innerHTML path to exploit.
+
+
+// ---------------------------------------------------------------------------
+// Model — placeholder data shaped like the eventual cache payload. Swapping in
+// live `az boards` / Outlook output is a data change, not markup surgery.
+// ---------------------------------------------------------------------------
+
+var MODEL = {
+  agenda: {
+    events: [
+      {
+        time: { label: "9:00 AM", tz: "EST", datetime: "2026-07-14T09:00:00-05:00" },
+        title: "Sprint Planning Sync",
+        location: { badge: "Teams", url: "https://teams.microsoft.com/l/meetup-join/example", urlLabel: "Join meeting →" },
+        details: [
+          { label: "With", text: "Platform Team · 6 attendees" }
+        ]
+      },
+      {
+        time: { label: "11:00 AM", tz: "EST", datetime: "2026-07-14T11:00:00-05:00" },
+        title: "Architecture Design Review",
+        location: { badge: "In person", text: "Room 132" },
+        details: [
+          { label: "Prep", link: { text: "Design doc →", url: "https://dev.azure.com/org/project/_wiki/wikis/project.wiki/42/Design-Review" } }
+        ]
+      }
+    ]
+  },
+
+  week: {
+    stories: {
+      label: "Stories to complete",
+      open: true,
+      items: [
+        { type: "Story", id: 1234, url: "https://dev.azure.com/org/project/_workitems/edit/1234", title: "Wire agenda tile to az boards query", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1234", state: "In progress" },
+        { type: "Story", id: 1240, url: "https://dev.azure.com/org/project/_workitems/edit/1240", title: "Outlook calendar pull for daily events", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1240", state: "Active" },
+        { type: "Bug", id: 1251, url: "https://dev.azure.com/org/project/_workitems/edit/1251", title: "Timezone offset on EST agenda rows", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1251", state: "In review" }
+      ]
+    },
+    prep: {
+      label: "Events to prepare for",
+      open: true,
+      items: [
+        { title: "Confirm demo build is deployed before Thu review" },
+        { title: "Send agenda for", link: { text: "Fri sprint retro", url: "https://teams.microsoft.com/l/meetup-join/example2" } }
+      ]
+    }
+  },
+
+  activity: {
+    groups: [
+      {
+        label: "Tagged discussions",
+        open: false,
+        items: [
+          { type: "Feature", id: 1180, url: "https://dev.azure.com/org/project/_workitems/edit/1180", title: "@you — “can you confirm the WIQL scope?”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1180?discussion" },
+          { type: "Story", id: 1240, url: "https://dev.azure.com/org/project/_workitems/edit/1240", title: "@you — “ready for review whenever”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1240?discussion" }
+        ]
+      },
+      {
+        label: "Active story updates",
+        open: false,
+        items: [
+          { type: "Story", id: 1234, url: "https://dev.azure.com/org/project/_workitems/edit/1234", title: "State → In progress by A. Rivera", note: "2h ago" },
+          { type: "Bug", id: 1251, url: "https://dev.azure.com/org/project/_workitems/edit/1251", title: "Moved to In review", note: "4h ago" }
+        ]
+      },
+      {
+        label: "Sprint close items",
+        open: false,
+        items: [
+          { type: "Task", id: 1209, url: "https://dev.azure.com/org/project/_workitems/edit/1209", title: "Update release notes", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1209", state: "Closing" },
+          { type: "Story", id: 1222, url: "https://dev.azure.com/org/project/_workitems/edit/1222", title: "Verify acceptance criteria signed off", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1222", state: "Closing" }
+        ]
+      }
+    ]
+  },
+
+  focus: {
+    primary: {
+      title: "User Story #1234 — Wire agenda tile to az boards",
+      url: "https://dev.azure.com/org/project/_workitems/edit/1234",
+      sub: "Primary commitment for today · In progress"
+    },
+    support: {
+      label: "SF devs — unplanned support",
+      open: true,
+      items: [
+        { type: "Bug", id: 1260, url: "https://dev.azure.com/org/project/_workitems/edit/1260", title: "Deploy failing on scratch org spin-up", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1260", state: "Active" },
+        { type: "Task", id: 1263, url: "https://dev.azure.com/org/project/_workitems/edit/1263", title: "Help triage permission set assignment", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1263", state: "New" }
+      ]
+    }
+  }
+};
+
+var TYPE_CLASS = {
+  Story: "t-story",
+  Bug: "t-bug",
+  Task: "t-task",
+  Feature: "t-feature",
+  Epic: "t-epic"
+};
+
+var STATE_CLASS = {
+  "New": "s-new",
+  "Active": "s-active",
+  "In progress": "s-progress",
+  "In review": "s-review",
+  "Closing": "s-closing"
+};
+
+var STAR_GLYPH = "★";
+
+
+// ---------------------------------------------------------------------------
+// DOM builder — the single, escaping-safe path from model to page. `text` sets
+// textContent and every other key goes through setAttribute, so a malicious
+// title renders as inert text. Children may be nodes or plain strings.
+// ---------------------------------------------------------------------------
+
+function el(tag, opts, children) {
+  var node = document.createElement(tag);
+
+  if (opts) {
+    Object.keys(opts).forEach(function (key) {
+      if (key === "class") {
+        node.className = opts[key];
+      } else if (key === "text") {
+        node.textContent = opts[key];
+      } else {
+        node.setAttribute(key, opts[key]);
+      }
+    });
+  }
+
+  if (children) {
+    children.forEach(function (child) {
+      if (child === null || child === undefined) {
+        return;
+      }
+      node.appendChild(typeof child === "string" ? document.createTextNode(child) : child);
+    });
+  }
+
+  return node;
+}
+
+function chevron() {
+  var tpl = document.getElementById("tpl-chev");
+  return tpl.content.firstElementChild.cloneNode(true);
+}
+
+function externalLink(text, url, className) {
+  var opts = { href: url, target: "_blank", rel: "noopener", text: text };
+  if (className) {
+    opts["class"] = className;
+  }
+  return el("a", opts);
+}
+
+
+// ---------------------------------------------------------------------------
+// Row builders — one per row shape. Each returns a single <li>/element.
+// ---------------------------------------------------------------------------
+
+function workItemRow(wi) {
+  var children = [];
+
+  children.push(el("span", { class: "type " + (TYPE_CLASS[wi.type] || ""), text: wi.type }));
+  children.push(externalLink("#" + wi.id, wi.url, "id"));
+
+  if (wi.titleUrl) {
+    children.push(el("span", { class: "wtitle" }, [ externalLink(wi.title, wi.titleUrl) ]));
+  } else {
+    children.push(el("span", { class: "wtitle", text: wi.title }));
+  }
+
+  if (wi.state) {
+    children.push(el("span", { class: "state " + (STATE_CLASS[wi.state] || ""), text: wi.state }));
+  }
+
+  if (wi.note) {
+    children.push(el("span", { class: "note", text: wi.note }));
+  }
+
+  return el("li", { class: "wi" }, children);
+}
+
+
+function checklistRow(item) {
+  var title = [ item.title ];
+
+  if (item.link) {
+    title.push(" ");
+    title.push(externalLink(item.link.text, item.link.url));
+  }
+
+  return el("li", { class: "wi" }, [
+    el("span", { class: "check", "aria-hidden": "true" }),
+    el("span", { class: "wtitle" }, title)
+  ]);
+}
+
+
+function eventRow(ev) {
+  var timeChildren = [ ev.time.label ];
+  if (ev.time.tz) {
+    timeChildren.push(el("span", { class: "tz", text: ev.time.tz }));
+  }
+  var time = el("time", { class: "time", datetime: ev.time.datetime }, timeChildren);
+
+  var whereChildren = [ el("span", { class: "badge-loc", text: ev.location.badge }) ];
+  if (ev.location.text) {
+    whereChildren.push(" ");
+    whereChildren.push(ev.location.text);
+  }
+  if (ev.location.url) {
+    whereChildren.push(" ");
+    whereChildren.push(externalLink(ev.location.urlLabel, ev.location.url));
+  }
+
+  var metaLines = [ el("p", { class: "meta" }, [ el("span", { class: "where" }, whereChildren) ]) ];
+
+  (ev.details || []).forEach(function (detail) {
+    var line = [ el("span", { class: "k", text: detail.label }), " " ];
+    if (detail.link) {
+      line.push(externalLink(detail.link.text, detail.link.url));
+    } else {
+      line.push(detail.text);
+    }
+    metaLines.push(el("p", { class: "meta" }, line));
+  });
+
+  var content = el("div", null, [ el("p", { class: "etitle", text: ev.title }) ].concat(metaLines));
+
+  return el("li", { class: "event" }, [ time, content ]);
+}
+
+
+function groupBlock(group, rowFn) {
+  var summary = el("summary", null, [
+    chevron(),
+    el("span", { class: "glabel", text: group.label }),
+    el("span", { class: "count", text: String(group.items.length) })
+  ]);
+
+  var list = el("ul", { class: "glist" }, group.items.map(rowFn));
+
+  var opts = { class: "group" };
+  if (group.open) {
+    opts.open = "";
+  }
+
+  return el("details", opts, [ summary, list ]);
+}
+
+
+// ---------------------------------------------------------------------------
+// Tile renderers — each returns the array of nodes for that tile's .body.
+// ---------------------------------------------------------------------------
+
+function renderAgenda(model) {
+  var list = el("ul", { class: "events" }, model.events.map(eventRow));
+  return [ list ];
+}
+
+
+function renderWeek(model) {
+  return [
+    groupBlock(model.stories, workItemRow),
+    groupBlock(model.prep, checklistRow)
+  ];
+}
+
+
+function renderActivity(model) {
+  return model.groups.map(function (group) {
+    return groupBlock(group, workItemRow);
+  });
+}
+
+
+function renderFocus(model) {
+  var primary = el("div", { class: "primary" }, [
+    el("span", { class: "star", "aria-hidden": "true" }, [ STAR_GLYPH ]),
+    el("div", null, [
+      el("p", { class: "ptitle" }, [ externalLink(model.primary.title, model.primary.url) ]),
+      el("p", { class: "psub", text: model.primary.sub })
+    ])
+  ]);
+
+  return [ primary, groupBlock(model.support, workItemRow) ];
+}
+
+
+// ---------------------------------------------------------------------------
+// Mount — populate each tile body, derive its count badge from the rendered
+// rows, and set each stat number from the collection it summarizes.
+// ---------------------------------------------------------------------------
+
+function tile(key) {
+  return document.querySelector('.tile[data-tile="' + key + '"]');
+}
+
+function mountTile(key, nodes) {
+  var body = tile(key).querySelector(".body");
+  nodes.forEach(function (node) { body.appendChild(node); });
+
+  var badge = tile(key).querySelector(".tt .count");
+  badge.textContent = String(body.querySelectorAll(".wi, .event").length);
+}
+
+function setStat(key, count) {
+  var number = document.querySelector('.stat[data-target="' + key + '"] .n');
+  number.textContent = String(count);
+}
+
+function activityTotal(model) {
+  return model.groups.reduce(function (sum, group) {
+    return sum + group.items.length;
+  }, 0);
+}
+
+function renderAll() {
+  mountTile("agenda", renderAgenda(MODEL.agenda));
+  mountTile("week", renderWeek(MODEL.week));
+  mountTile("activity", renderActivity(MODEL.activity));
+  mountTile("focus", renderFocus(MODEL.focus));
+
+  setStat("tile-agenda", MODEL.agenda.events.length);
+  setStat("tile-week", MODEL.week.stories.items.length);
+  setStat("tile-activity", activityTotal(MODEL.activity));
+  setStat("tile-focus", MODEL.focus.support.items.length);
+}
+
+renderAll();
+
+
+// ---------------------------------------------------------------------------
+// Controls — wired after render so every handler sees the rendered rows.
+// ---------------------------------------------------------------------------
 
 // Named liveRegion, not `status`: a top-level `var status` in a classic script
 // aliases the built-in window.status string and breaks assignment under strict mode.
@@ -72,15 +416,15 @@ document.getElementById("refreshAll").addEventListener("click", function () {
 // Stat strip: open and scroll to the tile a stat summarizes.
 document.querySelectorAll(".stat").forEach(function (stat) {
   stat.addEventListener("click", function () {
-    var tile = document.getElementById(stat.dataset.target);
-    if (!tile) return;
+    var target = document.getElementById(stat.dataset.target);
+    if (!target) return;
 
-    var details = tile.querySelector("details");
+    var details = target.querySelector("details");
     if (details) {
       details.open = true;
     }
 
-    tile.scrollIntoView({ behavior: "smooth", block: "start" });
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
   });
 });
 
@@ -135,8 +479,8 @@ function applyFilter(raw) {
 
   var matchTotal = 0;
 
-  document.querySelectorAll(".tile").forEach(function (tile) {
-    var rows = tile.querySelectorAll(".wi, .event");
+  document.querySelectorAll(".tile").forEach(function (t) {
+    var rows = t.querySelectorAll(".wi, .event");
     var anyVisible = false;
 
     rows.forEach(function (row) {
@@ -148,12 +492,12 @@ function applyFilter(raw) {
       }
     });
 
-    tile.querySelectorAll(".group").forEach(function (group) {
+    t.querySelectorAll(".group").forEach(function (group) {
       var visible = group.querySelectorAll(".wi:not(.hide), .event:not(.hide)").length;
       group.classList.toggle("hide", !!q && visible === 0);
     });
 
-    tile.classList.toggle("empty", !!q && !anyVisible);
+    t.classList.toggle("empty", !!q && !anyVisible);
   });
 
   if (q) {

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -33,13 +33,17 @@
 
   <main>
 
+    <!-- Stat numbers (.n) are filled from the model at render time; blank in markup so
+         they can never drift from the collections they summarize. -->
     <section class="stats" aria-label="Summary counts">
-      <button class="stat a" type="button" data-target="tile-agenda"><span class="n">2</span><span class="l">Meetings today</span></button>
-      <button class="stat f" type="button" data-target="tile-week"><span class="n">3</span><span class="l">Stories due this week</span></button>
-      <button class="stat s" type="button" data-target="tile-activity"><span class="n">6</span><span class="l">Recent updates</span></button>
-      <button class="stat g" type="button" data-target="tile-focus"><span class="n">2</span><span class="l">Support &amp; focus items</span></button>
+      <button class="stat a" type="button" data-target="tile-agenda"><span class="n"></span><span class="l">Meetings today</span></button>
+      <button class="stat f" type="button" data-target="tile-week"><span class="n"></span><span class="l">Stories due this week</span></button>
+      <button class="stat s" type="button" data-target="tile-activity"><span class="n"></span><span class="l">Recent updates</span></button>
+      <button class="stat g" type="button" data-target="tile-focus"><span class="n"></span><span class="l">Support &amp; focus items</span></button>
     </section>
 
+    <!-- Each tile is a static shell: header chrome, staleness, refresh button. Its
+         .count badge and its .body rows are rendered from the model in app.js. -->
     <div class="grid">
 
       <!-- Today's Agenda -->
@@ -47,32 +51,13 @@
         <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h2 id="h-agenda">Today&rsquo;s Agenda</h2><span class="count">2</span></span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h2 id="h-agenda">Today&rsquo;s Agenda</h2><span class="count"></span></span>
             <span class="tile-meta">
               <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 12m ago</span>
               <button class="refresh-btn" type="button" data-tile="agenda" aria-label="Refresh Today&rsquo;s Agenda"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
             </span>
           </summary>
-          <div class="body">
-            <ul class="events">
-              <li class="event">
-                <time class="time" datetime="2026-07-14T09:00:00-05:00">9:00 AM<span class="tz">EST</span></time>
-                <div>
-                  <p class="etitle">Sprint Planning Sync</p>
-                  <p class="meta"><span class="where"><span class="badge-loc">Teams</span> <a href="https://teams.microsoft.com/l/meetup-join/example" target="_blank" rel="noopener">Join meeting &rarr;</a></span></p>
-                  <p class="meta"><span class="k">With</span> Platform Team &middot; 6 attendees</p>
-                </div>
-              </li>
-              <li class="event">
-                <time class="time" datetime="2026-07-14T11:00:00-05:00">11:00 AM<span class="tz">EST</span></time>
-                <div>
-                  <p class="etitle">Architecture Design Review</p>
-                  <p class="meta"><span class="where"><span class="badge-loc">In person</span> Room 132</span></p>
-                  <p class="meta"><span class="k">Prep</span> <a href="https://dev.azure.com/org/project/_wiki/wikis/project.wiki/42/Design-Review" target="_blank" rel="noopener">Design doc &rarr;</a></p>
-                </div>
-              </li>
-            </ul>
-          </div>
+          <div class="body"></div>
         </details>
       </section>
 
@@ -81,61 +66,13 @@
         <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h2 id="h-week">This Week&rsquo;s Focus</h2><span class="count">2</span></span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h2 id="h-week">This Week&rsquo;s Focus</h2><span class="count"></span></span>
             <span class="tile-meta">
               <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 2h ago</span>
               <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
             </span>
           </summary>
-          <div class="body">
-
-            <details class="group" open>
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="glabel">Stories to complete</span>
-                <span class="count">3</span>
-              </summary>
-              <ul class="glist">
-                <li class="wi">
-                  <span class="type t-story">Story</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">#1234</a>
-                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">Wire agenda tile to az boards query</a></span>
-                  <span class="state s-progress">In progress</span>
-                </li>
-                <li class="wi">
-                  <span class="type t-story">Story</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">#1240</a>
-                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">Outlook calendar pull for daily events</a></span>
-                  <span class="state s-active">Active</span>
-                </li>
-                <li class="wi">
-                  <span class="type t-bug">Bug</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">#1251</a>
-                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">Timezone offset on EST agenda rows</a></span>
-                  <span class="state s-review">In review</span>
-                </li>
-              </ul>
-            </details>
-
-            <details class="group" open>
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="glabel">Events to prepare for</span>
-                <span class="count">2</span>
-              </summary>
-              <ul class="glist">
-                <li class="wi">
-                  <span class="check" aria-hidden="true"></span>
-                  <span class="wtitle">Confirm demo build is deployed before <strong>Thu review</strong></span>
-                </li>
-                <li class="wi">
-                  <span class="check" aria-hidden="true"></span>
-                  <span class="wtitle">Send agenda for <a href="https://teams.microsoft.com/l/meetup-join/example2" target="_blank" rel="noopener">Fri sprint retro</a></span>
-                </li>
-              </ul>
-            </details>
-
-          </div>
+          <div class="body"></div>
         </details>
       </section>
 
@@ -144,79 +81,13 @@
         <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 8h3l2-4.5 3 9 2-4.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg><h2 id="h-activity">Recent Activity</h2><span class="count">3</span></span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 8h3l2-4.5 3 9 2-4.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg><h2 id="h-activity">Recent Activity</h2><span class="count"></span></span>
             <span class="tile-meta">
               <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 5m ago</span>
               <button class="refresh-btn" type="button" data-tile="activity" aria-label="Refresh Recent Activity"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
             </span>
           </summary>
-          <div class="body">
-
-            <details class="group">
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="glabel">Tagged discussions</span>
-                <span class="count">2</span>
-              </summary>
-              <ul class="glist">
-                <li class="wi">
-                  <span class="type t-feature">Feature</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1180" target="_blank" rel="noopener">#1180</a>
-                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1180?discussion" target="_blank" rel="noopener">@you &mdash; &ldquo;can you confirm the WIQL scope?&rdquo;</a></span>
-                </li>
-                <li class="wi">
-                  <span class="type t-story">Story</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1240" target="_blank" rel="noopener">#1240</a>
-                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1240?discussion" target="_blank" rel="noopener">@you &mdash; &ldquo;ready for review whenever&rdquo;</a></span>
-                </li>
-              </ul>
-            </details>
-
-            <details class="group">
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="glabel">Active story updates</span>
-                <span class="count">2</span>
-              </summary>
-              <ul class="glist">
-                <li class="wi">
-                  <span class="type t-story">Story</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">#1234</a>
-                  <span class="wtitle">State &rarr; <strong>In progress</strong> by A. Rivera</span>
-                  <span class="note">2h ago</span>
-                </li>
-                <li class="wi">
-                  <span class="type t-bug">Bug</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1251" target="_blank" rel="noopener">#1251</a>
-                  <span class="wtitle">Moved to <strong>In review</strong></span>
-                  <span class="note">4h ago</span>
-                </li>
-              </ul>
-            </details>
-
-            <details class="group">
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="glabel">Sprint close items</span>
-                <span class="count">2</span>
-              </summary>
-              <ul class="glist">
-                <li class="wi">
-                  <span class="type t-task">Task</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1209" target="_blank" rel="noopener">#1209</a>
-                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1209" target="_blank" rel="noopener">Update release notes</a></span>
-                  <span class="state s-closing">Closing</span>
-                </li>
-                <li class="wi">
-                  <span class="type t-story">Story</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1222" target="_blank" rel="noopener">#1222</a>
-                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1222" target="_blank" rel="noopener">Verify acceptance criteria signed off</a></span>
-                  <span class="state s-closing">Closing</span>
-                </li>
-              </ul>
-            </details>
-
-          </div>
+          <div class="body"></div>
         </details>
       </section>
 
@@ -225,45 +96,13 @@
         <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2 id="h-focus">Today&rsquo;s Focus</h2><span class="count">2</span></span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2 id="h-focus">Today&rsquo;s Focus</h2><span class="count"></span></span>
             <span class="tile-meta">
               <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 1h ago</span>
               <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
             </span>
           </summary>
-          <div class="body">
-
-            <div class="primary">
-              <span class="star" aria-hidden="true">&#9733;</span>
-              <div>
-                <p class="ptitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1234" target="_blank" rel="noopener">User Story #1234 &mdash; Wire agenda tile to az boards</a></p>
-                <p class="psub">Primary commitment for today &middot; In progress</p>
-              </div>
-            </div>
-
-            <details class="group" open>
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="glabel">SF devs &mdash; unplanned support</span>
-                <span class="count">2</span>
-              </summary>
-              <ul class="glist">
-                <li class="wi">
-                  <span class="type t-bug">Bug</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1260" target="_blank" rel="noopener">#1260</a>
-                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1260" target="_blank" rel="noopener">Deploy failing on scratch org spin-up</a></span>
-                  <span class="state s-active">Active</span>
-                </li>
-                <li class="wi">
-                  <span class="type t-task">Task</span>
-                  <a class="id" href="https://dev.azure.com/org/project/_workitems/edit/1263" target="_blank" rel="noopener">#1263</a>
-                  <span class="wtitle"><a href="https://dev.azure.com/org/project/_workitems/edit/1263" target="_blank" rel="noopener">Help triage permission set assignment</a></span>
-                  <span class="state s-new">New</span>
-                </li>
-              </ul>
-            </details>
-
-          </div>
+          <div class="body"></div>
         </details>
       </section>
 
@@ -275,6 +114,10 @@
   </footer>
 
 </div>
+
+<!-- Reusable chevron glyph. Static, trusted markup cloned by the render layer so
+     group headers get the same disclosure caret without hand-built SVG in JS. -->
+<template id="tpl-chev"><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></template>
 
 <div id="sr-status" class="sr-only" role="status" aria-live="polite"></div>
 


### PR DESCRIPTION

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #191 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | ✅ 4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/196#issuecomment-4973861949) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/196#issuecomment-4973862467) |
| 🛡️ Security Audit | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/196#issuecomment-4973871549) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/196#issuecomment-4973870166) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/196#issuecomment-4973875918) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/196#issuecomment-4973900273) |

<!-- pr-diagram:start -->
## How it works

`renderAll()` is the single entry point: it reads the placeholder `MODEL`, fans out to the four per-tile renderers (`renderAgenda`/`renderWeek`/`renderActivity`/`renderFocus`), which lean on shared row/group builders that all funnel through the escaping-safe `el()` DOM builder — links first pass a `safeUrl` scheme gate. It then derives every tile count badge (`mountTile`) and stat number (`setStat`) from the rendered collections, and only afterward attaches the control wiring (filter/collapse/theme/refresh/stat-jump) so every handler runs against real rendered rows.

```mermaid
flowchart TD
    Model[(MODEL<br/>placeholder data)]:::io
    RenderAll([renderAll]):::pub

    Agenda([renderAgenda]):::pub
    Week([renderWeek]):::pub
    Activity([renderActivity]):::pub
    Focus([renderFocus]):::pub

    Group[groupBlock]:::priv
    WItem[workItemRow]:::priv
    Check[checklistRow]:::priv
    Event[eventRow]:::priv
    Chev[chevron<br/>template clone]:::priv

    El[el DOM builder<br/>textContent / setAttribute]:::priv
    Guard{externalLink<br/>safeUrl scheme ok?}

    Mount[mountTile<br/>derives count badge]:::pub
    Stat[setStat<br/>derives stat number]:::pub
    Controls([filter / collapse / theme<br/>refresh / stat-jump]):::pub

    Model --> RenderAll
    RenderAll --> Agenda & Week & Activity & Focus
    Agenda --> Event
    Week --> Group
    Activity --> Group
    Focus --> Group
    Group --> WItem & Check & Chev
    WItem --> El
    Check --> El
    Event --> El
    WItem --> Guard
    Event --> Guard
    Guard -- http/https/mailto --> El
    Guard -- other: href dropped --> El

    RenderAll --> Mount & Stat
    Mount -.wired after render.-> Controls

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
Makes the Daily Viewer mock a **function of data** instead of hand-authored markup. A `MODEL` object holds each tile&#39;s events/work-items/groups (placeholder JSON shaped like the eventual `az boards` / Outlook cache payload); a render layer builds every row from it; count badges and stat numbers are derived from collection length so they can&#39;t drift; and all model text reaches the DOM through a safe `el()` builder (`textContent`/`setAttribute` only — no `innerHTML` path), so untrusted Azure DevOps titles render as inert text.

## Issue
Closes #191 (part of #189)

## Changes
- **`daily-viewer/app.js`** — added `MODEL` placeholder data; an `el()` escaping-safe DOM builder; per-tile render functions (`renderAgenda`/`renderWeek`/`renderActivity`/`renderFocus`) plus shared row builders (`workItemRow`, `checklistRow`, `eventRow`, `groupBlock`); `renderAll()` derives tile count badges from the rendered rows and stat-strip numbers from the collections they summarize; render now runs before the control wiring so filter/collapse/theme/refresh/stat-jump operate on the rendered DOM.
- **`daily-viewer/index.html`** — removed every hardcoded row/group; emptied all four tile `.body`s; blanked the stat numbers and count badges (now filled from the model); added one `` for the group disclosure chevron.

## Test Plan
- [ ] Open `daily-viewer/index.html` in a browser — all four tiles render the same rows as before; count badges and stat numbers show derived values
- [ ] Type in the filter box — rows filter; groups/tiles collapse when nothing matches; clearing restores layout
- [ ] Collapse all / Expand all / theme toggle / click a stat — all still work against the rendered DOM
- [ ] XSS: a title of ``&#39;&lt;img src=x onerror=alert(1)&gt;&#39;`` in the model renders as inert text (no image, no alert)

Verified headless (Chromium): parity with the mock, derived counts (agenda 2 / week 5 / activity 6 / focus 2) and stats (2 / 3 / 6 / 2), working filter/collapse/theme, and the XSS probe inert with no `alert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuPvN6e5cCsfiVjLrKLJWa)_