### PR TITLE
Daily Viewer: local cache contract + PowerShell backend endpoint (serve + per-tile refresh on 127.0.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,26 @@ Schema file format (one entry per work-item type, each with `required` and `opti
 
 Supported `type` values: `string`, `int`, `picklist`, `bool`, `date`, `multiline`. Unknown types are treated as `string` with a warning from `az-Test-AzDevOpsSchema`.
 
+### Daily viewer (local dashboard)
+
+`Start-AzDevOpsDailyViewer` (in `powcuts_by_cli/daily_viewer.ps1`) serves the `daily-viewer/` dashboard from your machine so the four agenda tiles (Today's Agenda, This Week's Focus, Recent Activity, Today's Focus) render instantly from a local cache and only hit Azure DevOps when you refresh a tile.
+
+```powershell
+Start-AzDevOpsDailyViewer            # serve on http://127.0.0.1:8770/ and open the browser
+Start-AzDevOpsDailyViewer -Port 9000 # pick a different loopback port
+Start-AzDevOpsDailyViewer -NoBrowser # serve without auto-opening the browser (scripted / curl checks)
+```
+
+The server is a built-in `System.Net.HttpListener` (no external modules) bound to `127.0.0.1` only — never `0.0.0.0` — and your `az login` / PAT stays inside the server process; responses carry only work-item and agenda data. Press `Ctrl+C` to stop it.
+
+Each tile is backed by one JSON file under the active project's cache slice — `~/.bashcuts-az-devops-app/cache/<project-slug>/daily-viewer/{agenda,week,activity,focus}.json` (or the unsegmented `cache/daily-viewer/` for single-project use) — so it follows `az-Use-AzDevOpsProject` exactly like the synced datasets. Staleness is derived from each file's modified time and returned to the page. The API keeps the cheap and expensive paths distinct:
+
+- `GET /` — the page and its static assets.
+- `GET /api/tiles/<name>` — that tile's cached JSON, plus its `ageSeconds` / `stale` staleness (cheap read).
+- `POST /api/tiles/<name>/refresh` — re-runs that tile's query, rewrites its cache, and returns the fresh JSON (expensive; per-tile).
+
+> On Windows, `HttpListener` may need a one-time URL reservation the first time you bind a port — if `Start-AzDevOpsDailyViewer` reports it could not bind, run the `netsh http add urlacl` line it prints (or just pick another `-Port`).
+
 <br>
 
 ***

--- a/README.md
+++ b/README.md
@@ -681,12 +681,12 @@ Supported `type` values: `string`, `int`, `picklist`, `bool`, `date`, `multiline
 
 ### Daily viewer (local dashboard)
 
-`Start-AzDevOpsDailyViewer` (in `powcuts_by_cli/daily_viewer.ps1`) serves the `daily-viewer/` dashboard from your machine so the four agenda tiles (Today's Agenda, This Week's Focus, Recent Activity, Today's Focus) render instantly from a local cache and only hit Azure DevOps when you refresh a tile.
+`az-Start-AzDevOpsDailyViewer` (in `powcuts_by_cli/daily_viewer.ps1`, tab-tab on `az-` to discover it) serves the `daily-viewer/` dashboard from your machine so the four agenda tiles (Today's Agenda, This Week's Focus, Recent Activity, Today's Focus) render instantly from a local cache and only hit Azure DevOps when you refresh a tile.
 
 ```powershell
-Start-AzDevOpsDailyViewer            # serve on http://127.0.0.1:8770/ and open the browser
-Start-AzDevOpsDailyViewer -Port 9000 # pick a different loopback port
-Start-AzDevOpsDailyViewer -NoBrowser # serve without auto-opening the browser (scripted / curl checks)
+az-Start-AzDevOpsDailyViewer            # serve on http://127.0.0.1:8770/ and open the browser
+az-Start-AzDevOpsDailyViewer -Port 9000 # pick a different loopback port
+az-Start-AzDevOpsDailyViewer -NoBrowser # serve without auto-opening the browser (scripted / curl checks)
 ```
 
 The server is a built-in `System.Net.HttpListener` (no external modules) bound to `127.0.0.1` only — never `0.0.0.0` — and your `az login` / PAT stays inside the server process; responses carry only work-item and agenda data. Press `Ctrl+C` to stop it.
@@ -697,7 +697,7 @@ Each tile is backed by one JSON file under the active project's cache slice — 
 - `GET /api/tiles/<name>` — that tile's cached JSON, plus its `ageSeconds` / `stale` staleness (cheap read).
 - `POST /api/tiles/<name>/refresh` — re-runs that tile's query, rewrites its cache, and returns the fresh JSON (expensive; per-tile).
 
-> On Windows, `HttpListener` may need a one-time URL reservation the first time you bind a port — if `Start-AzDevOpsDailyViewer` reports it could not bind, run the `netsh http add urlacl` line it prints (or just pick another `-Port`).
+> On Windows, `HttpListener` may need a one-time URL reservation the first time you bind a port — if `az-Start-AzDevOpsDailyViewer` reports it could not bind, run the `netsh http add urlacl` line it prints (or just pick another `-Port`).
 
 <br>
 

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -28,6 +28,7 @@ $script:AzDevOpsDailyViewerDefaultPort     = 8770
 $script:AzDevOpsDailyViewerStaleSeconds    = 900     # 15 min: mtime age past which a tile reads "stale"
 $script:AzDevOpsDailyViewerCacheSubdir     = 'daily-viewer'
 $script:AzDevOpsDailyViewerLoopbackAddress = '127.0.0.1'
+$script:AzDevOpsDailyViewerJsonDepth       = 10      # nesting the tile payloads / API responses serialize to
 
 $script:AzDevOpsDailyViewerMimeTypes = @{
     '.html' = 'text/html; charset=utf-8'
@@ -255,7 +256,7 @@ function Write-AzDevOpsDailyViewerTile {
         items     = $items
     }
 
-    $json = $record | ConvertTo-Json -Depth 10
+    $json = $record | ConvertTo-Json -Depth $script:AzDevOpsDailyViewerJsonDepth
     Write-AzDevOpsCacheFile -Path $path -Content $json
 
     $model = Read-AzDevOpsDailyViewerTile -Tile $Tile
@@ -399,6 +400,7 @@ function Write-AzDevOpsDailyViewerBytes {
     }
 
     $Response.OutputStream.Close()
+    $Response.Close()
 }
 
 
@@ -409,7 +411,7 @@ function Write-AzDevOpsDailyViewerJson {
         [Parameter(Mandatory)] [AllowNull()] $Object
     )
 
-    $json = $Object | ConvertTo-Json -Depth 10
+    $json = $Object | ConvertTo-Json -Depth $script:AzDevOpsDailyViewerJsonDepth
     $bytes = [System.Text.Encoding]::UTF8.GetBytes($json)
 
     Write-AzDevOpsDailyViewerBytes -Response $Response -StatusCode $StatusCode `
@@ -555,8 +557,12 @@ function Invoke-AzDevOpsDailyViewerRequest {
         }
     }
     catch {
+        # Keep the exception detail (which can name filesystem paths) server-side;
+        # hand the browser a generic message only.
+        Write-Host "Daily viewer request error: $($_.Exception.Message)" -ForegroundColor Red
+
         try {
-            Write-AzDevOpsDailyViewerError -Response $response -StatusCode 500 -Message $_.Exception.Message
+            Write-AzDevOpsDailyViewerError -Response $response -StatusCode 500 -Message 'Internal server error.'
         }
         catch {
             # response already closed / client gone — nothing more we can do
@@ -581,7 +587,7 @@ function Open-AzDevOpsDailyViewerBrowser {
     param([Parameter(Mandatory)] [string] $Url)
 
     try {
-        if ($IsWindows -or ($env:OS -eq 'Windows_NT')) {
+        if (Test-WpfIsWindows) {
             Start-Process $Url
         } elseif ($IsMacOS) {
             & open $Url
@@ -595,7 +601,7 @@ function Open-AzDevOpsDailyViewerBrowser {
 }
 
 
-function Start-AzDevOpsDailyViewer {
+function az-Start-AzDevOpsDailyViewer {
     <#
     .SYNOPSIS
         Serve the Azure DevOps daily viewer on 127.0.0.1 with a per-tile cache API.

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -1,0 +1,674 @@
+# ============================================================================
+# Azure DevOps — Daily Viewer local server + cache contract
+# ============================================================================
+# Serves daily-viewer/ on 127.0.0.1 and exposes a small JSON API over the
+# per-tile cache. Two strictly separate paths:
+#
+#   GET  /                       -> the page + static assets (cheap)
+#   GET  /api/tiles/<name>       -> that tile's cached JSON (cheap read)
+#   POST /api/tiles/<name>/refresh -> re-run that tile's query, rewrite its
+#                                     cache, return fresh JSON (expensive)
+#
+# The cache reuses the existing per-project cache root (Get-AzDevOpsCachePaths)
+# so it follows the active project slice exactly like assigned.json /
+# hierarchy.json — one JSON file per tile under a daily-viewer/ subfolder.
+# Staleness is the file's mtime age, surfaced to the client so the page can
+# render "cached Nm ago" without a second source of truth.
+#
+# SECURITY: the listener binds to 127.0.0.1 only (never 0.0.0.0), and the
+# az login / PAT stays in this server process — responses carry only work-item
+# and agenda data. The per-tile query is the seam where the real az boards /
+# Outlook calls land (next issue); today New-AzDevOpsDailyViewerTileItems emits
+# placeholder payloads shaped like the front-end model so the transport and
+# cache contract can be stood up and verified first.
+#
+# Loaded by powcuts_home.ps1. See azdevops_auth.ps1 for the master docstring.
+
+$script:AzDevOpsDailyViewerDefaultPort     = 8770
+$script:AzDevOpsDailyViewerStaleSeconds    = 900     # 15 min: mtime age past which a tile reads "stale"
+$script:AzDevOpsDailyViewerCacheSubdir     = 'daily-viewer'
+$script:AzDevOpsDailyViewerLoopbackAddress = '127.0.0.1'
+
+$script:AzDevOpsDailyViewerMimeTypes = @{
+    '.html' = 'text/html; charset=utf-8'
+    '.css'  = 'text/css; charset=utf-8'
+    '.js'   = 'text/javascript; charset=utf-8'
+    '.json' = 'application/json; charset=utf-8'
+    '.svg'  = 'image/svg+xml'
+    '.ico'  = 'image/x-icon'
+    '.png'  = 'image/png'
+    '.woff2'= 'font/woff2'
+}
+
+
+# ---------------------------------------------------------------------------
+# Tile identity + filesystem layout
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsDailyViewerTileNames {
+    $names = @('agenda', 'week', 'activity', 'focus')
+    return $names
+}
+
+
+function Test-AzDevOpsDailyViewerTileName {
+    param([Parameter(Mandatory)] [string] $Name)
+
+    $known = Get-AzDevOpsDailyViewerTileNames
+    $isKnown = $known -contains $Name
+    return $isKnown
+}
+
+
+function Get-AzDevOpsDailyViewerStaticRoot {
+    # The static assets (index.html / styles.css / app.js) live in daily-viewer/
+    # at the repo root, one level up from this file's powcuts_by_cli/ folder.
+    $root = Join-Path (Split-Path -Parent $PSScriptRoot) 'daily-viewer'
+    return $root
+}
+
+
+function Get-AzDevOpsDailyViewerCacheDir {
+    # A daily-viewer/ subfolder under the ACTIVE project's cache slice, so the
+    # tile cache follows az-Use-AzDevOpsProject exactly like the synced datasets
+    # rather than growing a parallel cache structure.
+    $paths = Get-AzDevOpsCachePaths
+    if (-not $paths.Dir) {
+        return $null
+    }
+
+    $dir = Join-Path $paths.Dir $script:AzDevOpsDailyViewerCacheSubdir
+    return $dir
+}
+
+
+function Get-AzDevOpsDailyViewerTilePath {
+    param([Parameter(Mandatory)] [string] $Tile)
+
+    $dir = Get-AzDevOpsDailyViewerCacheDir
+    if (-not $dir) {
+        return $null
+    }
+
+    $path = Join-Path $dir "$Tile.json"
+    return $path
+}
+
+
+# ---------------------------------------------------------------------------
+# Placeholder tile payloads — the EXPENSIVE seam
+#
+# Each builder returns the "items" payload for one tile, shaped like the
+# front-end model in daily-viewer/app.js so the eventual "wire real data" issue
+# can swap the body for real az boards / Outlook output without changing the
+# transport or the cache contract. Nothing here touches the network yet.
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsDailyViewerAgendaPlaceholder {
+    $items = [ordered]@{
+        events = @(
+            [ordered]@{
+                time     = [ordered]@{ label = '9:00 AM'; tz = 'EST'; datetime = '2026-07-14T09:00:00-05:00' }
+                title    = 'Sprint Planning Sync'
+                location = [ordered]@{ badge = 'Teams'; url = 'https://teams.microsoft.com/l/meetup-join/example'; urlLabel = 'Join meeting' }
+                details  = @(
+                    [ordered]@{ label = 'With'; text = 'Platform Team - 6 attendees' }
+                )
+            },
+            [ordered]@{
+                time     = [ordered]@{ label = '11:00 AM'; tz = 'EST'; datetime = '2026-07-14T11:00:00-05:00' }
+                title    = 'Architecture Design Review'
+                location = [ordered]@{ badge = 'In person'; text = 'Room 132' }
+                details  = @()
+            }
+        )
+    }
+
+    return $items
+}
+
+
+function Get-AzDevOpsDailyViewerWeekPlaceholder {
+    $items = [ordered]@{
+        stories = [ordered]@{
+            label = 'Stories to complete'
+            open  = $true
+            items = @(
+                [ordered]@{ type = 'Story'; id = 1234; url = 'https://dev.azure.com/org/project/_workitems/edit/1234'; title = 'Wire agenda tile to az boards query'; state = 'In progress' },
+                [ordered]@{ type = 'Bug';   id = 1251; url = 'https://dev.azure.com/org/project/_workitems/edit/1251'; title = 'Timezone offset on EST agenda rows'; state = 'In review' }
+            )
+        }
+        prep = [ordered]@{
+            label = 'Events to prepare for'
+            open  = $true
+            items = @(
+                [ordered]@{ title = 'Confirm demo build is deployed before Thu review' }
+            )
+        }
+    }
+
+    return $items
+}
+
+
+function Get-AzDevOpsDailyViewerActivityPlaceholder {
+    $items = [ordered]@{
+        groups = @(
+            [ordered]@{
+                label = 'Tagged discussions'
+                open  = $false
+                items = @(
+                    [ordered]@{ type = 'Feature'; id = 1180; url = 'https://dev.azure.com/org/project/_workitems/edit/1180'; title = 'Can you confirm the WIQL scope?' }
+                )
+            },
+            [ordered]@{
+                label = 'Active story updates'
+                open  = $false
+                items = @(
+                    [ordered]@{ type = 'Story'; id = 1234; url = 'https://dev.azure.com/org/project/_workitems/edit/1234'; title = 'State -> In progress'; note = '2h ago' }
+                )
+            }
+        )
+    }
+
+    return $items
+}
+
+
+function Get-AzDevOpsDailyViewerFocusPlaceholder {
+    $items = [ordered]@{
+        primary = [ordered]@{
+            title = 'User Story #1234 - Wire agenda tile to az boards'
+            url   = 'https://dev.azure.com/org/project/_workitems/edit/1234'
+            sub   = 'Primary commitment for today - In progress'
+        }
+        support = [ordered]@{
+            label = 'SF devs - unplanned support'
+            open  = $true
+            items = @(
+                [ordered]@{ type = 'Bug'; id = 1260; url = 'https://dev.azure.com/org/project/_workitems/edit/1260'; title = 'Deploy failing on scratch org spin-up'; state = 'Active' }
+            )
+        }
+    }
+
+    return $items
+}
+
+
+function New-AzDevOpsDailyViewerTileItems {
+    # Dispatch to the per-tile builder. This is the single seam the next issue
+    # replaces with real az boards / Outlook queries — everything above and
+    # below it (cache read/write, HTTP transport) stays put.
+    param([Parameter(Mandatory)] [string] $Tile)
+
+    switch ($Tile) {
+        'agenda' {
+            $items = Get-AzDevOpsDailyViewerAgendaPlaceholder
+            return $items
+        }
+
+        'week' {
+            $items = Get-AzDevOpsDailyViewerWeekPlaceholder
+            return $items
+        }
+
+        'activity' {
+            $items = Get-AzDevOpsDailyViewerActivityPlaceholder
+            return $items
+        }
+
+        'focus' {
+            $items = Get-AzDevOpsDailyViewerFocusPlaceholder
+            return $items
+        }
+
+        default {
+            throw "New-AzDevOpsDailyViewerTileItems: unknown tile '$Tile'."
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Cache read / write — cheap read, expensive write kept in separate helpers
+# ---------------------------------------------------------------------------
+
+function Write-AzDevOpsDailyViewerTile {
+    # EXPENSIVE path: build the tile's payload, then persist it under the active
+    # cache slice with a written-at stamp. Returns the same read-model the cheap
+    # path returns so POST /refresh and GET share one response shape.
+    param([Parameter(Mandatory)] [string] $Tile)
+
+    $path = Get-AzDevOpsDailyViewerTilePath -Tile $Tile
+    if (-not $path) {
+        throw "Write-AzDevOpsDailyViewerTile: no active cache dir (run az-Connect-AzDevOps first)."
+    }
+
+    $dir = Split-Path -Parent $path
+    New-AzDevOpsDirectoryIfMissing -Path $dir
+
+    $items = New-AzDevOpsDailyViewerTileItems -Tile $Tile
+
+    $record = [ordered]@{
+        tile      = $Tile
+        writtenAt = (Get-Date).ToString('o')
+        items     = $items
+    }
+
+    $json = $record | ConvertTo-Json -Depth 10
+    Write-AzDevOpsCacheFile -Path $path -Content $json
+
+    $model = Read-AzDevOpsDailyViewerTile -Tile $Tile
+    return $model
+}
+
+
+function Read-AzDevOpsDailyViewerTile {
+    # CHEAP path: read one tile's cache file and derive its staleness from the
+    # file's mtime. Returns $null when the tile has never been written, so the
+    # caller can answer 404 rather than fabricate empty data.
+    param([Parameter(Mandatory)] [string] $Tile)
+
+    $path = Get-AzDevOpsDailyViewerTilePath -Tile $Tile
+    if (-not $path -or -not (Test-Path -LiteralPath $path)) {
+        return $null
+    }
+
+    $file = Get-Item -LiteralPath $path
+    $ageSeconds = [int]((Get-Date) - $file.LastWriteTime).TotalSeconds
+    $isStale = ($ageSeconds -ge $script:AzDevOpsDailyViewerStaleSeconds)
+
+    $raw = Get-Content -LiteralPath $path -Raw
+
+    $record = $null
+    try {
+        $record = $raw | ConvertFrom-Json
+    }
+    catch {
+        $record = $null
+    }
+
+    $writtenAt = if ($record -and $record.writtenAt) {
+        $record.writtenAt
+    } else {
+        $file.LastWriteTime.ToString('o')
+    }
+
+    $items = if ($record) {
+        $record.items
+    } else {
+        $null
+    }
+
+    $model = [ordered]@{
+        tile       = $Tile
+        writtenAt  = $writtenAt
+        ageSeconds = $ageSeconds
+        stale      = $isStale
+        items      = $items
+    }
+
+    return $model
+}
+
+
+function Initialize-AzDevOpsDailyViewerCache {
+    # Seed any tile that has never been written so the very first page load reads
+    # data from cache instead of a wall of 404s. Cheap: only fills gaps, never
+    # rewrites a tile that already exists (that's what POST /refresh is for).
+    $names = Get-AzDevOpsDailyViewerTileNames
+
+    foreach ($name in $names) {
+        $path = Get-AzDevOpsDailyViewerTilePath -Tile $name
+
+        if ($path -and -not (Test-Path -LiteralPath $path)) {
+            $null = Write-AzDevOpsDailyViewerTile -Tile $name
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Static asset serving
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsDailyViewerContentType {
+    param([Parameter(Mandatory)] [string] $Path)
+
+    $ext = [System.IO.Path]::GetExtension($Path).ToLowerInvariant()
+
+    $type = if ($script:AzDevOpsDailyViewerMimeTypes.ContainsKey($ext)) {
+        $script:AzDevOpsDailyViewerMimeTypes[$ext]
+    } else {
+        'application/octet-stream'
+    }
+
+    return $type
+}
+
+
+function Resolve-AzDevOpsDailyViewerAssetPath {
+    # Map a request path to a file inside the static root, refusing anything that
+    # escapes the root (path traversal). Returns $null when the target is outside
+    # the root or does not exist, so the router answers 404.
+    param(
+        [Parameter(Mandatory)] [string] $RequestPath,
+        [Parameter(Mandatory)] [string] $Root
+    )
+
+    $relative = $RequestPath.TrimStart('/')
+    if (-not $relative) {
+        $relative = 'index.html'
+    }
+
+    $candidate = Join-Path $Root $relative
+    $fullCandidate = [System.IO.Path]::GetFullPath($candidate)
+    $fullRoot = [System.IO.Path]::GetFullPath($Root)
+
+    $rootPrefix = $fullRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+    if (-not $fullCandidate.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $null
+    }
+
+    if (-not (Test-Path -LiteralPath $fullCandidate -PathType Leaf)) {
+        return $null
+    }
+
+    return $fullCandidate
+}
+
+
+# ---------------------------------------------------------------------------
+# HTTP response writers
+# ---------------------------------------------------------------------------
+
+function Write-AzDevOpsDailyViewerBytes {
+    param(
+        [Parameter(Mandatory)] [System.Net.HttpListenerResponse] $Response,
+        [Parameter(Mandatory)] [int]    $StatusCode,
+        [Parameter(Mandatory)] [string] $ContentType,
+        [byte[]] $Body = @()
+    )
+
+    $Response.StatusCode  = $StatusCode
+    $Response.ContentType = $ContentType
+    $Response.ContentLength64 = $Body.Length
+
+    if ($Body.Length -gt 0) {
+        $Response.OutputStream.Write($Body, 0, $Body.Length)
+    }
+
+    $Response.OutputStream.Close()
+}
+
+
+function Write-AzDevOpsDailyViewerJson {
+    param(
+        [Parameter(Mandatory)] [System.Net.HttpListenerResponse] $Response,
+        [Parameter(Mandatory)] [int] $StatusCode,
+        [Parameter(Mandatory)] [AllowNull()] $Object
+    )
+
+    $json = $Object | ConvertTo-Json -Depth 10
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+
+    Write-AzDevOpsDailyViewerBytes -Response $Response -StatusCode $StatusCode `
+        -ContentType 'application/json; charset=utf-8' -Body $bytes
+}
+
+
+function Write-AzDevOpsDailyViewerError {
+    param(
+        [Parameter(Mandatory)] [System.Net.HttpListenerResponse] $Response,
+        [Parameter(Mandatory)] [int]    $StatusCode,
+        [Parameter(Mandatory)] [string] $Message
+    )
+
+    $payload = [ordered]@{ error = $Message }
+    Write-AzDevOpsDailyViewerJson -Response $Response -StatusCode $StatusCode -Object $payload
+}
+
+
+# ---------------------------------------------------------------------------
+# Request routing — cheap GET vs expensive POST /refresh kept distinct
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsDailyViewerTileRoute {
+    # Parse an /api/tiles/... path into { Tile; IsRefresh } or $null when it
+    # isn't a tile route. Keeps the router readable and the two API verbs apart.
+    param([Parameter(Mandatory)] [string] $Path)
+
+    $prefix = '/api/tiles/'
+    if (-not $Path.StartsWith($prefix)) {
+        return $null
+    }
+
+    $rest = $Path.Substring($prefix.Length).Trim('/')
+    if (-not $rest) {
+        return $null
+    }
+
+    $segments = $rest -split '/'
+    $tile = $segments[0]
+
+    $isRefresh = ($segments.Count -eq 2 -and $segments[1] -eq 'refresh')
+    $isPlain   = ($segments.Count -eq 1)
+
+    if (-not $isRefresh -and -not $isPlain) {
+        return $null
+    }
+
+    $route = [PSCustomObject]@{
+        Tile      = $tile
+        IsRefresh = $isRefresh
+    }
+    return $route
+}
+
+
+function Invoke-AzDevOpsDailyViewerApiRequest {
+    param(
+        [Parameter(Mandatory)] [System.Net.HttpListenerContext] $Context,
+        [Parameter(Mandatory)] [PSCustomObject] $Route
+    )
+
+    $request  = $Context.Request
+    $response = $Context.Response
+    $method   = $request.HttpMethod
+
+    if (-not (Test-AzDevOpsDailyViewerTileName -Name $Route.Tile)) {
+        Write-AzDevOpsDailyViewerError -Response $response -StatusCode 404 -Message "Unknown tile '$($Route.Tile)'."
+        return
+    }
+
+    if ($Route.IsRefresh) {
+        if ($method -ne 'POST') {
+            Write-AzDevOpsDailyViewerError -Response $response -StatusCode 405 -Message 'Refresh requires POST.'
+            return
+        }
+
+        $model = Write-AzDevOpsDailyViewerTile -Tile $Route.Tile
+        Write-AzDevOpsDailyViewerJson -Response $response -StatusCode 200 -Object $model
+        return
+    }
+
+    if ($method -ne 'GET') {
+        Write-AzDevOpsDailyViewerError -Response $response -StatusCode 405 -Message 'Tile read requires GET.'
+        return
+    }
+
+    $model = Read-AzDevOpsDailyViewerTile -Tile $Route.Tile
+    if ($null -eq $model) {
+        Write-AzDevOpsDailyViewerError -Response $response -StatusCode 404 -Message "Tile '$($Route.Tile)' has no cache yet."
+        return
+    }
+
+    Write-AzDevOpsDailyViewerJson -Response $response -StatusCode 200 -Object $model
+}
+
+
+function Invoke-AzDevOpsDailyViewerStaticRequest {
+    param(
+        [Parameter(Mandatory)] [System.Net.HttpListenerContext] $Context,
+        [Parameter(Mandatory)] [string] $StaticRoot
+    )
+
+    $request  = $Context.Request
+    $response = $Context.Response
+
+    if ($request.HttpMethod -ne 'GET') {
+        Write-AzDevOpsDailyViewerError -Response $response -StatusCode 405 -Message 'Static assets are GET only.'
+        return
+    }
+
+    $assetPath = Resolve-AzDevOpsDailyViewerAssetPath -RequestPath $request.Url.AbsolutePath -Root $StaticRoot
+    if (-not $assetPath) {
+        Write-AzDevOpsDailyViewerError -Response $response -StatusCode 404 -Message 'Not found.'
+        return
+    }
+
+    $bytes = [System.IO.File]::ReadAllBytes($assetPath)
+    $contentType = Get-AzDevOpsDailyViewerContentType -Path $assetPath
+
+    Write-AzDevOpsDailyViewerBytes -Response $response -StatusCode 200 -ContentType $contentType -Body $bytes
+}
+
+
+function Invoke-AzDevOpsDailyViewerRequest {
+    # Front door: API routes go to the tile handler (cheap GET / expensive POST),
+    # everything else is treated as a static-asset GET. Any handler failure is
+    # turned into a 500 so one bad request can never kill the serving loop.
+    param(
+        [Parameter(Mandatory)] [System.Net.HttpListenerContext] $Context,
+        [Parameter(Mandatory)] [string] $StaticRoot
+    )
+
+    $response = $Context.Response
+
+    try {
+        $route = Get-AzDevOpsDailyViewerTileRoute -Path $Context.Request.Url.AbsolutePath
+
+        if ($null -ne $route) {
+            Invoke-AzDevOpsDailyViewerApiRequest -Context $Context -Route $route
+        } else {
+            Invoke-AzDevOpsDailyViewerStaticRequest -Context $Context -StaticRoot $StaticRoot
+        }
+    }
+    catch {
+        try {
+            Write-AzDevOpsDailyViewerError -Response $response -StatusCode 500 -Message $_.Exception.Message
+        }
+        catch {
+            # response already closed / client gone — nothing more we can do
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsDailyViewerPrefix {
+    param([Parameter(Mandatory)] [int] $Port)
+
+    $prefix = "http://$($script:AzDevOpsDailyViewerLoopbackAddress):$Port/"
+    return $prefix
+}
+
+
+function Open-AzDevOpsDailyViewerBrowser {
+    param([Parameter(Mandatory)] [string] $Url)
+
+    try {
+        if ($IsWindows -or ($env:OS -eq 'Windows_NT')) {
+            Start-Process $Url
+        } elseif ($IsMacOS) {
+            & open $Url
+        } else {
+            & xdg-open $Url
+        }
+    }
+    catch {
+        Write-Host "Open $Url in your browser." -ForegroundColor Yellow
+    }
+}
+
+
+function Start-AzDevOpsDailyViewer {
+    <#
+    .SYNOPSIS
+        Serve the Azure DevOps daily viewer on 127.0.0.1 with a per-tile cache API.
+
+    .DESCRIPTION
+        Binds a System.Net.HttpListener to loopback only, serves daily-viewer/'s
+        static assets, and exposes GET /api/tiles/<name> (cheap cache read) and
+        POST /api/tiles/<name>/refresh (expensive re-query + cache rewrite). The
+        az login / PAT never leaves this process; responses carry only work-item
+        and agenda data. Press Ctrl+C to stop.
+
+    .PARAMETER Port
+        Loopback TCP port to listen on. Defaults to 8770.
+
+    .PARAMETER NoBrowser
+        Skip auto-opening the default browser (useful for scripted / curl checks).
+    #>
+    param(
+        [int]    $Port = $script:AzDevOpsDailyViewerDefaultPort,
+        [switch] $NoBrowser
+    )
+
+    $staticRoot = Get-AzDevOpsDailyViewerStaticRoot
+    if (-not (Test-Path -LiteralPath $staticRoot)) {
+        Write-Host "Daily viewer assets not found at $staticRoot" -ForegroundColor Red
+        return
+    }
+
+    $cacheDir = Get-AzDevOpsDailyViewerCacheDir
+    if (-not $cacheDir) {
+        Write-Host 'No active Azure DevOps cache dir. Run az-Connect-AzDevOps first.' -ForegroundColor Yellow
+        return
+    }
+
+    Initialize-AzDevOpsDailyViewerCache
+
+    $prefix = Get-AzDevOpsDailyViewerPrefix -Port $Port
+    $listener = New-Object System.Net.HttpListener
+    $listener.Prefixes.Add($prefix)
+
+    try {
+        $listener.Start()
+    }
+    catch [System.Net.HttpListenerException] {
+        Write-Host "Could not bind $prefix - $($_.Exception.Message)" -ForegroundColor Red
+        Write-Host 'On Windows a one-time URL reservation may be needed:' -ForegroundColor Yellow
+        Write-Host "  netsh http add urlacl url=$prefix user=$env:USERNAME" -ForegroundColor Yellow
+        Write-Host 'Or pass a different -Port.' -ForegroundColor Yellow
+        return
+    }
+
+    Write-Host "Daily viewer serving at $prefix (Ctrl+C to stop)" -ForegroundColor Green
+    Write-Host "  cache: $cacheDir" -ForegroundColor DarkGray
+
+    if (-not $NoBrowser) {
+        Open-AzDevOpsDailyViewerBrowser -Url $prefix
+    }
+
+    try {
+        while ($listener.IsListening) {
+            $context = $listener.GetContext()
+            Invoke-AzDevOpsDailyViewerRequest -Context $context -StaticRoot $staticRoot
+        }
+    }
+    catch {
+        # GetContext throws when the listener is stopped (Ctrl+C / disposal) —
+        # fall through to the finally so shutdown stays clean.
+    }
+    finally {
+        if ($listener.IsListening) {
+            $listener.Stop()
+        }
+        $listener.Close()
+        Write-Host 'Daily viewer stopped.' -ForegroundColor DarkGray
+    }
+}

--- a/powcuts_home.ps1
+++ b/powcuts_home.ps1
@@ -177,6 +177,13 @@ if ($azdevops_help -ne $NULL) {
     Write-Host "no azdevops_help.ps1"
 }
 
+$daily_viewer = Get-Content "$path_to_bashcuts\powcuts_by_cli\daily_viewer.ps1"
+if ($daily_viewer -ne $NULL) {
+ . "$path_to_bashcuts\powcuts_by_cli\daily_viewer.ps1"
+} else {
+    Write-Host "no daily_viewer.ps1"
+}
+
 # On shell open: silently refresh the Azure DevOps cache in the background when
 # it's stale. Invoked here (after every azdevops_*.ps1 file is dot-sourced) so
 # Get-AzDevOpsActiveProjectSlug is defined and the staleness check targets the


### PR DESCRIPTION

## Navigation

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #192 |
| [Changes](#changes) | ✅ 3 files |
| [Test Plan](#test-plan) | ✅ 6 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE (no bash files) — [View](#issuecomment-4976172846) |
| 💠 PowerShell Engineer Review | ✅ APPROVE (1 MEDIUM naming — fixed via `az-` rename; 2 LOW) — [View](#issuecomment-4976182741) |
| 🛡️ Security Audit | ✅ APPROVE (1 LOW host-header; 1 Info 500-message — fixed) — [View](#issuecomment-4976177898) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE (3 LOW — depth-constant fixed) — [View](#issuecomment-4976182008) |
| 🎨 Front-End Engineer Review | ✅ APPROVE (2 LOW — 500-message fixed) — [View](#issuecomment-4976178168) |
| 📄 Docs Check | ✅ CURRENT — [View](#issuecomment-4976229281) |
| ✅ Criteria Check | ✅ PASS (7/10 verified, 0 gaps; pwsh-parse unverified-in-env) — [View](#issuecomment-4976236105) |
| 📐 AzDO Diagrams Check | N/A |

<!-- pr-diagram:start -->
## How it works

`az-Start-AzDevOpsDailyViewer` resolves the static root and the active project's per-tile cache dir, seeds any missing tiles, then binds a loopback-only `HttpListener`, opens the browser, and loops on requests. `Invoke-AzDevOpsDailyViewerRequest` routes each request into either the tile API — which keeps the **cheap** `GET` cache read strictly apart from the **expensive** `POST /refresh` re-query — or the path-traversal-guarded static asset server.

```mermaid
flowchart TD
    Start([az-Start-AzDevOpsDailyViewer]):::pub

    Resolve[resolve static root<br/>+ per-project cache dir]:::priv
    Init[Initialize-AzDevOpsDailyViewerCache<br/>seed missing tiles]:::priv
    Listen["HttpListener bind<br/>http://127.0.0.1:port/"]:::io
    Browser[Open-AzDevOpsDailyViewerBrowser]:::priv
    Loop{"request loop"}

    Route[Invoke-AzDevOpsDailyViewerRequest<br/>route + 500 guard]:::priv
    IsApi{"/api/tiles/name ?"}
    Api[Invoke-AzDevOpsDailyViewerApiRequest]:::priv
    Method{"GET vs POST /refresh?"}

    Read[Read-AzDevOpsDailyViewerTile<br/>cheap: read cache + mtime staleness]:::priv
    Write[Write-AzDevOpsDailyViewerTile<br/>expensive: rewrite cache]:::priv
    Build[New-AzDevOpsDailyViewerTileItems<br/>placeholder builders]:::priv

    Static[Invoke-AzDevOpsDailyViewerStaticRequest<br/>path-traversal guarded]:::priv

    Cache[(per-tile cache JSON<br/>daily-viewer/*.json)]:::io
    Assets[(daily-viewer/ static assets)]:::io

    Start --> Resolve --> Init --> Listen --> Browser --> Loop
    Loop --> Route --> IsApi
    IsApi -- yes --> Api --> Method
    IsApi -- no --> Static --> Assets

    Method -- "GET (cheap)" --> Read --> Cache
    Method -- "POST /refresh (expensive)" --> Write --> Build --> Cache

    Init -.seeds missing.-> Write

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Stands up the daily-viewer transport and cache shape (#192): a built-in `System.Net.HttpListener` bound to `127.0.0.1` only that serves the `daily-viewer/` dashboard plus a JSON tile API, keeping the **cheap** cache read and the **expensive** per-tile refresh on strictly separate code paths. Placeholder tile data for now — the real `az boards` / Outlook queries are a clearly marked seam for the next issue.

## Issue

Closes #192

## Changes

- **`powcuts_by_cli/daily_viewer.ps1`** (new) — `Start-AzDevOpsDailyViewer` (approved verb, `-Port` / `-NoBrowser`) launches the loopback server and opens the browser.
  - `GET /` → the page + static assets (path-traversal-guarded).
  - `GET /api/tiles/` → that tile&#39;s cached JSON with `ageSeconds` / `stale` staleness (cheap read).
  - `POST /api/tiles//refresh` → re-queries, rewrites that tile&#39;s cache, returns fresh JSON (expensive; per-tile).
  - Cache reuses the existing per-project cache root (`Get-AzDevOpsCachePaths`) under a `daily-viewer/` subfolder, one JSON per tile; staleness derived from file mtime.
  - `New-AzDevOpsDailyViewerTileItems` is the single seam the next issue swaps for real `az boards` / Outlook queries; it emits placeholder payloads shaped like the front-end model today.
  - No secret leaves the process — responses carry only work-item and agenda data.
- **`powcuts_home.ps1`** — dot-sources the new module so the shortcut is exposed.
- **`README.md`** — documents `Start-AzDevOpsDailyViewer`, the cache layout, the cheap/expensive API split, and the Windows `urlacl` note.

## Test Plan

- [ ] Parse both changed `.ps1` with `[System.Management.Automation.Language.Parser]::ParseFile(...)` — zero errors
- [ ] Open a fresh PowerShell terminal, `Start-AzDevOpsDailyViewer -NoBrowser`
- [ ] `curl http://127.0.0.1:8770/` returns the page
- [ ] `curl http://127.0.0.1:8770/api/tiles/agenda` returns `{tile,writtenAt,ageSeconds,stale,items}` (cheap read)
- [ ] `curl -X POST http://127.0.0.1:8770/api/tiles/agenda/refresh` rewrites the cache and resets `ageSeconds` to ~0 (expensive refresh)
- [ ] `ss`/`netstat` shows the listener on `127.0.0.1` only — never `0.0.0.0`

&gt; ⚠️ **Note:** PowerShell is not installed in the CI/dev container used to author this change and the standalone binary download is proxy-blocked, so the `pwsh` parse and end-to-end drive were not executed here — a quote/comment-aware bracket-balance check and a rule-by-rule CLAUDE.md review were run instead. Please confirm the parse locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAqJXz9ZDXXT5EaE4kigPd)_