### PR TITLE
Daily Viewer: wire real Azure DevOps + Outlook data per tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,15 @@ Each tile is backed by one JSON file under the active project's cache slice — 
 - `GET /api/tiles/<name>` — that tile's cached JSON, plus its `ageSeconds` / `stale` staleness (cheap read).
 - `POST /api/tiles/<name>/refresh` — re-runs that tile's query, rewrites its cache, and returns the fresh JSON (expensive; per-tile).
 
+Each tile is populated from a real source, reusing the same WIQL defaults and Outlook module the rest of the toolkit uses:
+
+- **Today's Agenda** — today's calendar events from `ol-Get-OutlookAgenda` (desktop Outlook), with the Teams join link when the meeting carries one.
+- **This Week's Focus** — your active assigned stories (the `assigned` WIQL) plus a prep checklist derived from today's meetings.
+- **Recent Activity** — @-mention discussions (the `mentions` WIQL), your recent updates (the `activity` WIQL), and sprint-close candidates.
+- **Today's Focus** — the pinned work item you set in `$global:AzDevOpsDailyFocus` (a work-item id), plus an "assigned & unplanned support" bucket. Set it in your `$profile`, e.g. `$global:AzDevOpsDailyFocus = 1234`; leave it unset and the tile shows the support bucket alone.
+
+Any tile whose source is unavailable (not logged in to `az`, Outlook not reachable, or nothing to show) renders a friendly empty state rather than erroring, and the page falls back to sample data when opened directly (without the local server). Opening the viewer off Windows still works — the Outlook-backed agenda simply comes up empty.
+
 > On Windows, `HttpListener` may need a one-time URL reservation the first time you bind a port — if `az-Start-AzDevOpsDailyViewer` reports it could not bind, run the `netsh http add urlacl` line it prints (or just pick another `-Port`).
 
 <br>

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -340,11 +340,13 @@ function renderFocus(model) {
 }
 
 
-
 // ---------------------------------------------------------------------------
 // Tile registry — the render function, stat target, and stat count for each
 // tile in one place, so mount and refresh iterate a single list.
 // ---------------------------------------------------------------------------
+
+// What counts as a "row" across mount, count badges, and the live filter.
+var ROW_SELECTOR = ".wi, .event";
 
 function activityTotal(model) {
   return asArray(model.groups).reduce(function (sum, group) {
@@ -396,7 +398,7 @@ function renderTileBody(key, model) {
 
   // "empty" counts the primary too so a focus tile with a pinned item but no
   // support rows isn't mislabeled as empty; the count badge stays row-only.
-  var meaningful = body.querySelectorAll(".wi, .event, .primary").length;
+  var meaningful = body.querySelectorAll(ROW_SELECTOR + ", .primary").length;
   if (meaningful === 0) {
     body.appendChild(el("p", { class: "empty-note", text: conf.empty }));
   }
@@ -406,7 +408,7 @@ function renderTileBody(key, model) {
   body.appendChild(el("p", { class: "nomatch", text: "No matching items in this tile." }));
 
   tile(key).querySelector(".tt .count").textContent =
-    String(body.querySelectorAll(".wi, .event").length);
+    String(body.querySelectorAll(ROW_SELECTOR).length);
 }
 
 
@@ -645,7 +647,7 @@ function applyFilter(raw) {
   var matchTotal = 0;
 
   document.querySelectorAll(".tile").forEach(function (t) {
-    var rows = t.querySelectorAll(".wi, .event");
+    var rows = t.querySelectorAll(ROW_SELECTOR);
     var anyVisible = false;
 
     rows.forEach(function (row) {

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -268,14 +268,23 @@ function eventRow(ev) {
 }
 
 
+// A tile's collections arrive from the cache/API as JSON. Guard every list
+// through this so a serialized-empty array (or an absent field) becomes [] and
+// never a `.map` on a non-array.
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
 function groupBlock(group, rowFn) {
+  var items = asArray(group.items);
+
   var summary = el("summary", null, [
     chevron(),
     el("span", { class: "glabel", text: group.label }),
-    el("span", { class: "count", text: String(group.items.length) })
+    el("span", { class: "count", text: String(items.length) })
   ]);
 
-  var list = el("ul", { class: "glist" }, group.items.map(rowFn));
+  var list = el("ul", { class: "glist" }, items.map(rowFn));
 
   var opts = { class: "group" };
   if (group.open) {
@@ -291,84 +300,200 @@ function groupBlock(group, rowFn) {
 // ---------------------------------------------------------------------------
 
 function renderAgenda(model) {
-  var list = el("ul", { class: "events" }, model.events.map(eventRow));
+  var list = el("ul", { class: "events" }, asArray(model.events).map(eventRow));
   return [ list ];
 }
 
 
 function renderWeek(model) {
   return [
-    groupBlock(model.stories, workItemRow),
-    groupBlock(model.prep, checklistRow)
+    groupBlock(model.stories || {}, workItemRow),
+    groupBlock(model.prep || {}, checklistRow)
   ];
 }
 
 
 function renderActivity(model) {
-  return model.groups.map(function (group) {
+  return asArray(model.groups).map(function (group) {
     return groupBlock(group, workItemRow);
   });
 }
 
 
 function renderFocus(model) {
-  var primary = el("div", { class: "primary" }, [
-    el("span", { class: "star", "aria-hidden": "true" }, [ STAR_GLYPH ]),
-    el("div", null, [
-      el("p", { class: "ptitle" }, [ externalLink(model.primary.title, model.primary.url) ]),
-      el("p", { class: "psub", text: model.primary.sub })
-    ])
-  ]);
+  var nodes = [];
 
-  return [ primary, groupBlock(model.support, workItemRow) ];
+  // The pinned item is optional — it comes from $global:AzDevOpsDailyFocus, and
+  // the tile renders its support bucket alone when nothing is pinned.
+  if (model.primary) {
+    nodes.push(el("div", { class: "primary" }, [
+      el("span", { class: "star", "aria-hidden": "true" }, [ STAR_GLYPH ]),
+      el("div", null, [
+        el("p", { class: "ptitle" }, [ externalLink(model.primary.title, model.primary.url) ]),
+        el("p", { class: "psub", text: model.primary.sub })
+      ])
+    ]));
+  }
+
+  nodes.push(groupBlock(model.support || {}, workItemRow));
+  return nodes;
 }
 
 
+
 // ---------------------------------------------------------------------------
-// Mount — populate each tile body, derive its count badge from the rendered
-// rows, and set each stat number from the collection it summarizes.
+// Tile registry — the render function, stat target, and stat count for each
+// tile in one place, so mount and refresh iterate a single list.
+// ---------------------------------------------------------------------------
+
+function activityTotal(model) {
+  return asArray(model.groups).reduce(function (sum, group) {
+    return sum + asArray(group.items).length;
+  }, 0);
+}
+
+var TILES = [
+  { key: "agenda",   render: renderAgenda,   stat: "tile-agenda",
+    empty: "No meetings today.",
+    statCount: function (m) { return asArray(m.events).length; } },
+  { key: "week",     render: renderWeek,     stat: "tile-week",
+    empty: "No stories or prep items this week.",
+    statCount: function (m) { return asArray(m.stories && m.stories.items).length; } },
+  { key: "activity", render: renderActivity, stat: "tile-activity",
+    empty: "No recent activity.",
+    statCount: activityTotal },
+  { key: "focus",    render: renderFocus,    stat: "tile-focus",
+    empty: "Nothing pinned. Set $global:AzDevOpsDailyFocus to a work-item id.",
+    statCount: function (m) { return asArray(m.support && m.support.items).length; } }
+];
+
+var TILE_BY_KEY = {};
+TILES.forEach(function (t) { TILE_BY_KEY[t.key] = t; });
+
+
+// ---------------------------------------------------------------------------
+// Mount — render one tile body from its data model: clear, render rows, derive
+// the count badge, and drop a friendly note when the tile is genuinely empty.
 // ---------------------------------------------------------------------------
 
 function tile(key) {
   return document.querySelector('.tile[data-tile="' + key + '"]');
 }
 
-function mountTile(key, nodes) {
+function setStat(statId, count) {
+  var number = document.querySelector('.stat[data-target="' + statId + '"] .n');
+  if (number) {
+    number.textContent = String(count);
+  }
+}
+
+function renderTileBody(key, model) {
+  var conf = TILE_BY_KEY[key];
   var body = tile(key).querySelector(".body");
-  nodes.forEach(function (node) { body.appendChild(node); });
 
-  var badge = tile(key).querySelector(".tt .count");
-  badge.textContent = String(body.querySelectorAll(".wi, .event").length);
+  body.textContent = "";
+  conf.render(model || {}).forEach(function (node) { body.appendChild(node); });
+
+  // "empty" counts the primary too so a focus tile with a pinned item but no
+  // support rows isn't mislabeled as empty; the count badge stays row-only.
+  var meaningful = body.querySelectorAll(".wi, .event, .primary").length;
+  if (meaningful === 0) {
+    body.appendChild(el("p", { class: "empty-note", text: conf.empty }));
+  }
+
+  // Re-add the filter's no-match note after each (re)render so the live filter
+  // has its placeholder whether the body came from cache or a refresh.
+  body.appendChild(el("p", { class: "nomatch", text: "No matching items in this tile." }));
+
+  tile(key).querySelector(".tt .count").textContent =
+    String(body.querySelectorAll(".wi, .event").length);
 }
-
-function setStat(key, count) {
-  var number = document.querySelector('.stat[data-target="' + key + '"] .n');
-  number.textContent = String(count);
-}
-
-function activityTotal(model) {
-  return model.groups.reduce(function (sum, group) {
-    return sum + group.items.length;
-  }, 0);
-}
-
-function renderAll() {
-  mountTile("agenda", renderAgenda(MODEL.agenda));
-  mountTile("week", renderWeek(MODEL.week));
-  mountTile("activity", renderActivity(MODEL.activity));
-  mountTile("focus", renderFocus(MODEL.focus));
-
-  setStat("tile-agenda", MODEL.agenda.events.length);
-  setStat("tile-week", MODEL.week.stories.items.length);
-  setStat("tile-activity", activityTotal(MODEL.activity));
-  setStat("tile-focus", MODEL.focus.support.items.length);
-}
-
-renderAll();
 
 
 // ---------------------------------------------------------------------------
-// Controls — wired after render so every handler sees the rendered rows.
+// Staleness — turn the cache's ageSeconds into the "cached Nm ago" label the
+// tile header shows, matching the server's own relative-time buckets.
+// ---------------------------------------------------------------------------
+
+function formatAge(sec) {
+  if (sec < 45) {
+    return "just now";
+  }
+
+  var min = Math.round(sec / 60);
+  if (min < 60) {
+    return min + "m ago";
+  }
+
+  var hr = Math.round(min / 60);
+  if (hr < 24) {
+    return hr + "h ago";
+  }
+
+  var day = Math.round(hr / 24);
+  return day + "d ago";
+}
+
+function staleLabelNode(key) {
+  var stale = tile(key).querySelector(".stale");
+  return stale.childNodes[stale.childNodes.length - 1];
+}
+
+function setStale(key, data) {
+  var stale = tile(key).querySelector(".stale");
+  var label = staleLabelNode(key);
+
+  stale.classList.remove("busy");
+
+  if (data && typeof data.ageSeconds === "number") {
+    label.textContent = "cached " + formatAge(data.ageSeconds);
+    stale.classList.toggle("warn", !!data.stale);
+  } else {
+    label.textContent = "sample data";
+    stale.classList.remove("warn");
+  }
+}
+
+
+// ---------------------------------------------------------------------------
+// Data layer — cheap GET on load, expensive POST /refresh on demand. Both hit
+// the same-origin local server; on any failure (offline preview, no backend)
+// the tile falls back to the embedded sample MODEL so the page still renders.
+// ---------------------------------------------------------------------------
+
+var API = "/api/tiles/";
+
+function fetchJson(url, options) {
+  return fetch(url, options).then(function (res) {
+    if (!res.ok) {
+      throw new Error("HTTP " + res.status);
+    }
+    return res.json();
+  });
+}
+
+function paintTile(key, model, data) {
+  var conf = TILE_BY_KEY[key];
+  renderTileBody(key, model);
+  setStat(conf.stat, conf.statCount(model || {}));
+  setStale(key, data);
+}
+
+function loadTile(key) {
+  return fetchJson(API + key, { headers: { "Accept": "application/json" } })
+    .then(function (data) {
+      paintTile(key, data.items || {}, data);
+    })
+    .catch(function () {
+      paintTile(key, MODEL[key], null);
+    });
+}
+
+
+// ---------------------------------------------------------------------------
+// Controls — announce, expand/collapse, per-tile + all refresh, stat jump,
+// theme, live filter. Wired once; all handlers query the DOM at event time so
+// they see whatever the async render produced.
 // ---------------------------------------------------------------------------
 
 // Named liveRegion, not `status`: a top-level `var status` in a classic script
@@ -391,10 +516,9 @@ document.getElementById("collapseAll").addEventListener("click", function () {
 });
 
 
-// Per-tile refresh: the only expensive path. Cheap render is already on screen
-// from cache; this is where the real build would fire that tile's az CLI calls.
-var REFRESH_MS = 900;
-
+// Per-tile refresh: the only expensive path. The cheap render is already on
+// screen from cache; this re-runs that tile's az / Outlook query server-side
+// via POST and swaps in the fresh data, count, and "cached just now" stamp.
 function tileNameFromButton(btn) {
   var label = btn.getAttribute("aria-label") || "This tile";
   var name = label.replace(/^Refresh\s+/, "");
@@ -402,10 +526,13 @@ function tileNameFromButton(btn) {
 }
 
 function refreshTile(btn) {
-  if (btn.disabled) return;
+  if (btn.disabled) {
+    return Promise.resolve();
+  }
 
-  var stale = btn.parentElement.querySelector(".stale");
-  var label = stale.childNodes[stale.childNodes.length - 1];
+  var key = btn.getAttribute("data-tile");
+  var stale = tile(key).querySelector(".stale");
+  var label = staleLabelNode(key);
   var name = tileNameFromButton(btn);
 
   btn.disabled = true;
@@ -415,13 +542,23 @@ function refreshTile(btn) {
   label.textContent = "refreshing…";
   announce("Refreshing " + name + "…");
 
-  window.setTimeout(function () {
-    btn.classList.remove("spinning");
-    btn.disabled = false;
-    stale.classList.remove("busy");
-    label.textContent = "cached just now";
-    announce(name + " updated — cached just now.");
-  }, REFRESH_MS);
+  return fetchJson(API + key + "/refresh", { method: "POST", headers: { "Accept": "application/json" } })
+    .then(function (data) {
+      paintTile(key, data.items || {}, data);
+      rememberOpenState();
+      applyFilter(searchBox.value);
+      announce(name + " updated — cached just now.");
+    })
+    .catch(function () {
+      stale.classList.remove("busy");
+      stale.classList.add("warn");
+      label.textContent = "refresh failed";
+      announce(name + " refresh failed.");
+    })
+    .then(function () {
+      btn.classList.remove("spinning");
+      btn.disabled = false;
+    });
 }
 
 document.querySelectorAll(".refresh-btn").forEach(function (btn) {
@@ -441,7 +578,9 @@ document.getElementById("refreshAll").addEventListener("click", function () {
 document.querySelectorAll(".stat").forEach(function (stat) {
   stat.addEventListener("click", function () {
     var target = document.getElementById(stat.dataset.target);
-    if (!target) return;
+    if (!target) {
+      return;
+    }
 
     var details = target.querySelector("details");
     if (details) {
@@ -460,7 +599,9 @@ var iconMoon = document.getElementById("icon-moon");
 
 function currentTheme() {
   var t = root.getAttribute("data-theme");
-  if (t) return t;
+  if (t) {
+    return t;
+  }
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
@@ -481,19 +622,19 @@ paintThemeIcon();
 
 
 // Live filter across every work-item and event row. Remembers each tile's
-// open/closed state so clearing the box restores the original layout.
-var allDetails = document.querySelectorAll("details");
-allDetails.forEach(function (d) { d.dataset.open0 = d.open ? "1" : "0"; });
-
-document.querySelectorAll(".tile .body").forEach(function (body) {
-  var note = document.createElement("p");
-  note.className = "nomatch";
-  note.textContent = "No matching items in this tile.";
-  body.appendChild(note);
-});
+// original open/closed state (recorded lazily, since rows render async) so
+// clearing the box restores the layout the data produced.
+function rememberOpenState() {
+  document.querySelectorAll("details").forEach(function (d) {
+    if (d.dataset.open0 === undefined) {
+      d.dataset.open0 = d.open ? "1" : "0";
+    }
+  });
+}
 
 function applyFilter(raw) {
   var q = raw.trim().toLowerCase();
+  var allDetails = document.querySelectorAll("details");
 
   if (q) {
     allDetails.forEach(function (d) { d.open = true; });
@@ -536,4 +677,14 @@ searchBox.addEventListener("keydown", function (e) {
     searchBox.value = "";
     applyFilter("");
   }
+});
+
+
+// ---------------------------------------------------------------------------
+// Boot — load every tile from cache (falling back to the sample model), then
+// record open state so the filter can restore it.
+// ---------------------------------------------------------------------------
+
+Promise.all(TILES.map(function (t) { return loadTile(t.key); })).then(function () {
+  rememberOpenState();
 });

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -485,9 +485,11 @@ function loadTile(key) {
   return fetchJson(API + key, { headers: { "Accept": "application/json" } })
     .then(function (data) {
       paintTile(key, data.items || {}, data);
+      return true;
     })
     .catch(function () {
       paintTile(key, MODEL[key], null);
+      return false;
     });
 }
 
@@ -687,6 +689,12 @@ searchBox.addEventListener("keydown", function (e) {
 // record open state so the filter can restore it.
 // ---------------------------------------------------------------------------
 
-Promise.all(TILES.map(function (t) { return loadTile(t.key); })).then(function () {
+Promise.all(TILES.map(function (t) { return loadTile(t.key); })).then(function (results) {
   rememberOpenState();
+
+  // Screen-reader parity with the refresh path: if any tile couldn't reach the
+  // backend and fell back to the sample model, say so once (not per tile).
+  if (results.indexOf(false) !== -1) {
+    announce("Showing sample data — the daily-viewer server isn't reachable.");
+  }
 });

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -110,7 +110,7 @@
   </main>
 
   <footer class="footer">
-    Mock &middot; placeholder data. Live build feeds from <code>az boards query</code> + the Outlook PowerShell module.
+    Cache-backed &middot; each tile reads local cache and refreshes from <code>az boards query</code> + the Outlook PowerShell module. Falls back to sample data when opened without the local server.
   </footer>
 
 </div>

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -385,6 +385,15 @@ details[open] > summary > .chev { transform: rotate(90deg); }
 }
 .tile.empty .nomatch { display: block; }
 
+/* Friendly note for a tile whose cache genuinely has no items (distinct from
+   .nomatch, which the live filter shows when a search hides every row). */
+.empty-note {
+  padding: var(--space-6) var(--space-0) var(--space-2);
+  color: var(--text-faint);
+  font-size: var(--fs-md);
+}
+.tile.empty .empty-note { display: none; }
+
 /* ---------- per-tile freshness + refresh ---------- */
 .tile-meta {
   flex: none;

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -64,6 +64,7 @@ flowchart LR
         NewTask["az-New-Task"]
         ShowFeats["az-Show-Features"]
         Help["az-help"]
+        DailyViewer["daily-viewer backend<br/>(daily_viewer.ps1)<br/>per-tile live query"]
     end
 
     subgraph PathOpeners["Path inspectors (az-Open-*)"]
@@ -166,6 +167,8 @@ flowchart LR
     NewTask --> IterJson
     NewTask --> AreasJson
     NewTask --> AzBoards
+
+    DailyViewer -.per-tile refresh.-> AzBoards
 
     BgSync -.spawns hidden pwsh when stale.-> Sync
 
@@ -927,6 +930,17 @@ graph LR
     EchoLn[Write-AzDevOpsQueryEcho]:::priv
     ConvNative[ConvertTo-AzDevOpsNativeArgList]:::priv
 
+    %% Daily-viewer backend (daily_viewer.ps1) — live per-tile query seam
+    DVQuery[Get-AzDevOpsDailyViewerQueryRows]:::priv
+    DVAssigned[Get-AzDevOpsDailyViewerAssignedRows]:::priv
+    DVActive[Get-AzDevOpsDailyViewerActiveRows]:::priv
+    DVAgenda[Get-AzDevOpsDailyViewerAgendaItems]:::priv
+    DVPrep[Get-AzDevOpsDailyViewerPrepItems]:::priv
+    DVWeek[Get-AzDevOpsDailyViewerWeekItems]:::priv
+    DVActivity[Get-AzDevOpsDailyViewerActivityItems]:::priv
+    DVFocus[Get-AzDevOpsDailyViewerFocusItems]:::priv
+    DVWiNode[New-AzDevOpsDailyViewerWorkItemNode]:::priv
+
     %% Cross-cutting console spinner (pow_common.ps1)
     Spinner[Invoke-WithSpinner]:::priv
 
@@ -1157,6 +1171,23 @@ graph LR
     InvHier --> QNames --> QDefaults --> QPaths
     InvHier --> QWiql --> QInit
     InvHier --> Boards
+
+    %% Daily-viewer per-tile builders share one query seam into the data-plane
+    DVAssigned --> DVQuery
+    DVActive --> DVQuery
+    DVAgenda --> DVQuery
+    DVActivity --> DVQuery
+    DVFocus --> DVQuery
+    DVWeek --> DVAssigned
+    DVFocus --> DVAssigned
+    DVQuery --> QWiql
+    DVQuery --> Boards
+    DVQuery -.logs failures.-> LogFn
+    DVWiNode --> WiUrl
+    DVQuery -.converter.-> ConvA
+    DVQuery -.converter.-> ConvM
+    DVQuery -.converter.-> ConvAct
+
     QInit --> QDefaults
     QInit --> QPaths
     QInit --> SeedFiles

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -179,6 +179,20 @@ function New-AzDevOpsDailyViewerWorkItemNode {
 }
 
 
+function Get-AzDevOpsDailyViewerActiveRows {
+    # Drop closed / removed / done rows — the "still open" filter every tile
+    # applies to its query output before projecting. Comma-wrapped so an
+    # all-closed result stays an empty array through the caller's assignment
+    # instead of unrolling to $null. Private helper (unapproved verb is fine).
+    param([Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Rows)
+
+    $closedStates = Get-AzDevOpsClosedStates
+    $active = @($Rows | Where-Object { $_.State -notin $closedStates })
+
+    return ,$active
+}
+
+
 function Get-AzDevOpsDailyViewerRelativeTime {
     # Compact "how long ago" label for the activity tile's note column
     # (e.g. "2h ago"). Mirrors the front-end formatAge buckets so cached notes
@@ -339,9 +353,8 @@ function Get-AzDevOpsDailyViewerPrepItems {
 
 function Get-AzDevOpsDailyViewerWeekItems {
     $assigned = @(Get-AzDevOpsDailyViewerAssignedRows)
-    $closedStates = Get-AzDevOpsClosedStates
 
-    $activeRows = @($assigned | Where-Object { $_.State -notin $closedStates })
+    $activeRows = Get-AzDevOpsDailyViewerActiveRows -Rows $assigned
     $storyItems = @($activeRows | ForEach-Object {
         New-AzDevOpsDailyViewerWorkItemNode -Row $_ -LinkTitle
     })
@@ -410,8 +423,8 @@ function Get-AzDevOpsDailyViewerActivityItems {
 
     $closedStates = Get-AzDevOpsClosedStates
 
-    $taggedRows  = @($mentions | Where-Object { $_.State -notin $closedStates })
-    $updateRows  = @($activity | Where-Object { $_.State -notin $closedStates })
+    $taggedRows  = Get-AzDevOpsDailyViewerActiveRows -Rows $mentions
+    $updateRows  = Get-AzDevOpsDailyViewerActiveRows -Rows $activity
     $closingRows = @($activity | Where-Object { $_.State -in $closedStates })
 
     $groups = New-Object System.Collections.Generic.List[object]
@@ -487,13 +500,13 @@ function New-AzDevOpsDailyViewerFocusPrimary {
 
 function Get-AzDevOpsDailyViewerFocusItems {
     $assigned = @(Get-AzDevOpsDailyViewerAssignedRows)
-    $closedStates = Get-AzDevOpsClosedStates
 
     $primary = New-AzDevOpsDailyViewerFocusPrimary -Assigned $assigned
     $focusId = Get-AzDevOpsDailyFocusId
 
-    $supportRows = @($assigned | Where-Object {
-        $_.State -notin $closedStates -and (-not $focusId -or [int]$_.Id -ne $focusId)
+    $activeRows = Get-AzDevOpsDailyViewerActiveRows -Rows $assigned
+    $supportRows = @($activeRows | Where-Object {
+        -not $focusId -or [int]$_.Id -ne $focusId
     })
     $supportItems = @($supportRows | ForEach-Object {
         New-AzDevOpsDailyViewerWorkItemNode -Row $_ -LinkTitle

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -30,6 +30,10 @@ $script:AzDevOpsDailyViewerCacheSubdir     = 'daily-viewer'
 $script:AzDevOpsDailyViewerLoopbackAddress = '127.0.0.1'
 $script:AzDevOpsDailyViewerJsonDepth       = 10      # nesting the tile payloads / API responses serialize to
 
+$script:AzDevOpsDailyViewerTitleDash = "$([char]0x2014)"   # em dash — "Story #1234 — <title>"
+$script:AzDevOpsDailyViewerMiddot    = "$([char]0x00B7)"   # middle dot — "<sub> · <state>"
+$script:AzDevOpsDailyViewerJoinLabel = "Join meeting $([char]0x2192)"   # right arrow
+
 $script:AzDevOpsDailyViewerMimeTypes = @{
     '.html' = 'text/html; charset=utf-8'
     '.css'  = 'text/css; charset=utf-8'
@@ -97,54 +101,263 @@ function Get-AzDevOpsDailyViewerTilePath {
 
 
 # ---------------------------------------------------------------------------
-# Placeholder tile payloads — the EXPENSIVE seam
+# Per-tile query + normalization — the EXPENSIVE seam
 #
-# Each builder returns the "items" payload for one tile, shaped like the
-# front-end model in daily-viewer/app.js so the eventual "wire real data" issue
-# can swap the body for real az boards / Outlook output without changing the
-# transport or the cache contract. Nothing here touches the network yet.
+# Each builder runs its real source (the Outlook module for the agenda tile,
+# `az boards query` via the shared WIQL defaults for the rest) and normalizes
+# the result into the "items" payload shaped like the front-end model in
+# daily-viewer/app.js. The transport and cache contract above/below this block
+# stay put. Every builder fails soft: a missing az login, an Outlook that isn't
+# reachable, or a parse error yields an empty payload (logged server-side) so
+# the tile renders a clean empty state instead of taking down the serving loop.
 # ---------------------------------------------------------------------------
 
-function Get-AzDevOpsDailyViewerAgendaPlaceholder {
+function Get-AzDevOpsDailyViewerQueryRows {
+    # Run a named WIQL default (assigned / mentions / activity) through
+    # Invoke-AzDevOpsBoardsQuery and map each row with $Converter (the same
+    # ConvertFrom-AzDevOps* projections the az-Show-* views use). Returns @() on
+    # any failure so a tile fails soft to an empty state — the expensive refresh
+    # path must never surface a 500 for a query the user simply isn't logged in
+    # for. Failures are recorded in the sync log for later diagnosis.
+    param(
+        [Parameter(Mandatory)] [string]      $Name,
+        [Parameter(Mandatory)] [scriptblock] $Converter
+    )
+
+    try {
+        $wiql   = Get-AzDevOpsWiql -Name $Name
+        $result = Invoke-AzDevOpsBoardsQuery -Wiql $wiql
+
+        if ($result.ExitCode -ne 0) {
+            Write-AzDevOpsSyncLog "daily-viewer: query '$Name' failed (exit $($result.ExitCode)): $($result.Error)"
+            return @()
+        }
+
+        $raw = $result.Json | ConvertFrom-Json
+        if ($null -eq $raw) {
+            return @()
+        }
+
+        $rows = @($raw | ForEach-Object { & $Converter $_ })
+        return $rows
+    }
+    catch {
+        Write-AzDevOpsSyncLog "daily-viewer: query '$Name' error: $($_.Exception.Message)"
+        return @()
+    }
+}
+
+
+function New-AzDevOpsDailyViewerWorkItemNode {
+    # Map a normalized { Id; Type; State; Title } row (as emitted by the
+    # ConvertFrom-AzDevOps* projections) to the front-end work-item row shape.
+    # Both the id chip and — with -LinkTitle — the title link to the item's
+    # dev.azure.com/.../_workitems/edit/<id> page. Get-AzDevOpsWorkItemUrl
+    # returns $null when az devops defaults are unset; the view drops the href
+    # and still renders the id/title as inert text, so no link is never a crash.
+    param(
+        [Parameter(Mandatory)] $Row,
+        [switch] $LinkTitle
+    )
+
+    $id  = [int]$Row.Id
+    $url = Get-AzDevOpsWorkItemUrl -Id $id
+
+    $node = [ordered]@{
+        type  = $Row.Type
+        id    = $id
+        url   = $url
+        title = $Row.Title
+        state = $Row.State
+    }
+
+    if ($LinkTitle -and $url) {
+        $node.titleUrl = $url
+    }
+
+    return $node
+}
+
+
+function Get-AzDevOpsDailyViewerRelativeTime {
+    # Compact "how long ago" label for the activity tile's note column
+    # (e.g. "2h ago"). Mirrors the front-end formatAge buckets so cached notes
+    # and freshly-refreshed ones read the same.
+    param([Parameter(Mandatory)] [datetime] $When)
+
+    $span = (Get-Date) - $When
+
+    if ($span.TotalMinutes -lt 1) {
+        return 'just now'
+    }
+
+    if ($span.TotalMinutes -lt 60) {
+        $mins = [int]$span.TotalMinutes
+        return "${mins}m ago"
+    }
+
+    if ($span.TotalHours -lt 24) {
+        $hours = [int]$span.TotalHours
+        return "${hours}h ago"
+    }
+
+    $days = [int]$span.TotalDays
+    return "${days}d ago"
+}
+
+
+function Get-AzDevOpsDailyViewerAssignedRows {
+    # Shared source of the user's assigned work items for the week + focus
+    # tiles (each refreshes independently, so both run the query on their own
+    # refresh). Reuses the 'assigned' WIQL default and the assigned projection.
+    $rows = Get-AzDevOpsDailyViewerQueryRows -Name 'assigned' -Converter {
+        param($r) ConvertFrom-AzDevOpsAssignedItem -Raw $r
+    }
+
+    return $rows
+}
+
+
+function Get-AzDevOpsDailyViewerAgendaEvents {
+    # Shared source of today's calendar events for the agenda tile and the week
+    # tile's prep list. ol-Get-OutlookAgenda fails soft to $null off Windows /
+    # desktop Outlook (or when the module isn't loaded); normalize that to an
+    # empty array so callers render a clean empty state instead of tripping on
+    # $null.
+    if (-not (Get-Command ol-Get-OutlookAgenda -ErrorAction SilentlyContinue)) {
+        return @()
+    }
+
+    $events = ol-Get-OutlookAgenda
+    if ($null -eq $events) {
+        return @()
+    }
+
+    return @($events)
+}
+
+
+# --- Agenda tile ------------------------------------------------------------
+
+function New-AzDevOpsDailyViewerLocation {
+    # Build the front-end location object for one calendar event: a Teams join
+    # link when the meeting carries one, the room/place text otherwise, and a
+    # neutral badge when neither is set. The badge is always present because the
+    # view renders it unconditionally.
+    param([Parameter(Mandatory)] $CalendarEvent)
+
+    $joinUrl = $CalendarEvent.MeetingUrl
+    if ($joinUrl) {
+        $location = [ordered]@{
+            badge    = 'Teams'
+            url      = $joinUrl
+            urlLabel = $script:AzDevOpsDailyViewerJoinLabel
+        }
+        return $location
+    }
+
+    $place = [string]$CalendarEvent.Location
+    if ($place) {
+        $location = [ordered]@{ badge = 'In person'; text = $place }
+        return $location
+    }
+
+    $location = [ordered]@{ badge = 'No location' }
+    return $location
+}
+
+
+function New-AzDevOpsDailyViewerAgendaNode {
+    # Normalize one ol-Get-OutlookAgenda row into the front-end event shape.
+    param([Parameter(Mandatory)] $CalendarEvent)
+
+    $start = $CalendarEvent.Start
+
+    $timeLabel = if ($CalendarEvent.IsAllDay) {
+        'All day'
+    } else {
+        $start.ToString('h:mm tt')
+    }
+
+    $time = [ordered]@{
+        label    = $timeLabel
+        datetime = $start.ToString('o')
+    }
+
+    $location = New-AzDevOpsDailyViewerLocation -CalendarEvent $CalendarEvent
+
+    $details = New-Object System.Collections.Generic.List[object]
+    if ($CalendarEvent.Organizer) {
+        $details.Add([ordered]@{ label = 'With'; text = [string]$CalendarEvent.Organizer })
+    }
+
+    $node = [ordered]@{
+        time     = $time
+        title    = [string]$CalendarEvent.Subject
+        location = $location
+        details  = $details
+    }
+
+    return $node
+}
+
+
+function Get-AzDevOpsDailyViewerAgendaItems {
+    $events = @(Get-AzDevOpsDailyViewerAgendaEvents)
+
+    $eventNodes = @($events | ForEach-Object { New-AzDevOpsDailyViewerAgendaNode -CalendarEvent $_ })
+
     $items = [ordered]@{
-        events = @(
-            [ordered]@{
-                time     = [ordered]@{ label = '9:00 AM'; tz = 'EST'; datetime = '2026-07-14T09:00:00-05:00' }
-                title    = 'Sprint Planning Sync'
-                location = [ordered]@{ badge = 'Teams'; url = 'https://teams.microsoft.com/l/meetup-join/example'; urlLabel = 'Join meeting' }
-                details  = @(
-                    [ordered]@{ label = 'With'; text = 'Platform Team - 6 attendees' }
-                )
-            },
-            [ordered]@{
-                time     = [ordered]@{ label = '11:00 AM'; tz = 'EST'; datetime = '2026-07-14T11:00:00-05:00' }
-                title    = 'Architecture Design Review'
-                location = [ordered]@{ badge = 'In person'; text = 'Room 132' }
-                details  = @()
-            }
-        )
+        events = $eventNodes
     }
 
     return $items
 }
 
 
-function Get-AzDevOpsDailyViewerWeekPlaceholder {
+# --- This week's focus tile -------------------------------------------------
+
+function Get-AzDevOpsDailyViewerPrepItems {
+    # "Events to prepare for" = today's meetings, each a checklist line that
+    # links to the Teams join when there is one. Derived from the same agenda
+    # source so the week tile shares the agenda pull rather than a second query.
+    $events = @(Get-AzDevOpsDailyViewerAgendaEvents)
+
+    $prep = @($events | ForEach-Object {
+        $node = [ordered]@{ title = "Prep for $($_.Subject)" }
+
+        if ($_.MeetingUrl) {
+            $node.link = [ordered]@{ text = 'Join meeting'; url = $_.MeetingUrl }
+        }
+
+        $node
+    })
+
+    return $prep
+}
+
+
+function Get-AzDevOpsDailyViewerWeekItems {
+    $assigned = @(Get-AzDevOpsDailyViewerAssignedRows)
+    $closedStates = Get-AzDevOpsClosedStates
+
+    $activeRows = @($assigned | Where-Object { $_.State -notin $closedStates })
+    $storyItems = @($activeRows | ForEach-Object {
+        New-AzDevOpsDailyViewerWorkItemNode -Row $_ -LinkTitle
+    })
+
+    $prepItems = Get-AzDevOpsDailyViewerPrepItems
+
     $items = [ordered]@{
         stories = [ordered]@{
             label = 'Stories to complete'
             open  = $true
-            items = @(
-                [ordered]@{ type = 'Story'; id = 1234; url = 'https://dev.azure.com/org/project/_workitems/edit/1234'; title = 'Wire agenda tile to az boards query'; state = 'In progress' },
-                [ordered]@{ type = 'Bug';   id = 1251; url = 'https://dev.azure.com/org/project/_workitems/edit/1251'; title = 'Timezone offset on EST agenda rows'; state = 'In review' }
-            )
+            items = $storyItems
         }
         prep = [ordered]@{
             label = 'Events to prepare for'
             open  = $true
-            items = @(
-                [ordered]@{ title = 'Confirm demo build is deployed before Thu review' }
-            )
+            items = $prepItems
         }
     }
 
@@ -152,43 +365,146 @@ function Get-AzDevOpsDailyViewerWeekPlaceholder {
 }
 
 
-function Get-AzDevOpsDailyViewerActivityPlaceholder {
+# --- Recent activity tile ---------------------------------------------------
+
+function New-AzDevOpsDailyViewerActivityGroup {
+    # One collapsible activity group: sort the rows newest-first, project each
+    # to a work-item node, and stamp a relative-time note from $DateField (the
+    # per-source timestamp — MentionedAt for mentions, ChangedDate for activity).
+    param(
+        [Parameter(Mandatory)] [string] $Label,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Rows,
+        [Parameter(Mandatory)] [string] $DateField
+    )
+
+    $sorted = Sort-AzDevOpsByDateDesc -Items $Rows -Field $DateField
+
+    $items = @($sorted | ForEach-Object {
+        $node = New-AzDevOpsDailyViewerWorkItemNode -Row $_ -LinkTitle
+
+        $when = $_.$DateField
+        if ($when) {
+            $node.note = Get-AzDevOpsDailyViewerRelativeTime -When $when
+        }
+
+        $node
+    })
+
+    $group = [ordered]@{
+        label = $Label
+        open  = $false
+        items = $items
+    }
+
+    return $group
+}
+
+
+function Get-AzDevOpsDailyViewerActivityItems {
+    $mentions = @(Get-AzDevOpsDailyViewerQueryRows -Name 'mentions' -Converter {
+        param($r) ConvertFrom-AzDevOpsMentionItem -Raw $r
+    })
+    $activity = @(Get-AzDevOpsDailyViewerQueryRows -Name 'activity' -Converter {
+        param($r) ConvertFrom-AzDevOpsActivityItem -Raw $r
+    })
+
+    $closedStates = Get-AzDevOpsClosedStates
+
+    $taggedRows  = @($mentions | Where-Object { $_.State -notin $closedStates })
+    $updateRows  = @($activity | Where-Object { $_.State -notin $closedStates })
+    $closingRows = @($activity | Where-Object { $_.State -in $closedStates })
+
+    $groups = New-Object System.Collections.Generic.List[object]
+    $groups.Add((New-AzDevOpsDailyViewerActivityGroup -Label 'Tagged discussions'      -Rows $taggedRows  -DateField 'MentionedAt'))
+    $groups.Add((New-AzDevOpsDailyViewerActivityGroup -Label 'Recent updates'          -Rows $updateRows  -DateField 'ChangedDate'))
+    $groups.Add((New-AzDevOpsDailyViewerActivityGroup -Label 'Sprint-close candidates' -Rows $closingRows -DateField 'ChangedDate'))
+
     $items = [ordered]@{
-        groups = @(
-            [ordered]@{
-                label = 'Tagged discussions'
-                open  = $false
-                items = @(
-                    [ordered]@{ type = 'Feature'; id = 1180; url = 'https://dev.azure.com/org/project/_workitems/edit/1180'; title = 'Can you confirm the WIQL scope?' }
-                )
-            },
-            [ordered]@{
-                label = 'Active story updates'
-                open  = $false
-                items = @(
-                    [ordered]@{ type = 'Story'; id = 1234; url = 'https://dev.azure.com/org/project/_workitems/edit/1234'; title = 'State -> In progress'; note = '2h ago' }
-                )
-            }
-        )
+        groups = $groups
     }
 
     return $items
 }
 
 
-function Get-AzDevOpsDailyViewerFocusPlaceholder {
+# --- Today's focus tile -----------------------------------------------------
+
+function Get-AzDevOpsDailyFocusId {
+    # The pinned "today's focus" work item is a user-set config value
+    # ($global:AzDevOpsDailyFocus) rather than a query, so the tile shows the one
+    # thing you chose to commit to. Returns $null when it is unset or not a
+    # positive integer, and the focus tile then renders its support bucket only.
+    $raw = $global:AzDevOpsDailyFocus
+    if (-not $raw) {
+        return $null
+    }
+
+    $id = 0
+    if ([int]::TryParse([string]$raw, [ref] $id) -and $id -gt 0) {
+        return $id
+    }
+
+    return $null
+}
+
+
+function New-AzDevOpsDailyViewerFocusPrimary {
+    # Build the pinned-item header from the configured focus id, enriching the
+    # title + state from the assigned rows when the id is one of them. Returns
+    # $null when no focus id is configured so the view renders support only.
+    param([Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Assigned)
+
+    $focusId = Get-AzDevOpsDailyFocusId
+    if (-not $focusId) {
+        return $null
+    }
+
+    $match = $Assigned | Where-Object { [int]$_.Id -eq $focusId } | Select-Object -First 1
+
+    $title = if ($match) {
+        "$($match.Type) #$focusId $script:AzDevOpsDailyViewerTitleDash $($match.Title)"
+    } else {
+        "Work item #$focusId"
+    }
+
+    $sub = if ($match) {
+        "Primary commitment for today $script:AzDevOpsDailyViewerMiddot $($match.State)"
+    } else {
+        'Primary commitment for today'
+    }
+
+    $url = Get-AzDevOpsWorkItemUrl -Id $focusId
+
+    $primary = [ordered]@{
+        title = $title
+        url   = $url
+        sub   = $sub
+    }
+
+    return $primary
+}
+
+
+function Get-AzDevOpsDailyViewerFocusItems {
+    $assigned = @(Get-AzDevOpsDailyViewerAssignedRows)
+    $closedStates = Get-AzDevOpsClosedStates
+
+    $primary = New-AzDevOpsDailyViewerFocusPrimary -Assigned $assigned
+    $focusId = Get-AzDevOpsDailyFocusId
+
+    $supportRows = @($assigned | Where-Object {
+        $_.State -notin $closedStates -and (-not $focusId -or [int]$_.Id -ne $focusId)
+    })
+    $supportItems = @($supportRows | ForEach-Object {
+        New-AzDevOpsDailyViewerWorkItemNode -Row $_ -LinkTitle
+    })
+
     $items = [ordered]@{
-        primary = [ordered]@{
-            title = 'User Story #1234 - Wire agenda tile to az boards'
-            url   = 'https://dev.azure.com/org/project/_workitems/edit/1234'
-            sub   = 'Primary commitment for today - In progress'
-        }
+        primary = $primary
         support = [ordered]@{
-            label = 'SF devs - unplanned support'
+            label = 'Assigned & unplanned support'
             open  = $true
-            items = @(
-                [ordered]@{ type = 'Bug'; id = 1260; url = 'https://dev.azure.com/org/project/_workitems/edit/1260'; title = 'Deploy failing on scratch org spin-up'; state = 'Active' }
-            )
+            items = $supportItems
         }
     }
 
@@ -197,29 +513,28 @@ function Get-AzDevOpsDailyViewerFocusPlaceholder {
 
 
 function New-AzDevOpsDailyViewerTileItems {
-    # Dispatch to the per-tile builder. This is the single seam the next issue
-    # replaces with real az boards / Outlook queries — everything above and
-    # below it (cache read/write, HTTP transport) stays put.
+    # Dispatch to the per-tile builder. Each returns the tile's normalized
+    # "items" payload; Write-AzDevOpsDailyViewerTile stamps + persists it.
     param([Parameter(Mandatory)] [string] $Tile)
 
     switch ($Tile) {
         'agenda' {
-            $items = Get-AzDevOpsDailyViewerAgendaPlaceholder
+            $items = Get-AzDevOpsDailyViewerAgendaItems
             return $items
         }
 
         'week' {
-            $items = Get-AzDevOpsDailyViewerWeekPlaceholder
+            $items = Get-AzDevOpsDailyViewerWeekItems
             return $items
         }
 
         'activity' {
-            $items = Get-AzDevOpsDailyViewerActivityPlaceholder
+            $items = Get-AzDevOpsDailyViewerActivityItems
             return $items
         }
 
         'focus' {
-            $items = Get-AzDevOpsDailyViewerFocusPlaceholder
+            $items = Get-AzDevOpsDailyViewerFocusItems
             return $items
         }
 

--- a/powcuts_by_cli/outlook_agenda.ps1
+++ b/powcuts_by_cli/outlook_agenda.ps1
@@ -34,6 +34,11 @@ $script:OutlookMapiNamespace = 'MAPI'
 # beyond this year is treated as unset.
 $script:OutlookNoDateYear = 4000
 
+# Teams meetings stash their one-click join URL in the appointment body. Match
+# the meetup-join link so the daily viewer's agenda tile can turn it into a
+# clickable "Join meeting" action.
+$script:OutlookTeamsJoinPattern = 'https://teams\.microsoft\.com/l/meetup-join/\S+'
+
 $script:OutlookIconCalendar = [char]::ConvertFromUtf32(0x1F4C5)   # calendar
 $script:OutlookIconTasks    = [char]::ConvertFromUtf32(0x1F5D2)   # spiral notepad
 $script:OutlookIconParty    = [char]::ConvertFromUtf32(0x1F389)   # party popper
@@ -181,6 +186,34 @@ function ConvertFrom-OutlookImportance {
 }
 
 
+function Get-OutlookMeetingJoinUrl {
+    # Private. Extracts a Teams "join meeting" URL from an appointment body, or
+    # $null when the body is empty / unreadable / has no join link. Body access
+    # is wrapped so a transient COM fault fails soft (no join link) rather than
+    # aborting the whole agenda pull. Unapproved verb is fine — not user-facing.
+    param([Parameter(Mandatory)] $Appointment)
+
+    $body = ''
+    try {
+        $body = [string]$Appointment.Body
+    }
+    catch {
+        return $null
+    }
+
+    if (-not $body) {
+        return $null
+    }
+
+    $match = [regex]::Match($body, $script:OutlookTeamsJoinPattern)
+    if ($match.Success) {
+        return $match.Value
+    }
+
+    return $null
+}
+
+
 function ol-Get-OutlookAgenda {
     # Today's calendar events (recurrences expanded) as objects. Emits data
     # only — formatting lives in ol-Show-OutlookAgenda.
@@ -215,6 +248,7 @@ function ol-Get-OutlookAgenda {
 
     foreach ($appointment in $restricted) {
         $responseText = ConvertFrom-OutlookResponseStatus -Status ([int]$appointment.ResponseStatus)
+        $joinUrl = Get-OutlookMeetingJoinUrl -Appointment $appointment
 
         $row = [PSCustomObject]@{
             Start          = $appointment.Start
@@ -224,6 +258,7 @@ function ol-Get-OutlookAgenda {
             Organizer      = $appointment.Organizer
             IsAllDay       = [bool]$appointment.AllDayEvent
             ResponseStatus = $responseText
+            MeetingUrl     = $joinUrl
         }
 
         $events.Add($row)


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #193 |
| [Changes](#changes) | ✅ 7 files |
| [Test Plan](#test-plan) | ✅ 5 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4976676670) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4976690008) |
| 🛡️ Security Audit | ✅ PASS — 1 MEDIUM (deferred), 1 LOW — [View](#issuecomment-4976686437) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4976686362) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](#issuecomment-4976686703) |
| ✅ Criteria Check | ✅ PASS (9/9) — [View](#issuecomment-4976702987) |
<!-- toc:end -->

## Summary

Replaces the daily-viewer&#39;s placeholder tile data with real queries, normalized into the cache JSON contract the data-driven view already renders, and wires the front-end to the cache API. Each tile now reads from a concrete source (Outlook agenda + `az boards query` via the existing WIQL defaults), and the per-tile / all refresh buttons re-run those queries against the local backend.

## Issue

Closes #193 (part of #189; builds on #191 data-driven view + #192 cache/backend).

## Changes

**Backend — `powcuts_by_cli/daily_viewer.ps1`**
- **Agenda** — today&#39;s calendar events from `ol-Get-OutlookAgenda`, turning a detected Teams join link into a clickable &#34;Join meeting&#34; action.
- **This Week&#39;s Focus** — active assigned stories (the `assigned` WIQL default) + a prep checklist derived from today&#39;s meetings.
- **Recent Activity** — @-mention discussions (`mentions`), recent updates (`activity`), and sprint-close candidates, each with a relative-time note.
- **Today&#39;s Focus** — the pinned work item from `$global:AzDevOpsDailyFocus` (config-first), enriched from the assigned rows, plus an assigned/unplanned support bucket.
- Shared helpers: a fail-soft query runner (empty tile + server-side log, never a 500), a work-item node projection reusing `Get-AzDevOpsWorkItemUrl`, a private `Get-AzDevOpsDailyViewerActiveRows` for the shared non-closed filter, and relative-time formatting. Every getter is `@()`-normalized so an empty query can&#39;t bind `$null`.

**Outlook — `powcuts_by_cli/outlook_agenda.ps1`**
- `ol-Get-OutlookAgenda` now surfaces `MeetingUrl` (Teams join link extracted from the appointment body) as an additive row property.

**Front-end — `daily-viewer/app.js`, `index.html`, `styles.css`**
- Loads each tile from `GET /api/tiles/`; per-tile refresh + &#34;refresh all&#34; call `POST /api/tiles//refresh` and swap in the fresh data, derived count, and &#34;cached just now&#34; stamp. Staleness formatted from `ageSeconds`.
- Friendly empty-state note (`.empty-note`) per tile; all model text still reaches the DOM via `textContent` / gated hrefs (regression-safe on the #191 escaping).
- Keeps the embedded sample model as an offline/preview fallback.

**Docs** — README documents the per-tile sources and `$global:AzDevOpsDailyFocus`; footer copy updated from mock to cache-backed.

## Test Plan

Windows desktop + `az` login required for the live path (`pwsh` isn&#39;t on the CI PATH; PS parse verified by review).

- [ ] `az-Connect-AzDevOps`; optionally set `$global:AzDevOpsDailyFocus = `.
- [ ] `az-Start-AzDevOpsDailyViewer` → tiles render from cache with real assigned / mention / activity items and today&#39;s Outlook agenda.
- [ ] Click a tile&#39;s refresh (and &#34;Refresh all&#34;) → data, count badge, and &#34;cached just now&#34; update.
- [ ] A work item titled `&#39;``&lt;img src=x onerror=alert(1)&gt;``&#39;` renders as inert text (no script executes).
- [ ] Open `daily-viewer/index.html` directly (no server) → falls back to sample data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdsCGaDRks498sLrQ9P8N4

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdsCGaDRks498sLrQ9P8N4)_