### PR TITLE
Daily Viewer: security + accessibility hardening pass (CSP, contrast)

### DIFF
--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -20,8 +20,8 @@
   --bug:     #D1373A;
   --task:    #2C9E43;
 
-  --good: #1E7E34;
-  --warn: #906500;
+  --good: #197031;
+  --warn: #855D00;
   --crit: #D1373A;
 
   --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);
@@ -137,8 +137,8 @@
   --bug:     #D1373A;
   --task:    #2C9E43;
 
-  --good: #1E7E34;
-  --warn: #906500;
+  --good: #197031;
+  --warn: #855D00;
   --crit: #D1373A;
 
   --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -10,7 +10,7 @@
   --border-strong: #C6CFDC;
   --text: #1B2430;
   --text-dim: #5A6675;
-  --text-faint: #8A94A3;
+  --text-faint: #626C79;
   --accent: #0E6FCE;
   --accent-weak: rgba(14,111,206,.10);
 
@@ -20,8 +20,8 @@
   --bug:     #D1373A;
   --task:    #2C9E43;
 
-  --good: #2C9E43;
-  --warn: #B5820A;
+  --good: #1E7E34;
+  --warn: #906500;
   --crit: #D1373A;
 
   --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);
@@ -74,7 +74,7 @@
     --border-strong: #38424F;
     --text: #E7ECF3;
     --text-dim: #97A3B4;
-    --text-faint: #6C7889;
+    --text-faint: #7C8797;
     --accent: #4AA3F0;
     --accent-weak: rgba(74,163,240,.14);
 
@@ -101,7 +101,7 @@
   --border-strong: #38424F;
   --text: #E7ECF3;
   --text-dim: #97A3B4;
-  --text-faint: #6C7889;
+  --text-faint: #7C8797;
   --accent: #4AA3F0;
   --accent-weak: rgba(74,163,240,.14);
 
@@ -127,7 +127,7 @@
   --border-strong: #C6CFDC;
   --text: #1B2430;
   --text-dim: #5A6675;
-  --text-faint: #8A94A3;
+  --text-faint: #626C79;
   --accent: #0E6FCE;
   --accent-weak: rgba(14,111,206,.10);
 
@@ -137,8 +137,8 @@
   --bug:     #D1373A;
   --task:    #2C9E43;
 
-  --good: #2C9E43;
-  --warn: #B5820A;
+  --good: #1E7E34;
+  --warn: #906500;
   --crit: #D1373A;
 
   --shadow: 0 1px 2px rgba(19,34,54,.06), 0 6px 20px rgba(19,34,54,.06);

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -17,10 +17,10 @@
 #
 # SECURITY: the listener binds to 127.0.0.1 only (never 0.0.0.0), and the
 # az login / PAT stays in this server process — responses carry only work-item
-# and agenda data. The per-tile query is the seam where the real az boards /
-# Outlook calls land (next issue); today New-AzDevOpsDailyViewerTileItems emits
-# placeholder payloads shaped like the front-end model so the transport and
-# cache contract can be stood up and verified first.
+# and agenda data. Every response also ships a strict Content-Security-Policy
+# (default-src 'self', no unsafe-inline) plus nosniff / no-referrer / DENY
+# framing headers, so even a work-item title carrying markup renders inert:
+# the page has no inline-script/style path for it to escape into.
 #
 # Loaded by powcuts_home.ps1. See azdevops_auth.ps1 for the master docstring.
 
@@ -29,6 +29,21 @@ $script:AzDevOpsDailyViewerStaleSeconds    = 900     # 15 min: mtime age past wh
 $script:AzDevOpsDailyViewerCacheSubdir     = 'daily-viewer'
 $script:AzDevOpsDailyViewerLoopbackAddress = '127.0.0.1'
 $script:AzDevOpsDailyViewerJsonDepth       = 10      # nesting the tile payloads / API responses serialize to
+
+# Strict Content-Security-Policy for the served app. The page loads styles.css +
+# app.js as external same-origin assets and fetches /api/tiles/* same-origin;
+# there are no inline handlers/styles, CDN scripts, or webfonts, so 'self' with
+# no 'unsafe-inline' loads clean. Inline <svg> in the markup uses presentation
+# attributes (fill/stroke), which CSP does not gate. base-uri/object/frame/form
+# are locked down so an injected <base>/<object>/framing can't reroute the page.
+$script:AzDevOpsDailyViewerContentSecurityPolicy = @(
+    "default-src 'self'"
+    "base-uri 'none'"
+    "object-src 'none'"
+    "frame-ancestors 'none'"
+    "form-action 'self'"
+    "img-src 'self' data:"
+) -join '; '
 
 $script:AzDevOpsDailyViewerTitleDash = "$([char]0x2014)"   # em dash — "Story #1234 — <title>"
 $script:AzDevOpsDailyViewerMiddot    = "$([char]0x00B7)"   # middle dot — "<sub> · <state>"
@@ -711,6 +726,20 @@ function Resolve-AzDevOpsDailyViewerAssetPath {
 # HTTP response writers
 # ---------------------------------------------------------------------------
 
+function Add-AzDevOpsDailyViewerSecurityHeaders {
+    # Stamp the hardening headers on every response — HTML, static asset, JSON,
+    # and error alike — since all of them funnel through the byte writer below.
+    # A strict same-origin CSP is the anchor; nosniff stops MIME-confusion,
+    # no-referrer keeps local URLs off the wire, and DENY refuses any framing.
+    param([Parameter(Mandatory)] [System.Net.HttpListenerResponse] $Response)
+
+    $Response.Headers['Content-Security-Policy'] = $script:AzDevOpsDailyViewerContentSecurityPolicy
+    $Response.Headers['X-Content-Type-Options']  = 'nosniff'
+    $Response.Headers['Referrer-Policy']         = 'no-referrer'
+    $Response.Headers['X-Frame-Options']         = 'DENY'
+}
+
+
 function Write-AzDevOpsDailyViewerBytes {
     param(
         [Parameter(Mandatory)] [System.Net.HttpListenerResponse] $Response,
@@ -718,6 +747,8 @@ function Write-AzDevOpsDailyViewerBytes {
         [Parameter(Mandatory)] [string] $ContentType,
         [byte[]] $Body = @()
     )
+
+    Add-AzDevOpsDailyViewerSecurityHeaders -Response $Response
 
     $Response.StatusCode  = $StatusCode
     $Response.ContentType = $ContentType


### PR DESCRIPTION

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #194 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | ✅ 4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/202#issuecomment-4981061983) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/202#issuecomment-4981072234) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/202#issuecomment-4981074490) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/202#issuecomment-4981076710) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/202#issuecomment-4981091755) |
| 📚 Docs Check | ✅ CURRENT — [View](https://github.com/jdschleicher/bashcuts/pull/202#issuecomment-4981116334) |
| 📊 AzDO Diagrams Check | ✅ CURRENT (N/A) — [View](https://github.com/jdschleicher/bashcuts/pull/202#issuecomment-4981126883) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/202#issuecomment-4981127967) |


<!-- pr-diagram:start -->
## How it works

This PR routes every backend response through a single hardening choke point. The two request handlers still emit tile JSON, errors, and static assets exactly as before, but each of those paths now funnels through `Write-AzDevOpsDailyViewerBytes`, which calls the new private helper `Add-AzDevOpsDailyViewerSecurityHeaders` to stamp a strict CSP plus `nosniff` / `no-referrer` / `DENY`-framing headers before the bytes go out. No response can bypass it.

```mermaid
flowchart TD
    Api([Invoke-...ApiRequest]):::pub
    Static([Invoke-...StaticRequest]):::pub

    Json[Write-...Json]:::priv
    Err[Write-...Error]:::priv

    Bytes{{Write-...Bytes<br/>single response writer}}:::priv
    Hdr[Add-...SecurityHeaders<br/>NEW helper]:::priv
    Csp[/CSP + nosniff<br/>+ no-referrer + X-Frame DENY/]:::io

    Client([HTTP response<br/>headers stamped]):::io

    Api -- tile JSON 200 --> Json
    Api -- 404 / 405 --> Err
    Static -- 405 / 404 --> Err
    Static -- asset bytes 200 --> Bytes
    Err --> Json
    Json --> Bytes

    Bytes --> Hdr
    Hdr -. reads .-> Csp
    Hdr --> Client

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Final security + accessibility hardening pass for the `daily-viewer/` served app. Adds a strict Content-Security-Policy (plus companion hardening headers) to every backend response, and closes the last open WCAG AA color-contrast gaps in the stylesheet. The escaping path, `127.0.0.1` bind, secret boundary, and a11y landmark/aria-live/focus/reduced-motion criteria were already satisfied by prior issues (#193 and earlier) and were re-verified.

## Issue

Closes #194.

## Changes

**`powcuts_by_cli/daily_viewer.ps1`** — new `Add-AzDevOpsDailyViewerSecurityHeaders` helper, called from `Write-AzDevOpsDailyViewerBytes` (the single writer all HTML / static / JSON / error responses funnel through), so every response ships:
- `Content-Security-Policy: default-src &#39;self&#39;; base-uri &#39;none&#39;; object-src &#39;none&#39;; frame-ancestors &#39;none&#39;; form-action &#39;self&#39;; img-src &#39;self&#39; data:` — no `unsafe-inline`; css/js load as external same-origin assets and `/api/tiles/*` is fetched same-origin, so the page loads clean under it
- `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, `X-Frame-Options: DENY`

**`daily-viewer/styles.css`** — color tokens only, `text &gt; dim &gt; faint` hierarchy preserved:
- `--text-faint` raised to WCAG AA on the surfaces it renders text on (footer, empty/no-match notes, tz + meta labels) in both themes
- light-theme `--warn` / `--good` darkened so the `.s-progress` / `.s-closing` state chips and the `.check` glyph clear 4.5:1 (dark-theme values already passed; decorative `--task` dot untouched)

## Test Plan

- [ ] `az-Connect-AzDevOps` → `az-Start-AzDevOpsDailyViewer -NoBrowser`, then `curl -sI http://127.0.0.1:8770/` shows the CSP + `X-Content-Type-Options` / `Referrer-Policy` / `X-Frame-Options` headers; same for `curl -sI http://127.0.0.1:8770/api/tiles/agenda`
- [ ] Open `http://127.0.0.1:8770/` — DevTools console shows **no** CSP violations (external css/js/fetch all resolve under `&#39;self&#39;`)
- [ ] Create a work item titled ``&#39;&lt;img src=x onerror=alert(1)&gt;&#39;``, refresh the tile — it renders as literal inert text, no alert
- [ ] Spot-check contrast in both light and dark themes: footer, empty-state notes, and the In-progress / Closing state chips read at WCAG AA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ek1ip7Mr73D1bi8tTXkRh

---
_Generated by [Claude Code](https://claude.ai/code/session_012ek1ip7Mr73D1bi8tTXkRh)_