### PR TITLE
Daily Viewer: agenda-first tile order, tagged-discussions visibility, and current-sprint scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ Each tile is populated from a real source, reusing the same WIQL defaults and Ou
 
 - **Today's Agenda** — today's calendar events from `ol-Get-OutlookAgenda` (desktop Outlook), with the Teams join link when the meeting carries one.
 - **This Week's Focus** — your active assigned stories (the `assigned` WIQL) plus a prep checklist derived from today's meetings.
-- **Recent Activity** — @-mention discussions (the `mentions` WIQL), your recent updates (the `activity` WIQL), and sprint-close candidates.
+- **Recent Activity** — @-mention discussions (the `mentions` WIQL), your recent updates (the `activity` WIQL), and your current-sprint items (the `activity` rows scoped to the iteration that brackets today). The current-sprint group reads `[System.IterationPath]` off the `activity` WIQL; the seeded default already selects it, but if you seeded your `activity.wiql` before this field was added, open `o-az-devops-queries-config-dir`, add `[System.IterationPath]` to the `SELECT` in `activity.wiql`, and re-run `az-Sync-AzDevOpsCache` so the group can populate.
 - **Today's Focus** — the pinned work item you set in `$global:AzDevOpsDailyFocus` (a work-item id), plus an "assigned & unplanned support" bucket. Set it in your `$profile`, e.g. `$global:AzDevOpsDailyFocus = 1234`; leave it unset and the tile shows the support bucket alone.
 
 Any tile whose source is unavailable (not logged in to `az`, Outlook not reachable, or nothing to show) renders a friendly empty state rather than erroring, and the page falls back to sample data when opened directly (without the local server). Opening the viewer off Windows still works — the Outlook-backed agenda simply comes up empty.

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -58,7 +58,7 @@ var MODEL = {
     groups: [
       {
         label: "Tagged discussions",
-        open: false,
+        open: true,
         items: [
           { type: "Feature", id: 1180, url: "https://dev.azure.com/org/project/_workitems/edit/1180", title: "@you — “can you confirm the WIQL scope?”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1180?discussion" },
           { type: "Story", id: 1240, url: "https://dev.azure.com/org/project/_workitems/edit/1240", title: "@you — “ready for review whenever”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1240?discussion" }
@@ -73,11 +73,11 @@ var MODEL = {
         ]
       },
       {
-        label: "Sprint close items",
+        label: "Current sprint",
         open: false,
         items: [
-          { type: "Task", id: 1209, url: "https://dev.azure.com/org/project/_workitems/edit/1209", title: "Update release notes", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1209", state: "Closing" },
-          { type: "Story", id: 1222, url: "https://dev.azure.com/org/project/_workitems/edit/1222", title: "Verify acceptance criteria signed off", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1222", state: "Closing" }
+          { type: "Task", id: 1209, url: "https://dev.azure.com/org/project/_workitems/edit/1209", title: "Update release notes", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1209", state: "In progress" },
+          { type: "Story", id: 1222, url: "https://dev.azure.com/org/project/_workitems/edit/1222", title: "Verify acceptance criteria signed off", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1222", state: "Active" }
         ]
       }
     ]

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -37,9 +37,9 @@
          they can never drift from the collections they summarize. -->
     <section class="stats" aria-label="Summary counts">
       <button class="stat a" type="button" data-target="tile-agenda"><span class="n"></span><span class="l">Meetings today</span></button>
-      <button class="stat f" type="button" data-target="tile-week"><span class="n"></span><span class="l">Stories due this week</span></button>
-      <button class="stat s" type="button" data-target="tile-activity"><span class="n"></span><span class="l">Recent updates</span></button>
       <button class="stat g" type="button" data-target="tile-focus"><span class="n"></span><span class="l">Support &amp; focus items</span></button>
+      <button class="stat s" type="button" data-target="tile-activity"><span class="n"></span><span class="l">Recent updates</span></button>
+      <button class="stat f" type="button" data-target="tile-week"><span class="n"></span><span class="l">Stories due this week</span></button>
     </section>
 
     <!-- Each tile is a static shell: header chrome, staleness, refresh button. Its
@@ -61,15 +61,15 @@
         </details>
       </section>
 
-      <!-- This Week's Focus -->
-      <section class="tile" id="tile-week" data-tile="week" aria-labelledby="h-week">
+      <!-- Today's Focus -->
+      <section class="tile" id="tile-focus" data-tile="focus" aria-labelledby="h-focus">
         <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h2 id="h-week">This Week&rsquo;s Focus</h2><span class="count"></span></span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2 id="h-focus">Today&rsquo;s Focus</h2><span class="count"></span></span>
             <span class="tile-meta">
-              <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 2h ago</span>
-              <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+              <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 1h ago</span>
+              <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
             </span>
           </summary>
           <div class="body"></div>
@@ -91,15 +91,15 @@
         </details>
       </section>
 
-      <!-- Today's Focus -->
-      <section class="tile" id="tile-focus" data-tile="focus" aria-labelledby="h-focus">
+      <!-- This Week's Focus -->
+      <section class="tile" id="tile-week" data-tile="week" aria-labelledby="h-week">
         <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2 id="h-focus">Today&rsquo;s Focus</h2><span class="count"></span></span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h2 id="h-week">This Week&rsquo;s Focus</h2><span class="count"></span></span>
             <span class="tile-meta">
-              <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 1h ago</span>
-              <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+              <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 2h ago</span>
+              <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
             </span>
           </summary>
           <div class="body"></div>

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -938,6 +938,7 @@ graph LR
     DVPrep[Get-AzDevOpsDailyViewerPrepItems]:::priv
     DVWeek[Get-AzDevOpsDailyViewerWeekItems]:::priv
     DVActivity[Get-AzDevOpsDailyViewerActivityItems]:::priv
+    DVSprint[Get-AzDevOpsDailyViewerCurrentSprintRows]:::priv
     DVFocus[Get-AzDevOpsDailyViewerFocusItems]:::priv
     DVWiNode[New-AzDevOpsDailyViewerWorkItemNode]:::priv
 
@@ -1037,6 +1038,7 @@ graph LR
     SprintGrid[Show-AzDevOpsSprintGrid]:::priv
     SprintPool[Get-AzDevOpsSprintItemPool]:::priv
     SprintCur[Resolve-AzDevOpsCurrentIteration]:::priv
+    IterPathEnv[Resolve-AzDevOpsIterationPathOrEnv]:::priv
     SprintBanner[Write-AzDevOpsCurrentSprintBanner]:::priv
     SprintSort[Sort-AzDevOpsByClosedLast]:::priv
     SelIterRow[Select-AzDevOpsCurrentIterationRow]:::priv
@@ -1177,6 +1179,9 @@ graph LR
     DVActive --> DVQuery
     DVAgenda --> DVQuery
     DVActivity --> DVQuery
+    DVActivity --> DVSprint
+    DVSprint --> CurCache
+    DVSprint --> IterPathEnv
     DVFocus --> DVQuery
     DVWeek --> DVAssigned
     DVFocus --> DVAssigned
@@ -1319,6 +1324,7 @@ graph LR
     %% Sprint views — both delegate the pool→filter→sort→render→dispatch body to SprintGrid
     CurSprint --> SprintCur --> ReadRows
     SprintCur --> FmtDate
+    CurSprint --> IterPathEnv
     CurSprint --> SprintBanner
     CurSprint --> SprintGrid
     BySprint --> PKind

--- a/powcuts_by_cli/azdevops_paths.ps1
+++ b/powcuts_by_cli/azdevops_paths.ps1
@@ -217,7 +217,7 @@ Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [Syst
 "@
 
 $script:AzDevOpsDefaultActivityWiql = @"
-Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.ChangedBy], [System.AreaPath], [System.ChangedDate] From WorkItems Where [System.ChangedBy] = @Me
+Select [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.ChangedBy], [System.AreaPath], [System.IterationPath], [System.ChangedDate] From WorkItems Where [System.ChangedBy] = @Me
 "@
 
 

--- a/powcuts_by_cli/azdevops_views.ps1
+++ b/powcuts_by_cli/azdevops_views.ps1
@@ -732,6 +732,7 @@ function ConvertFrom-AzDevOpsActivityItem {
         Type        = $f.'System.WorkItemType'
         State       = $f.'System.State'
         Title       = $f.'System.Title'
+        Iteration   = $f.'System.IterationPath'
         ChangedDate = $changedAt
     }
 }

--- a/powcuts_by_cli/azdevops_views.ps1
+++ b/powcuts_by_cli/azdevops_views.ps1
@@ -1851,6 +1851,23 @@ function Resolve-AzDevOpsCurrentIteration {
 }
 
 
+function Resolve-AzDevOpsIterationPathOrEnv {
+    # Private. Given a resolved current-iteration row (or $null), return its Path,
+    # falling back to $env:AZ_ITERATION when no row bracketed today. Shared by the
+    # current-sprint callers so the env-fallback branch lives in one place,
+    # regardless of which resolver (live vs cache-only) produced $Current.
+    param([object] $Current)
+
+    $iterationPath = if ($null -ne $Current) {
+        $Current.Path
+    } else {
+        $env:AZ_ITERATION
+    }
+
+    return $iterationPath
+}
+
+
 function Write-AzDevOpsCurrentSprintBanner {
     # Prints the one-line "which sprint am I looking at" banner for
     # az-Show-CurrentSprint. When the iteration was resolved from dated cache
@@ -1943,11 +1960,7 @@ function az-Show-CurrentSprint {
     # so this view does not print a second one.
     $current = Resolve-AzDevOpsCurrentIteration
 
-    $iterationPath = if ($null -ne $current) {
-        $current.Path
-    } else {
-        $env:AZ_ITERATION
-    }
+    $iterationPath = Resolve-AzDevOpsIterationPathOrEnv -Current $current
 
     if (-not $iterationPath) {
         Write-Host "No current sprint: no iteration brackets today and `$env:AZ_ITERATION is unset." -ForegroundColor Yellow

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -419,26 +419,24 @@ function Get-AzDevOpsDailyViewerCurrentSprintRows {
     # the cache-only Resolve-AzDevOpsCurrentIterationFromCache (no live `az`
     # callout, honoring the viewer's read path), falling back to $env:AZ_ITERATION;
     # when neither resolves, the group renders empty rather than guessing a sprint.
-    # Exact-path match mirrors Get-AzDevOpsDayViewRows.
+    # Exact-path match mirrors Get-AzDevOpsDayViewRows. Comma-wrapped returns so an
+    # empty result stays an empty array through the caller's assignment instead of
+    # unrolling to $null (which the -Rows [object[]] bind would reject).
     param(
         [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Rows
     )
 
     $current = Resolve-AzDevOpsCurrentIterationFromCache
 
-    $iterationPath = if ($null -ne $current) {
-        $current.Path
-    } else {
-        $env:AZ_ITERATION
-    }
+    $iterationPath = Resolve-AzDevOpsIterationPathOrEnv -Current $current
 
     if (-not $iterationPath) {
-        return @()
+        return ,@()
     }
 
     $inSprint = @($Rows | Where-Object { $_.Iteration -eq $iterationPath })
 
-    return $inSprint
+    return ,$inSprint
 }
 
 

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -387,7 +387,8 @@ function New-AzDevOpsDailyViewerActivityGroup {
     param(
         [Parameter(Mandatory)] [string] $Label,
         [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Rows,
-        [Parameter(Mandatory)] [string] $DateField
+        [Parameter(Mandatory)] [string] $DateField,
+        [switch] $Open
     )
 
     $sorted = Sort-AzDevOpsByDateDesc -Items $Rows -Field $DateField
@@ -405,11 +406,39 @@ function New-AzDevOpsDailyViewerActivityGroup {
 
     $group = [ordered]@{
         label = $Label
-        open  = $false
+        open  = [bool]$Open
         items = $items
     }
 
     return $group
+}
+
+
+function Get-AzDevOpsDailyViewerCurrentSprintRows {
+    # Filter activity rows to the current sprint. The iteration path comes from
+    # the cache-only Resolve-AzDevOpsCurrentIterationFromCache (no live `az`
+    # callout, honoring the viewer's read path), falling back to $env:AZ_ITERATION;
+    # when neither resolves, the group renders empty rather than guessing a sprint.
+    # Exact-path match mirrors Get-AzDevOpsDayViewRows.
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Rows
+    )
+
+    $current = Resolve-AzDevOpsCurrentIterationFromCache
+
+    $iterationPath = if ($null -ne $current) {
+        $current.Path
+    } else {
+        $env:AZ_ITERATION
+    }
+
+    if (-not $iterationPath) {
+        return @()
+    }
+
+    $inSprint = @($Rows | Where-Object { $_.Iteration -eq $iterationPath })
+
+    return $inSprint
 }
 
 
@@ -421,16 +450,14 @@ function Get-AzDevOpsDailyViewerActivityItems {
         param($r) ConvertFrom-AzDevOpsActivityItem -Raw $r
     })
 
-    $closedStates = Get-AzDevOpsClosedStates
-
-    $taggedRows  = Get-AzDevOpsDailyViewerActiveRows -Rows $mentions
-    $updateRows  = Get-AzDevOpsDailyViewerActiveRows -Rows $activity
-    $closingRows = @($activity | Where-Object { $_.State -in $closedStates })
+    $taggedRows = Get-AzDevOpsDailyViewerActiveRows -Rows $mentions
+    $updateRows = Get-AzDevOpsDailyViewerActiveRows -Rows $activity
+    $sprintRows = Get-AzDevOpsDailyViewerCurrentSprintRows -Rows $activity
 
     $groups = New-Object System.Collections.Generic.List[object]
-    $groups.Add((New-AzDevOpsDailyViewerActivityGroup -Label 'Tagged discussions'      -Rows $taggedRows  -DateField 'MentionedAt'))
-    $groups.Add((New-AzDevOpsDailyViewerActivityGroup -Label 'Recent updates'          -Rows $updateRows  -DateField 'ChangedDate'))
-    $groups.Add((New-AzDevOpsDailyViewerActivityGroup -Label 'Sprint-close candidates' -Rows $closingRows -DateField 'ChangedDate'))
+    $groups.Add((New-AzDevOpsDailyViewerActivityGroup -Label 'Tagged discussions' -Rows $taggedRows -DateField 'MentionedAt' -Open))
+    $groups.Add((New-AzDevOpsDailyViewerActivityGroup -Label 'Recent updates'     -Rows $updateRows -DateField 'ChangedDate'))
+    $groups.Add((New-AzDevOpsDailyViewerActivityGroup -Label 'Current sprint'      -Rows $sprintRows -DateField 'ChangedDate'))
 
     $items = [ordered]@{
         groups = $groups


### PR DESCRIPTION
<!-- toc:start -->
## Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #199 |
| [Changes](#changes) | ✅ 7 files |
| [Test Plan](#test-plan) | 4 manual checks |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4981067441) |
| 💠 PowerShell Engineer Review | ✅ Fixed — was REQUEST CHANGES, resolved in `cf5bcd9` — [View](#issuecomment-4981090218) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4981076157) |
| 🧼 Clean-Code Engineer Review | ✅ Fixed — was REQUEST CHANGES, resolved in `cf5bcd9` — [View](#issuecomment-4981087986) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](#issuecomment-4981079572) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4981137276) |
| 📖 Docs Check | ✅ CURRENT — README fixed in `0620211` — [View](#issuecomment-4981133897) |
<!-- toc:end -->

## Summary
Three layout/scope refinements to the daily viewer (issue **A** of the three-way split of the original adjustments bundle):

1. **Agenda-first order** — Today's Focus now renders above This Week's Focus. Swapped the two `<section>`s in the grid and reordered the matching stat-strip buttons; `app.js` queries tiles/stats by `data-tile`/`data-target`, so behavior is order-independent.
2. **Tagged discussions visible** — the Recent Activity "Tagged discussions" group now defaults **open** (sample MODEL + a new `-Open` switch on `New-AzDevOpsDailyViewerActivityGroup`) so @-mentions show on load.
3. **Current-sprint scope** — the old "Sprint-close candidates" group is now **"Current sprint"**, scoped to the current iteration via a new cache-only helper (`Get-AzDevOpsDailyViewerCurrentSprintRows` → `Resolve-AzDevOpsCurrentIterationFromCache`, `$env:AZ_ITERATION` fallback). Added `[System.IterationPath]` to the activity WIQL and projected `Iteration` in `ConvertFrom-AzDevOpsActivityItem`. The iteration-path fallback is shared via `Resolve-AzDevOpsIterationPathOrEnv`.

## Issue
Closes #199

## Changes
| File | Change |
|------|--------|
| `daily-viewer/index.html` | Tile + stat-strip reorder (agenda · focus · activity · week) |
| `daily-viewer/app.js` | Sample MODEL: discussions `open:true`; relabel `Current sprint` |
| `powcuts_by_cli/daily_viewer.ps1` | `-Open` switch; `Get-AzDevOpsDailyViewerCurrentSprintRows`; activity groups reworked |
| `powcuts_by_cli/azdevops_paths.ps1` | `[System.IterationPath]` in activity WIQL |
| `powcuts_by_cli/azdevops_views.ps1` | `Iteration` field in `ConvertFrom-AzDevOpsActivityItem`; shared `Resolve-AzDevOpsIterationPathOrEnv` helper |
| `README.md` | Renamed activity tile's sprint group + re-seed migration note |
| `docs/azure-devops-diagrams.md` | Synced Diagram 9 with the new helpers |

## Test Plan
- [ ] Open `daily-viewer/index.html` directly (no server) → tiles read agenda / **focus** (top-right) / activity / **week** (bottom-right); Recent Activity shows **Tagged discussions expanded** and a **Current sprint** group
- [ ] Collapse/expand, stat-jump, live filter, theme toggle still work
- [ ] `Start-AzDevOpsDailyViewer` in pwsh → refresh Recent Activity → "Current sprint" lists current-iteration items (needs iteration cache via `az-Sync-AzDevOpsCache`, or `$env:AZ_ITERATION` set)
- [ ] Confirm `$env:AZ_USER_EMAIL` is set so the mentions WIQL surfaces real @-mentions (unset falls back to matching `'@'`)

### Notes
- **pwsh not on the build host** — the `.ps1` files got manual review, not a parse gate. The PowerShell reviewer runs where pwsh is available.
- **Migration:** the `[System.IterationPath]` addition is in the *seed* default; an already-seeded `activity.wiql` needs a re-seed/edit before "Current sprint" populates. Fresh installs are unaffected.
- **AC-5 mechanism:** scoping uses a cache-only iteration filter (`Resolve-AzDevOpsCurrentIterationFromCache` + `$env:AZ_ITERATION`) rather than the literal `@currentIteration` WIQL macro named in the issue — same end scope, no team-parameter config required. Flagged for reviewer awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xk12iSYJRX3F9NTdtgQm6r