### PR TITLE
Daily Viewer: two-week calendar prep window with all-set / prep-needed markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ Each tile is backed by one JSON file under the active project's cache slice — 
 Each tile is populated from a real source, reusing the same WIQL defaults and Outlook module the rest of the toolkit uses:
 
 - **Today's Agenda** — today's calendar events from `ol-Get-OutlookAgenda` (desktop Outlook), with the Teams join link when the meeting carries one.
-- **This Week's Focus** — your active assigned stories (the `assigned` WIQL) plus a prep checklist derived from today's meetings.
+- **This Week's Focus** — your active assigned stories (the `assigned` WIQL) plus an "events to prepare for" list spanning the next two weeks of meetings, each row carrying a date and a marker you can toggle between "prep still needed" and "all set."
 - **Recent Activity** — @-mention discussions (the `mentions` WIQL), your recent updates (the `activity` WIQL), and your current-sprint items (the `activity` rows scoped to the iteration that brackets today). The current-sprint group reads `[System.IterationPath]` off the `activity` WIQL; the seeded default already selects it, but if you seeded your `activity.wiql` before this field was added, open `o-az-devops-queries-config-dir`, add `[System.IterationPath]` to the `SELECT` in `activity.wiql`, and re-run `az-Sync-AzDevOpsCache` so the group can populate.
 - **Today's Focus** — the pinned work item you set in `$global:AzDevOpsDailyFocus` (a work-item id), plus an "assigned & unplanned support" bucket. Set it in your `$profile`, e.g. `$global:AzDevOpsDailyFocus = 1234`; leave it unset and the tile shows the support bucket alone.
 

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -48,8 +48,10 @@ var MODEL = {
       label: "Events to prepare for",
       open: true,
       items: [
-        { title: "Confirm demo build is deployed before Thu review" },
-        { title: "Send agenda for", link: { text: "Fri sprint retro", url: "https://teams.microsoft.com/l/meetup-join/example2" } }
+        { title: "Sprint Planning Sync", date: "Jul 16", datetime: "2026-07-16T09:00:00-05:00", marker: "needed" },
+        { title: "Architecture Design Review", date: "Jul 18", datetime: "2026-07-18T11:00:00-05:00", marker: "set" },
+        { title: "Cross-team API Contract Review", date: "Jul 22", datetime: "2026-07-22T14:00:00-05:00", marker: "needed", link: { text: "Join meeting", url: "https://teams.microsoft.com/l/meetup-join/example2" } },
+        { title: "Quarterly Roadmap Workshop", date: "Jul 27", datetime: "2026-07-27T10:00:00-05:00", marker: "needed" }
       ]
     }
   },
@@ -117,6 +119,13 @@ var STATE_CLASS = {
 };
 
 var STAR_GLYPH = "★";
+
+// Prep-marker states. Meetings arrive "needed" (unprepared) and the user toggles
+// each to "set" (all set). Persistence is a follow-up — the toggle is in-memory
+// for now, so a refresh re-reads the model's default state.
+var MARKER_SET = "set";
+var MARKER_SET_LABEL = "All set";
+var MARKER_NEEDED_LABEL = "Prep still needed";
 
 
 // ---------------------------------------------------------------------------
@@ -240,7 +249,38 @@ function workItemRow(wi) {
 }
 
 
-function checklistRow(item) {
+// The prep marker is a real toggle button: aria-pressed carries the state (and
+// drives the chip color in CSS), the visible text is its accessible name, and
+// every flip is announced through the shared aria-live region so a screen reader
+// hears which meeting changed. State lives on the button only (persistence is a
+// follow-up), so a re-render resets it to the model's default.
+function markerText(pressed) {
+  return pressed ? MARKER_SET_LABEL : MARKER_NEEDED_LABEL;
+}
+
+function prepMarkerButton(item) {
+  var pressed = item.marker === MARKER_SET;
+
+  var btn = el("button", {
+    type: "button",
+    class: "marker",
+    "aria-pressed": pressed ? "true" : "false",
+    text: markerText(pressed)
+  });
+
+  btn.addEventListener("click", function () {
+    var next = btn.getAttribute("aria-pressed") !== "true";
+    btn.setAttribute("aria-pressed", next ? "true" : "false");
+    btn.textContent = markerText(next);
+
+    var label = item.title || "This item";
+    announce(label + (next ? " marked all set." : " marked prep still needed."));
+  });
+
+  return btn;
+}
+
+function prepRow(item) {
   var title = [ item.title ];
 
   if (item.link) {
@@ -248,10 +288,15 @@ function checklistRow(item) {
     title.push(externalLink(item.link.text, item.link.url));
   }
 
-  return el("li", { class: "wi" }, [
-    el("span", { class: "check", "aria-hidden": "true" }),
-    el("span", { class: "wtitle" }, title)
-  ]);
+  var children = [ el("span", { class: "wtitle" }, title) ];
+
+  if (item.date) {
+    children.push(el("span", { class: "date", text: item.date }));
+  }
+
+  children.push(prepMarkerButton(item));
+
+  return el("li", { class: "wi prep" }, children);
 }
 
 
@@ -297,7 +342,7 @@ function asArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
-function groupBlock(group, rowFn) {
+function groupBlock(group, rowFn, emptyNote) {
   var items = asArray(group.items);
 
   var summary = el("summary", null, [
@@ -307,6 +352,13 @@ function groupBlock(group, rowFn) {
   ]);
 
   var list = el("ul", { class: "glist" }, items.map(rowFn));
+
+  // A group that's empty for a friendly reason (no meetings in the prep window)
+  // gets a note in place of a blank list; the note isn't a row, so it never
+  // inflates the count badge or the tile's meaningful-row check.
+  if (items.length === 0 && emptyNote) {
+    list.appendChild(el("li", { class: "empty-note", text: emptyNote }));
+  }
 
   var opts = { class: "group" };
   if (group.open) {
@@ -330,7 +382,7 @@ function renderAgenda(model) {
 function renderWeek(model) {
   return [
     groupBlock(model.stories || {}, workItemRow),
-    groupBlock(model.prep || {}, checklistRow)
+    groupBlock(model.prep || {}, prepRow, "No meetings to prepare for in the next two weeks.")
   ];
 }
 

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -258,6 +258,7 @@ function markerText(pressed) {
   return pressed ? MARKER_SET_LABEL : MARKER_NEEDED_LABEL;
 }
 
+
 function prepMarkerButton(item) {
   var pressed = item.marker === MARKER_SET;
 
@@ -279,6 +280,7 @@ function prepMarkerButton(item) {
 
   return btn;
 }
+
 
 function prepRow(item) {
   var title = [ item.title ];

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -565,11 +565,37 @@ details[open] > summary > .chev { transform: rotate(90deg); }
 }
 
 .note { font-size: var(--fs-smd); color: var(--text-dim); }
-.check {
+
+/* Prep marker toggle — "prep still needed" (warn) flips to "all set" (good) on
+   aria-pressed. State drives the color, so the JS only toggles the attribute;
+   both palettes carry over through the same theme tokens the chips already use. */
+.prep .marker {
+  flex: none;
+  font-family: inherit;
+  font-size: var(--fs-2xs); font-weight: 700; letter-spacing: .03em;
+  cursor: pointer;
   display: inline-flex; align-items: center; gap: var(--space-2);
-  font-size: var(--fs-sm); font-weight: 600; color: var(--warn);
+  padding: var(--space-0) var(--space-3);
+  border-radius: var(--radius-pill);
+  color: var(--warn);
+  border: 1px solid color-mix(in srgb, var(--warn) 35%, transparent);
+  background: color-mix(in srgb, var(--warn) 15%, transparent);
+  transition: color .15s ease, background .15s ease, border-color .15s ease;
 }
-.check::before { content: "\25CB"; }        /* open circle = to confirm */
+.prep .marker::before {
+  content: ""; width: 0.4375rem; height: 0.4375rem; border-radius: 50%;
+  background: currentColor;
+  flex: none;
+}
+.prep .marker[aria-pressed="true"] {
+  color: var(--good);
+  border-color: color-mix(in srgb, var(--good) 35%, transparent);
+  background: color-mix(in srgb, var(--good) 15%, transparent);
+}
+.prep .marker:hover { border-color: currentColor; }
+@media (prefers-reduced-motion: reduce) {
+  .prep .marker { transition: none; }
+}
 
 .primary {
   display: flex; gap: var(--space-5); align-items: flex-start;

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -29,6 +29,8 @@ $script:AzDevOpsDailyViewerStaleSeconds    = 900     # 15 min: mtime age past wh
 $script:AzDevOpsDailyViewerCacheSubdir     = 'daily-viewer'
 $script:AzDevOpsDailyViewerLoopbackAddress = '127.0.0.1'
 $script:AzDevOpsDailyViewerJsonDepth       = 10      # nesting the tile payloads / API responses serialize to
+$script:AzDevOpsDailyViewerPrepWindowDays  = 14      # "events to prepare for" look-ahead: the next two weeks
+$script:AzDevOpsDailyViewerMarkerNeeded    = 'needed'  # a newly-pulled meeting starts "prep still needed"
 
 # Strict Content-Security-Policy for the served app. The page loads styles.css +
 # app.js as external same-origin assets and fetches /api/tiles/* same-origin;
@@ -276,16 +278,18 @@ function Get-AzDevOpsDailyViewerAssignedRows {
 
 
 function Get-AzDevOpsDailyViewerAgendaEvents {
-    # Shared source of today's calendar events for the agenda tile and the week
-    # tile's prep list. ol-Get-OutlookAgenda fails soft to $null off Windows /
-    # desktop Outlook (or when the module isn't loaded); normalize that to an
-    # empty array so callers render a clean empty state instead of tripping on
-    # $null.
+    # Shared source of calendar events for the agenda tile (today, the default)
+    # and the week tile's prep list (the two-week window, via -Days).
+    # ol-Get-OutlookAgenda fails soft to $null off Windows / desktop Outlook (or
+    # when the module isn't loaded); normalize that to an empty array so callers
+    # render a clean empty state instead of tripping on $null.
+    param([int] $Days = 1)
+
     if (-not (Get-Command ol-Get-OutlookAgenda -ErrorAction SilentlyContinue)) {
         return @()
     }
 
-    $events = ol-Get-OutlookAgenda
+    $events = ol-Get-OutlookAgenda -Days $Days
     if ($null -eq $events) {
         return @()
     }
@@ -375,13 +379,21 @@ function Get-AzDevOpsDailyViewerAgendaItems {
 # --- This week's focus tile -------------------------------------------------
 
 function Get-AzDevOpsDailyViewerPrepItems {
-    # "Events to prepare for" = today's meetings, each a checklist line that
-    # links to the Teams join when there is one. Derived from the same agenda
-    # source so the week tile shares the agenda pull rather than a second query.
-    $events = @(Get-AzDevOpsDailyViewerAgendaEvents)
+    # "Events to prepare for" = the next two weeks of meetings, widened from
+    # today so nothing on the calendar sneaks up unprepared. Each row carries a
+    # short date chip, the meeting's ISO datetime, a default "prep still needed"
+    # marker the viewer can toggle to "all set", and a Teams join link when the
+    # meeting has one. Durable marker state is a follow-up — the model ships the
+    # default and the page owns the toggle.
+    $events = @(Get-AzDevOpsDailyViewerAgendaEvents -Days $script:AzDevOpsDailyViewerPrepWindowDays)
 
     $prep = @($events | ForEach-Object {
-        $node = [ordered]@{ title = "Prep for $($_.Subject)" }
+        $node = [ordered]@{
+            title    = [string]$_.Subject
+            date     = Format-AzDevOpsDailyViewerShortDate -When $_.Start
+            datetime = $_.Start.ToString('o')
+            marker   = $script:AzDevOpsDailyViewerMarkerNeeded
+        }
 
         if ($_.MeetingUrl) {
             $node.link = [ordered]@{ text = 'Join meeting'; url = $_.MeetingUrl }

--- a/powcuts_by_cli/outlook_agenda.ps1
+++ b/powcuts_by_cli/outlook_agenda.ps1
@@ -215,11 +215,15 @@ function Get-OutlookMeetingJoinUrl {
 
 
 function ol-Get-OutlookAgenda {
-    # Today's calendar events (recurrences expanded) as objects. Emits data
-    # only — formatting lives in ol-Show-OutlookAgenda.
+    # Calendar events (recurrences expanded) as objects, from $Date's day start
+    # through $Days days later. -Days defaults to 1 (today only), so the daily
+    # agenda callers are unchanged; the daily viewer's prep tile passes a wider
+    # window for its two-week look-ahead. Emits data only — formatting lives in
+    # ol-Show-OutlookAgenda.
     [CmdletBinding()]
     param(
-        [datetime] $Date = (Get-Date)
+        [datetime] $Date = (Get-Date),
+        [int]      $Days = 1
     )
 
     $calendar = Get-OutlookDefaultFolder -FolderId $script:OutlookFolderCalendar
@@ -232,7 +236,7 @@ function ol-Get-OutlookAgenda {
     $items.Sort('[Start]')
 
     $dayStart = $Date.Date
-    $dayEnd = $Date.Date.AddDays(1).AddSeconds(-1)
+    $dayEnd = $Date.Date.AddDays($Days).AddSeconds(-1)
 
     $startText = $dayStart.ToString($script:OutlookRestrictDateFormat)
     $endText = $dayEnd.ToString($script:OutlookRestrictDateFormat)


### PR DESCRIPTION

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #201 |
| [Changes](#changes) | ✅ 5 files |
| [Test Plan](#test-plan) | ✅ 4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/205#issuecomment-4985672826) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/205#issuecomment-4985680263) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/205#issuecomment-4985680765) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/205#issuecomment-4985684124) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/205#issuecomment-4985685658) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/205#issuecomment-4985705743) |

<!-- pr-diagram:start -->
## How it works

The public entry `ol-Get-OutlookAgenda` gains a `-Days` window so the backend can pull a two-week slice of the calendar; `Get-AzDevOpsDailyViewerPrepItems` shapes each meeting into a prep node (title, date chip, ISO datetime, default marker, Teams link) and writes the tile cache. The page renders that cache through `renderWeek → groupBlock → prepRow`, and each row's new interactive `prepMarkerButton` toggles `aria-pressed`, swaps its label via `markerText`, and announces the change through the shared `aria-live` region.

```mermaid
flowchart TD
    Outlook["Outlook COM calendar<br/>(two-week window)"]:::io
    OlAgenda([ol-Get-OutlookAgenda -Days N]):::pub
    AgendaEvents[Get-AzDevOpsDailyViewerAgendaEvents<br/>-Days 14]:::priv
    PrepItems[Get-AzDevOpsDailyViewerPrepItems]:::priv
    Cache[(prep tile JSON<br/>title / date / datetime / marker / link)]:::io

    Tile["tile GET / refresh"]:::io
    RenderWeek[renderWeek]:::priv
    GroupBlock["groupBlock(prep, prepRow, emptyNote)"]:::priv
    Empty{items empty?}
    Note["empty-note:<br/>no meetings in next two weeks"]
    PrepRow[prepRow<br/>title + date chip]:::priv
    MarkerBtn([prepMarkerButton]):::pub
    Toggle[toggle aria-pressed<br/>markerText label swap]:::priv
    Announce["announce() → aria-live region"]:::io

    Outlook --> OlAgenda
    OlAgenda -->|events| AgendaEvents
    AgendaEvents -->|events| PrepItems
    PrepItems -->|shaped nodes| Cache

    Cache -.served to page.-> Tile
    Tile --> RenderWeek --> GroupBlock --> Empty
    Empty -- yes --> Note
    Empty -- no --> PrepRow
    PrepRow --> MarkerBtn
    MarkerBtn -- click / Enter / Space --> Toggle --> Announce

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Widens the daily viewer&#39;s &#34;Events to prepare for&#34; list from today&#39;s meetings to the **next 14 days**, and gives each prep row a real toggle button so you can flag whether a meeting is **&#34;All set&#34;** or **&#34;Prep still needed&#34;**. Nothing on the calendar sneaks up unprepared, and you can see at a glance what still needs work.

## Issue

Closes #201 (part of epic #189; issue **C** of the three-way split).

## Changes

- **`powcuts_by_cli/outlook_agenda.ps1`** — `ol-Get-OutlookAgenda` gains a `-Days` window parameter (default `1` → today only, so existing agenda callers are unchanged).
- **`powcuts_by_cli/daily_viewer.ps1`** — prep pull widened to 14 days via `-Days`; prep nodes now carry a short `date` chip, ISO `datetime`, a default `marker` state, and the Teams join link when present. Two new script constants (`PrepWindowDays = 14`, `MarkerNeeded`).
- **`daily-viewer/app.js`** — mock prep model reshaped to a 14-day calendar; new `prepRow` + `prepMarkerButton` replace the old `checklistRow`; `groupBlock` gains an optional empty-note so an empty prep window renders a friendly line. The marker is a real `` — keyboard-operable, announced through the existing `aria-live` region, with state driving the chip color in CSS.
- **`daily-viewer/styles.css`** — `aria-pressed`-driven marker chip tokenized for both light/dark themes with a `prefers-reduced-motion` guard; removed the now-dead `.check` styles.

Marker state is in-memory for now — durable &#34;all set&#34; persistence is a follow-up (out of scope here). Untrusted calendar titles still reach the DOM only through the escaping `el()` path (no `innerHTML`).

## Test Plan

- [ ] PowerShell parity: `ol-Get-OutlookAgenda -Days 14` returns the next two weeks of meetings (Windows + desktop Outlook)
- [ ] `az-Start-AzDevOpsDailyViewer` → **This Week&#39;s Focus** tile → each prep row shows a date chip + a marker toggle
- [ ] Toggle a marker with mouse and keyboard (Enter/Space); chip flips **Prep still needed ⇄ All set** and the change is announced
- [ ] Page opens directly from `file://` (sample data) and behaves identically; an empty prep window shows the friendly note

Verified headless in Chromium: 4 markers render, default/`set` states correct, keyboard toggle + `aria-live` announce work, empty-window note renders, and a markup-bearing title escapes to inert text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYfum3gzLmh9tzb1pWbiRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYfum3gzLmh9tzb1pWbiRn)_