### PR TITLE
Daily Viewer — split "Events to Prepare For" into its own tile under Calendar / Azure DevOps sections

### DIFF
--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -454,6 +454,19 @@ function renderWeek(model) {
 }
 
 
+// A start time in epoch millis, or Infinity when the datetime is absent or
+// unparseable — so a missing/garbled value sorts last instead of throwing or
+// (for NaN) leaving the row wherever it happened to sit.
+function startMillis(datetime) {
+  if (!datetime) {
+    return Infinity;
+  }
+
+  var ms = new Date(datetime).getTime();
+  return isNaN(ms) ? Infinity : ms;
+}
+
+
 // Prep events read as a chronological upcoming-meetings list, so sort a copy by
 // start time ascending; an item missing a datetime sorts last rather than
 // throwing. The tile header already names the group, so rows render as a flat
@@ -462,8 +475,8 @@ function sortByDatetime(items) {
   var copy = items.slice();
 
   copy.sort(function (a, b) {
-    var ta = a.datetime ? new Date(a.datetime).getTime() : Infinity;
-    var tb = b.datetime ? new Date(b.datetime).getTime() : Infinity;
+    var ta = startMillis(a.datetime);
+    var tb = startMillis(b.datetime);
     return ta - tb;
   });
 

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -540,7 +540,7 @@ var TILES = [
     empty: "No meetings to prepare for in the next two weeks.",
     statCount: function (m) { return asArray(m.items).length; } },
   { key: "week",     render: renderWeek,     stat: "tile-week",
-    empty: "No stories or prep items this week.",
+    empty: "No stories to complete this week.",
     statCount: function (m) { return asArray(m.stories && m.stories.items).length; } },
   { key: "activity", render: renderActivity, stat: "tile-activity",
     empty: "No recent activity.",

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -43,17 +43,27 @@ var MODEL = {
         { type: "Story", id: 1240, url: "https://dev.azure.com/org/project/_workitems/edit/1240", title: "Outlook calendar pull for daily events", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1240", state: "Active", priority: 3, date: "Jul 17" },
         { type: "Bug", id: 1251, url: "https://dev.azure.com/org/project/_workitems/edit/1251", title: "Timezone offset on EST agenda rows", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1251", state: "In review", priority: 1, date: "Jul 16" }
       ]
-    },
-    prep: {
-      label: "Events to prepare for",
-      open: true,
-      items: [
-        { title: "Sprint Planning Sync", date: "Jul 16", datetime: "2026-07-16T09:00:00-05:00", marker: "needed" },
-        { title: "Architecture Design Review", date: "Jul 18", datetime: "2026-07-18T11:00:00-05:00", marker: "set" },
-        { title: "Cross-team API Contract Review", date: "Jul 22", datetime: "2026-07-22T14:00:00-05:00", marker: "needed", link: { text: "Join meeting", url: "https://teams.microsoft.com/l/meetup-join/example2" } },
-        { title: "Quarterly Roadmap Workshop", date: "Jul 27", datetime: "2026-07-27T10:00:00-05:00", marker: "needed" }
-      ]
     }
+  },
+
+  // Prep is its own calendar tile. Items carry the same optional time/location
+  // shape as agenda events, so a prep row can surface meeting detail when the
+  // Outlook pull provides it and degrade to just title + date when it doesn't.
+  prep: {
+    label: "Events to prepare for",
+    open: true,
+    items: [
+      { title: "Sprint Planning Sync", date: "Jul 16", datetime: "2026-07-16T09:00:00-05:00", marker: "needed",
+        time: { label: "9:00 AM", tz: "EST" },
+        location: { badge: "Teams", urlLabel: "Join meeting →", url: "https://teams.microsoft.com/l/meetup-join/example" } },
+      { title: "Architecture Design Review", date: "Jul 18", datetime: "2026-07-18T11:00:00-05:00", marker: "set",
+        time: { label: "11:00 AM", tz: "EST" },
+        location: { badge: "In person", text: "Room 132" } },
+      { title: "Cross-team API Contract Review", date: "Jul 22", datetime: "2026-07-22T14:00:00-05:00", marker: "needed",
+        time: { label: "2:00 PM", tz: "EST" },
+        location: { badge: "Teams", urlLabel: "Join meeting →", url: "https://teams.microsoft.com/l/meetup-join/example2" } },
+      { title: "Quarterly Roadmap Workshop", date: "Jul 27", datetime: "2026-07-27T10:00:00-05:00", marker: "needed" }
+    ]
   },
 
   activity: {
@@ -282,15 +292,53 @@ function prepMarkerButton(item) {
 }
 
 
-function prepRow(item) {
-  var title = [ item.title ];
+// Agenda-style detail on a prep row: the meeting time and location share one meta
+// line under the title, joined by the middle-dot separator. Both are optional, so
+// a prep item that carries neither renders as just its title.
+var META_SEP = "·";
 
-  if (item.link) {
-    title.push(" ");
-    title.push(externalLink(item.link.text, item.link.url));
+function prepMetaLine(item) {
+  var bits = [];
+
+  if (item.time) {
+    bits.push(timeNode({ label: item.time.label, tz: item.time.tz, datetime: item.datetime }));
+  }
+  if (item.location) {
+    bits.push(whereLine(item.location));
   }
 
-  var children = [ el("span", { class: "wtitle" }, title) ];
+  if (bits.length === 0) {
+    return null;
+  }
+
+  var children = [];
+  bits.forEach(function (bit, i) {
+    if (i > 0) {
+      children.push(META_SEP);
+    }
+    children.push(bit);
+  });
+
+  return el("p", { class: "meta" }, children);
+}
+
+
+function prepRow(item) {
+  var titleLine = [ item.title ];
+
+  if (item.link) {
+    titleLine.push(" ");
+    titleLine.push(externalLink(item.link.text, item.link.url));
+  }
+
+  var column = [ el("p", { class: "ptitle" }, titleLine) ];
+
+  var meta = prepMetaLine(item);
+  if (meta) {
+    column.push(meta);
+  }
+
+  var children = [ el("div", { class: "wtitle" }, column) ];
 
   if (item.date) {
     children.push(el("span", { class: "date", text: item.date }));
@@ -302,24 +350,44 @@ function prepRow(item) {
 }
 
 
+// Shared time + location renderers — the agenda tile and the prep tile both
+// surface a meeting's start time and place, so the escaping-safe markup for each
+// lives in one helper. The datetime attribute is optional: agenda events carry it
+// on the time object, prep passes the item-level datetime, and a row without one
+// renders a plain <time> label rather than a literal "undefined" attribute.
+function timeNode(time) {
+  var opts = { class: "time" };
+  if (time.datetime) {
+    opts.datetime = time.datetime;
+  }
+
+  var children = [ time.label ];
+  if (time.tz) {
+    children.push(el("span", { class: "tz", text: time.tz }));
+  }
+
+  return el("time", opts, children);
+}
+
+
+function whereLine(location) {
+  var children = [ el("span", { class: "badge-loc", text: location.badge }) ];
+
+  if (location.text) {
+    children.push(" ");
+    children.push(location.text);
+  }
+  if (location.url) {
+    children.push(" ");
+    children.push(externalLink(location.urlLabel, location.url));
+  }
+
+  return el("span", { class: "where" }, children);
+}
+
+
 function eventRow(ev) {
-  var timeChildren = [ ev.time.label ];
-  if (ev.time.tz) {
-    timeChildren.push(el("span", { class: "tz", text: ev.time.tz }));
-  }
-  var time = el("time", { class: "time", datetime: ev.time.datetime }, timeChildren);
-
-  var whereChildren = [ el("span", { class: "badge-loc", text: ev.location.badge }) ];
-  if (ev.location.text) {
-    whereChildren.push(" ");
-    whereChildren.push(ev.location.text);
-  }
-  if (ev.location.url) {
-    whereChildren.push(" ");
-    whereChildren.push(externalLink(ev.location.urlLabel, ev.location.url));
-  }
-
-  var metaLines = [ el("p", { class: "meta" }, [ el("span", { class: "where" }, whereChildren) ]) ];
+  var metaLines = [ el("p", { class: "meta" }, [ whereLine(ev.location) ]) ];
 
   (ev.details || []).forEach(function (detail) {
     var line = [ el("span", { class: "k", text: detail.label }), " " ];
@@ -333,7 +401,7 @@ function eventRow(ev) {
 
   var content = el("div", null, [ el("p", { class: "etitle", text: ev.title }) ].concat(metaLines));
 
-  return el("li", { class: "event" }, [ time, content ]);
+  return el("li", { class: "event" }, [ timeNode(ev.time), content ]);
 }
 
 
@@ -382,10 +450,31 @@ function renderAgenda(model) {
 
 
 function renderWeek(model) {
-  return [
-    groupBlock(model.stories || {}, workItemRow),
-    groupBlock(model.prep || {}, prepRow, "No meetings to prepare for in the next two weeks.")
-  ];
+  return [ groupBlock(model.stories || {}, workItemRow) ];
+}
+
+
+// Prep events read as a chronological upcoming-meetings list, so sort a copy by
+// start time ascending; an item missing a datetime sorts last rather than
+// throwing. The tile header already names the group, so rows render as a flat
+// list (no nested group label to duplicate it).
+function sortByDatetime(items) {
+  var copy = items.slice();
+
+  copy.sort(function (a, b) {
+    var ta = a.datetime ? new Date(a.datetime).getTime() : Infinity;
+    var tb = b.datetime ? new Date(b.datetime).getTime() : Infinity;
+    return ta - tb;
+  });
+
+  return copy;
+}
+
+
+function renderPrep(model) {
+  var items = sortByDatetime(asArray(model.items));
+  var list = el("ul", { class: "plist" }, items.map(prepRow));
+  return [ list ];
 }
 
 
@@ -434,6 +523,9 @@ var TILES = [
   { key: "agenda",   render: renderAgenda,   stat: "tile-agenda",
     empty: "No meetings today.",
     statCount: function (m) { return asArray(m.events).length; } },
+  { key: "prep",     render: renderPrep,     stat: "tile-prep",
+    empty: "No meetings to prepare for in the next two weeks.",
+    statCount: function (m) { return asArray(m.items).length; } },
   { key: "week",     render: renderWeek,     stat: "tile-week",
     empty: "No stories or prep items this week.",
     statCount: function (m) { return asArray(m.stories && m.stories.items).length; } },
@@ -654,12 +746,21 @@ document.getElementById("refreshAll").addEventListener("click", function () {
 });
 
 
-// Stat strip: open and scroll to the tile a stat summarizes.
+// Stat strip: open and scroll to the tile a stat summarizes. Open the parent
+// section first so a collapsed Calendar / Azure DevOps group reveals the tile.
 document.querySelectorAll(".stat").forEach(function (stat) {
   stat.addEventListener("click", function () {
     var target = document.getElementById(stat.dataset.target);
     if (!target) {
       return;
+    }
+
+    var section = target.closest(".section");
+    if (section) {
+      var sectionDetails = section.querySelector("details");
+      if (sectionDetails) {
+        sectionDetails.open = true;
+      }
     }
 
     var details = target.querySelector("details");
@@ -745,6 +846,20 @@ function applyFilter(raw) {
     t.classList.toggle("empty", !!q && !anyVisible);
   });
 
+  // A whole parent section drops out when a search empties every tile inside it,
+  // so the filtered view isn't padded with empty Calendar / Azure DevOps headers.
+  document.querySelectorAll(".section").forEach(function (section) {
+    var anyTileVisible = false;
+
+    section.querySelectorAll(".tile").forEach(function (t) {
+      if (!t.classList.contains("empty")) {
+        anyTileVisible = true;
+      }
+    });
+
+    section.classList.toggle("section-empty", !!q && !anyTileVisible);
+  });
+
   if (q) {
     announce(matchTotal + (matchTotal === 1 ? " item matches." : " items match."));
   }
@@ -758,6 +873,21 @@ searchBox.addEventListener("keydown", function (e) {
     applyFilter("");
   }
 });
+
+
+// Header date — rendered live so the dashboard always names the current day,
+// replacing the static fallback baked into the markup for the JS-off case.
+function paintTodayDate() {
+  var node = document.getElementById("today-date");
+  if (!node) {
+    return;
+  }
+
+  var today = new Date();
+  node.textContent = today.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
+}
+
+paintTodayDate();
 
 
 // ---------------------------------------------------------------------------

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -65,7 +65,7 @@
             <details open>
               <summary>
                 <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h2 id="h-agenda">Today&rsquo;s Agenda</h2><span class="count"></span></span>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h3 id="h-agenda">Today&rsquo;s Agenda</h3><span class="count"></span></span>
                 <span class="tile-meta">
                   <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 12m ago</span>
                   <button class="refresh-btn" type="button" data-tile="agenda" aria-label="Refresh Today&rsquo;s Agenda"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -80,7 +80,7 @@
             <details open>
               <summary>
                 <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="3" y="2.5" width="10" height="12" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M6 1.5h4v2H6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/><path d="M5.5 7.6l1.2 1.2 2.3-2.6M5.5 11h5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg><h2 id="h-prep">Events to Prepare For</h2><span class="count"></span></span>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="3" y="2.5" width="10" height="12" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M6 1.5h4v2H6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/><path d="M5.5 7.6l1.2 1.2 2.3-2.6M5.5 11h5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg><h3 id="h-prep">Events to Prepare For</h3><span class="count"></span></span>
                 <span class="tile-meta">
                   <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 15m ago</span>
                   <button class="refresh-btn" type="button" data-tile="prep" aria-label="Refresh Events to Prepare For"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -110,7 +110,7 @@
             <details open>
               <summary>
                 <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h2 id="h-week">This Week&rsquo;s Focus</h2><span class="count"></span></span>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h3 id="h-week">This Week&rsquo;s Focus</h3><span class="count"></span></span>
                 <span class="tile-meta">
                   <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 2h ago</span>
                   <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -125,7 +125,7 @@
             <details open>
               <summary>
                 <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 8h3l2-4.5 3 9 2-4.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg><h2 id="h-activity">Recent Activity</h2><span class="count"></span></span>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 8h3l2-4.5 3 9 2-4.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg><h3 id="h-activity">Recent Activity</h3><span class="count"></span></span>
                 <span class="tile-meta">
                   <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 5m ago</span>
                   <button class="refresh-btn" type="button" data-tile="activity" aria-label="Refresh Recent Activity"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -140,7 +140,7 @@
             <details open>
               <summary>
                 <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2 id="h-focus">Today&rsquo;s Focus</h2><span class="count"></span></span>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h3 id="h-focus">Today&rsquo;s Focus</h3><span class="count"></span></span>
                 <span class="tile-meta">
                   <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 1h ago</span>
                   <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -13,7 +13,7 @@
   <header class="topbar">
     <div class="brand">
       <h1>Daily Viewer</h1>
-      <p class="sub">Azure DevOps agenda &middot; <span class="date">Tuesday, July 14</span></p>
+      <p class="sub">Azure DevOps agenda &middot; <span class="date" id="today-date">Tuesday, July 14</span></p>
     </div>
     <nav class="toolbar" aria-label="Viewer controls">
       <label class="search">
@@ -37,76 +37,123 @@
          they can never drift from the collections they summarize. -->
     <section class="stats" aria-label="Summary counts">
       <button class="stat a" type="button" data-target="tile-agenda"><span class="n"></span><span class="l">Meetings today</span></button>
+      <button class="stat p" type="button" data-target="tile-prep"><span class="n"></span><span class="l">Events to prep</span></button>
       <button class="stat g" type="button" data-target="tile-focus"><span class="n"></span><span class="l">Support &amp; focus items</span></button>
       <button class="stat s" type="button" data-target="tile-activity"><span class="n"></span><span class="l">Recent updates</span></button>
       <button class="stat f" type="button" data-target="tile-week"><span class="n"></span><span class="l">Stories due this week</span></button>
     </section>
 
-    <!-- Each tile is a static shell: header chrome, staleness, refresh button. Its
-         .count badge and its .body rows are rendered from the model in app.js. -->
-    <div class="grid">
+    <!-- Tiles group under two collapsible parent sections by data source: Calendar
+         (Outlook) and Azure DevOps (az boards). Each parent is a <details> so the
+         whole group collapses with JS off. Each tile inside is itself a static
+         shell — header chrome, staleness, refresh button — whose .count badge and
+         .body rows are rendered from the model in app.js. -->
 
-      <!-- Today's Agenda -->
-      <section class="tile" id="tile-agenda" data-tile="agenda" aria-labelledby="h-agenda">
-        <details open>
-          <summary>
-            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h2 id="h-agenda">Today&rsquo;s Agenda</h2><span class="count"></span></span>
-            <span class="tile-meta">
-              <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 12m ago</span>
-              <button class="refresh-btn" type="button" data-tile="agenda" aria-label="Refresh Today&rsquo;s Agenda"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-            </span>
-          </summary>
-          <div class="body"></div>
-        </details>
-      </section>
+    <!-- Calendar — Outlook-derived tiles -->
+    <section class="section cal" aria-labelledby="sec-calendar">
+      <details open>
+        <summary>
+          <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          <svg class="sicon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>
+          <h2 class="section-title" id="sec-calendar">Calendar</h2>
+        </summary>
 
-      <!-- Today's Focus -->
-      <section class="tile" id="tile-focus" data-tile="focus" aria-labelledby="h-focus">
-        <details open>
-          <summary>
-            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2 id="h-focus">Today&rsquo;s Focus</h2><span class="count"></span></span>
-            <span class="tile-meta">
-              <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 1h ago</span>
-              <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-            </span>
-          </summary>
-          <div class="body"></div>
-        </details>
-      </section>
+        <div class="grid">
 
-      <!-- Recent Activity -->
-      <section class="tile" id="tile-activity" data-tile="activity" aria-labelledby="h-activity">
-        <details open>
-          <summary>
-            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 8h3l2-4.5 3 9 2-4.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg><h2 id="h-activity">Recent Activity</h2><span class="count"></span></span>
-            <span class="tile-meta">
-              <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 5m ago</span>
-              <button class="refresh-btn" type="button" data-tile="activity" aria-label="Refresh Recent Activity"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-            </span>
-          </summary>
-          <div class="body"></div>
-        </details>
-      </section>
+          <!-- Today's Agenda -->
+          <section class="tile" id="tile-agenda" data-tile="agenda" aria-labelledby="h-agenda">
+            <details open>
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h2 id="h-agenda">Today&rsquo;s Agenda</h2><span class="count"></span></span>
+                <span class="tile-meta">
+                  <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 12m ago</span>
+                  <button class="refresh-btn" type="button" data-tile="agenda" aria-label="Refresh Today&rsquo;s Agenda"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                </span>
+              </summary>
+              <div class="body"></div>
+            </details>
+          </section>
 
-      <!-- This Week's Focus -->
-      <section class="tile" id="tile-week" data-tile="week" aria-labelledby="h-week">
-        <details open>
-          <summary>
-            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h2 id="h-week">This Week&rsquo;s Focus</h2><span class="count"></span></span>
-            <span class="tile-meta">
-              <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 2h ago</span>
-              <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-            </span>
-          </summary>
-          <div class="body"></div>
-        </details>
-      </section>
+          <!-- Events to Prepare For -->
+          <section class="tile" id="tile-prep" data-tile="prep" aria-labelledby="h-prep">
+            <details open>
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="3" y="2.5" width="10" height="12" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M6 1.5h4v2H6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/><path d="M5.5 7.6l1.2 1.2 2.3-2.6M5.5 11h5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg><h2 id="h-prep">Events to Prepare For</h2><span class="count"></span></span>
+                <span class="tile-meta">
+                  <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 15m ago</span>
+                  <button class="refresh-btn" type="button" data-tile="prep" aria-label="Refresh Events to Prepare For"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                </span>
+              </summary>
+              <div class="body"></div>
+            </details>
+          </section>
 
-    </div>
+        </div>
+      </details>
+    </section>
+
+    <!-- Azure DevOps — az boards-derived tiles -->
+    <section class="section ado" aria-labelledby="sec-azuredevops">
+      <details open>
+        <summary>
+          <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          <svg class="sicon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l6 3.2-6 3.2-6-3.2z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/><path d="M2 8l6 3.2L14 8M2 11.3l6 3.2 6-3.2" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
+          <h2 class="section-title" id="sec-azuredevops">Azure DevOps</h2>
+        </summary>
+
+        <div class="grid">
+
+          <!-- This Week's Focus -->
+          <section class="tile" id="tile-week" data-tile="week" aria-labelledby="h-week">
+            <details open>
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h2 id="h-week">This Week&rsquo;s Focus</h2><span class="count"></span></span>
+                <span class="tile-meta">
+                  <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 2h ago</span>
+                  <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                </span>
+              </summary>
+              <div class="body"></div>
+            </details>
+          </section>
+
+          <!-- Recent Activity -->
+          <section class="tile" id="tile-activity" data-tile="activity" aria-labelledby="h-activity">
+            <details open>
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 8h3l2-4.5 3 9 2-4.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg><h2 id="h-activity">Recent Activity</h2><span class="count"></span></span>
+                <span class="tile-meta">
+                  <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 5m ago</span>
+                  <button class="refresh-btn" type="button" data-tile="activity" aria-label="Refresh Recent Activity"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                </span>
+              </summary>
+              <div class="body"></div>
+            </details>
+          </section>
+
+          <!-- Today's Focus -->
+          <section class="tile" id="tile-focus" data-tile="focus" aria-labelledby="h-focus">
+            <details open>
+              <summary>
+                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2 id="h-focus">Today&rsquo;s Focus</h2><span class="count"></span></span>
+                <span class="tile-meta">
+                  <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 1h ago</span>
+                  <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                </span>
+              </summary>
+              <div class="body"></div>
+            </details>
+          </section>
+
+        </div>
+      </details>
+    </section>
+
   </main>
 
   <footer class="footer">

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -270,7 +270,7 @@ button:focus-visible {
 /* ---------- summary stat strip ---------- */
 .stats {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   gap: var(--space-5);
   margin-bottom: var(--space-8);
 }
@@ -296,9 +296,45 @@ button:focus-visible {
 }
 .stat .l { font-size: var(--fs-sm); color: var(--text-dim); }
 .stat.a { --stat: var(--accent); }
+.stat.p { --stat: var(--epic); }
 .stat.f { --stat: var(--feature); }
 .stat.s { --stat: var(--story); }
 .stat.g { --stat: var(--warn); }
+
+/* ---------- parent sections (Calendar / Azure DevOps) ---------- */
+.section { margin-bottom: var(--space-8); }
+.section:last-of-type { margin-bottom: 0; }
+.section.section-empty { display: none; }
+.section.cal { --tint: var(--epic); }
+.section.ado { --tint: var(--story); }
+
+.section > details > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-1);
+  margin-bottom: var(--space-6);
+  border-bottom: 1px solid var(--border);
+  user-select: none;
+}
+.section > details > summary::-webkit-details-marker { display: none; }
+.section > details > summary:hover .section-title { color: var(--text); }
+
+.section .sicon {
+  flex: none;
+  width: var(--icon); height: var(--icon);
+  color: var(--tint, var(--accent));
+}
+.section-title {
+  margin: 0;
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
 
 /* ---------- grid ---------- */
 .grid {
@@ -321,6 +357,7 @@ button:focus-visible {
   overflow: hidden;
 }
 .tile[data-tile="agenda"]   { --tint: var(--accent); }
+.tile[data-tile="prep"]     { --tint: var(--epic); }
 .tile[data-tile="week"]     { --tint: var(--feature); }
 .tile[data-tile="activity"] { --tint: var(--story); }
 .tile[data-tile="focus"]    { --tint: var(--warn); }
@@ -596,6 +633,42 @@ details[open] > summary > .chev { transform: rotate(90deg); }
 @media (prefers-reduced-motion: reduce) {
   .prep .marker { transition: none; }
 }
+
+/* Prep tile list — a flat chronological list (the tile header already names the
+   group). Each row stacks title over an agenda-style time/location meta line. */
+.plist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+.prep .wtitle {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.prep .ptitle { font-weight: 600; color: var(--text); }
+.prep .meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.prep .meta .time {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text-dim);
+}
+.prep .meta .time .tz {
+  margin-left: var(--space-1);
+  font-weight: 400;
+  font-size: var(--fs-2xs);
+  color: var(--text-faint);
+}
+.prep .meta a { color: var(--accent); }
 
 .primary {
   display: flex; gap: var(--space-5); align-items: flex-start;

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -394,7 +394,7 @@ details[open] > summary > .chev { transform: rotate(90deg); }
   width: var(--icon); height: var(--icon);
   color: var(--tint, var(--accent));
 }
-.tt h2 {
+.tt h3 {
   margin: 0;
   font-size: var(--fs-smd);
   font-weight: 700;
@@ -662,7 +662,7 @@ details[open] > summary > .chev { transform: rotate(90deg); }
   font-weight: 600;
   color: var(--text-dim);
 }
-.prep .meta .time .tz {
+.prep .tz {
   margin-left: var(--space-1);
   font-weight: 400;
   font-size: var(--fs-2xs);


### PR DESCRIPTION

## Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #208 |
| [Changes](#changes) | ✅ 3 files |
| [Design notes](#design-notes) | ✅ |
| [Test Plan](#test-plan) | ✅ 8 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4993949877) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4993949687) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4993958092) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4993964378) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](#issuecomment-4993967272) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4994011446) |


<!-- pr-diagram:start -->
## How it works

Each tile boots through `loadTile → paintTile → renderTileBody`, which dispatches to the tile's `render` fn registered in `TILES`. The new **prep** tile registers `renderPrep`, which sorts its events chronologically (`sortByDatetime` → `startMillis`, missing dates last) and maps each to a `prepRow`; the row's `prepMetaLine` reuses the same `timeNode`/`whereLine` helpers the agenda's `eventRow` now shares, plus a `prepMarkerButton`. `paintTodayDate` fills the live header, while the section-aware stat-jump and `applyFilter` controllers open/hide the parent Calendar / Azure DevOps `.section` around each tile.

```mermaid
flowchart TD
    Boot([loadTile]):::pub --> Paint[paintTile]:::priv
    Paint --> Body[renderTileBody]:::priv
    Body --> Tiles{TILES render dispatch}:::priv
    Tiles -- prep key --> RenderPrep([renderPrep]):::pub
    Tiles -- agenda key --> EventRow([eventRow]):::pub

    RenderPrep --> Sort[sortByDatetime]:::priv
    Sort --> StartMs[startMillis<br/>missing date sorts last]:::priv
    RenderPrep --> PrepRow[prepRow]:::priv
    PrepRow --> Meta[prepMetaLine]:::priv
    PrepRow --> Marker[prepMarkerButton]:::priv
    Meta --> TimeNode[timeNode]:::priv
    Meta --> Where[whereLine]:::priv
    EventRow -.reuses.-> TimeNode
    EventRow -.reuses.-> Where

    PaintDate([paintTodayDate]):::pub --> DOM[(DOM tiles / sections)]:::io
    StatJump([stat-jump: open parent section]):::pub --> DOM
    Filter([applyFilter: hide empty section]):::pub --> DOM
    PrepRow --> DOM

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Promotes **"Events to prepare for"** from a secondary group inside the *This Week's Focus* tile to a **first-class tile**, and groups the five daily-viewer tiles under **two collapsible parent sections** by data source:

- **📅 Calendar** (Outlook) — Today's Agenda · Events to Prepare For
- **🔷 Azure DevOps** (`az boards`) — This Week's Focus · Recent Activity · Today's Focus

Prep rows are enriched with agenda-style detail (time + location/Teams-join), and the header date is now rendered live. Front-end-only change to the `daily-viewer/` mock — no shell shortcuts touched.

## Issue

Closes #208

## Changes

| File | What changed |
|------|--------------|
| `daily-viewer/index.html` | New `tile-prep` shell; five tiles wrapped in two collapsible `` parents; 5th "Events to prep" stat; header date given an id |
| `daily-viewer/app.js` | `MODEL.prep` moved to top level (+ optional `time`/`location`); `renderPrep` sorts events by start time ascending; `prepRow` enriched via shared `timeNode`/`whereLine` helpers (also used by `eventRow`); prep removed from `renderWeek`; live header date; stat-click + live filter are section-aware |
| `daily-viewer/styles.css` | Parent-section summary styling, prep tile tint, 5-column stat grid, prep list/row layout — all token-driven, both themes |

## Design notes

- **Escaping preserved** — every model string still reaches the DOM through `el()` (`textContent`/`setAttribute`); links pass `safeUrl()`. No `innerHTML` path added.
- **Derived counts** — the prep tile's count badge and its stat number both come from `items.length`; no hand-authored literal that can drift.
- **DRY** — the agenda and prep tiles now share `timeNode`/`whereLine` rather than duplicating time/location markup.
- **Two open-question defaults applied**: sections **expanded on load**, prep **sorted by date ascending**.

## Test Plan

Verified end-to-end in Chromium (both light and dark themes):

- [x] Two collapsible sections; prep is its own tile under **Calendar**
- [x] Prep rows show **date + time + Teams-join link + prep toggle**, sorted Jul 16 → 27
- [x] Marker toggle flips *Prep still needed* ↔ *All set* and announces via `aria-live`
- [x] Header shows today's live date
- [x] Collapse-all (tiles close, sections stay) · Expand-all (all open)
- [x] Live filter hides a section with no matches and restores it on clear
- [x] Stat-click reveals a collapsed parent section
- [x] `node --check app.js` passes; no debug artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wi6SAejEkZEXqutEJShFuL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wi6SAejEkZEXqutEJShFuL)_
