### PR TITLE
Persist daily-viewer prep "all set" markers across cache reloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,11 +696,12 @@ Each tile is backed by one JSON file under the active project's cache slice — 
 - `GET /` — the page and its static assets.
 - `GET /api/tiles/<name>` — that tile's cached JSON, plus its `ageSeconds` / `stale` staleness (cheap read).
 - `POST /api/tiles/<name>/refresh` — re-runs that tile's query, rewrites its cache, and returns the fresh JSON (expensive; per-tile).
+- `POST /api/tiles/week/prep-marker` — persists one prep row's "all set" / "prep still needed" marker (body `{ "id", "marker" }`, keyed by the meeting's stable event id) so the choice survives a refresh or reload.
 
 Each tile is populated from a real source, reusing the same WIQL defaults and Outlook module the rest of the toolkit uses:
 
 - **Today's Agenda** — today's calendar events from `ol-Get-OutlookAgenda` (desktop Outlook), with the Teams join link when the meeting carries one.
-- **This Week's Focus** — your active assigned stories (the `assigned` WIQL) plus an "events to prepare for" list spanning the next two weeks of meetings, each row carrying a date and a marker you can toggle between "prep still needed" and "all set."
+- **This Week's Focus** — your active assigned stories (the `assigned` WIQL) plus an "events to prepare for" list spanning the next two weeks of meetings, each row carrying a date and a marker you can toggle between "prep still needed" and "all set." That choice is saved server-side by the meeting's event id (a small `prep-markers.json` beside the tile cache), so a meeting you mark "all set" stays that way when the cache reloads.
 - **Recent Activity** — @-mention discussions (the `mentions` WIQL), your recent updates (the `activity` WIQL), and your current-sprint items (the `activity` rows scoped to the iteration that brackets today). The current-sprint group reads `[System.IterationPath]` off the `activity` WIQL; the seeded default already selects it, but if you seeded your `activity.wiql` before this field was added, open `o-az-devops-queries-config-dir`, add `[System.IterationPath]` to the `SELECT` in `activity.wiql`, and re-run `az-Sync-AzDevOpsCache` so the group can populate.
 - **Today's Focus** — the pinned work item you set in `$global:AzDevOpsDailyFocus` (a work-item id), plus an "assigned & unplanned support" bucket. Set it in your `$profile`, e.g. `$global:AzDevOpsDailyFocus = 1234`; leave it unset and the tile shows the support bucket alone.
 

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -287,7 +287,17 @@ function prepMarkerButton(item) {
     text: markerText(pressed)
   });
 
+  // Guard re-clicks with a flag (plus aria-disabled) rather than the native
+  // `disabled` property: toggling `disabled` synchronously punts keyboard focus
+  // to <body>, so a keyboard user loses their place in the list. aria-disabled
+  // keeps focus on the button while the save is in flight.
+  var saving = false;
+
   btn.addEventListener("click", function () {
+    if (saving) {
+      return;
+    }
+
     var next = btn.getAttribute("aria-pressed") !== "true";
     setMarkerPressed(btn, next);
 
@@ -301,14 +311,17 @@ function prepMarkerButton(item) {
       return;
     }
 
-    btn.disabled = true;
+    saving = true;
+    btn.setAttribute("aria-disabled", "true");
     savePrepMarker(item.id, next)
       .then(function () {
-        btn.disabled = false;
+        saving = false;
+        btn.removeAttribute("aria-disabled");
       })
       .catch(function () {
+        saving = false;
+        btn.removeAttribute("aria-disabled");
         setMarkerPressed(btn, !next);
-        btn.disabled = false;
         announce(label + " — couldn't save, change reverted.");
       });
   });

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -48,10 +48,10 @@ var MODEL = {
       label: "Events to prepare for",
       open: true,
       items: [
-        { title: "Sprint Planning Sync", date: "Jul 16", datetime: "2026-07-16T09:00:00-05:00", marker: "needed" },
-        { title: "Architecture Design Review", date: "Jul 18", datetime: "2026-07-18T11:00:00-05:00", marker: "set" },
-        { title: "Cross-team API Contract Review", date: "Jul 22", datetime: "2026-07-22T14:00:00-05:00", marker: "needed", link: { text: "Join meeting", url: "https://teams.microsoft.com/l/meetup-join/example2" } },
-        { title: "Quarterly Roadmap Workshop", date: "Jul 27", datetime: "2026-07-27T10:00:00-05:00", marker: "needed" }
+        { id: "sample-planning", title: "Sprint Planning Sync", date: "Jul 16", datetime: "2026-07-16T09:00:00-05:00", marker: "needed" },
+        { id: "sample-arch", title: "Architecture Design Review", date: "Jul 18", datetime: "2026-07-18T11:00:00-05:00", marker: "set" },
+        { id: "sample-api", title: "Cross-team API Contract Review", date: "Jul 22", datetime: "2026-07-22T14:00:00-05:00", marker: "needed", link: { text: "Join meeting", url: "https://teams.microsoft.com/l/meetup-join/example2" } },
+        { id: "sample-roadmap", title: "Quarterly Roadmap Workshop", date: "Jul 27", datetime: "2026-07-27T10:00:00-05:00", marker: "needed" }
       ]
     }
   },
@@ -121,9 +121,11 @@ var STATE_CLASS = {
 var STAR_GLYPH = "★";
 
 // Prep-marker states. Meetings arrive "needed" (unprepared) and the user toggles
-// each to "set" (all set). Persistence is a follow-up — the toggle is in-memory
-// for now, so a refresh re-reads the model's default state.
+// each to "set" (all set). The flip is optimistic in the UI and POSTed to the
+// backend, which stores it by event id — so a cache reload re-reads the saved
+// state, not the model default (see prepMarkerButton / savePrepMarker).
 var MARKER_SET = "set";
+var MARKER_NEEDED = "needed";
 var MARKER_SET_LABEL = "All set";
 var MARKER_NEEDED_LABEL = "Prep still needed";
 
@@ -252,10 +254,26 @@ function workItemRow(wi) {
 // The prep marker is a real toggle button: aria-pressed carries the state (and
 // drives the chip color in CSS), the visible text is its accessible name, and
 // every flip is announced through the shared aria-live region so a screen reader
-// hears which meeting changed. State lives on the button only (persistence is a
-// follow-up), so a re-render resets it to the model's default.
+// hears which meeting changed. The flip is optimistic and then persisted by
+// event id, so it survives a cache reload; if the save fails the button reverts.
 function markerText(pressed) {
   return pressed ? MARKER_SET_LABEL : MARKER_NEEDED_LABEL;
+}
+
+function setMarkerPressed(btn, pressed) {
+  btn.setAttribute("aria-pressed", pressed ? "true" : "false");
+  btn.textContent = markerText(pressed);
+}
+
+// Persist one meeting's marker to the backend so it outlives the tile cache.
+// Returns the fetch promise; the caller reverts the optimistic flip on reject.
+function savePrepMarker(id, pressed) {
+  var marker = pressed ? MARKER_SET : MARKER_NEEDED;
+  return fetchJson(API + WEEK_TILE + "/prep-marker", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Accept": "application/json" },
+    body: JSON.stringify({ id: id, marker: marker })
+  });
 }
 
 
@@ -271,11 +289,28 @@ function prepMarkerButton(item) {
 
   btn.addEventListener("click", function () {
     var next = btn.getAttribute("aria-pressed") !== "true";
-    btn.setAttribute("aria-pressed", next ? "true" : "false");
-    btn.textContent = markerText(next);
+    setMarkerPressed(btn, next);
 
     var label = item.title || "This item";
     announce(label + (next ? " marked all set." : " marked prep still needed."));
+
+    // Only persist rows backed by the live server: they carry a real event id
+    // and the week tile loaded from the backend, not the offline sample model.
+    // In sample mode the toggle stays an in-memory preview, as it was before.
+    if (!item.id || !tileFromBackend.week) {
+      return;
+    }
+
+    btn.disabled = true;
+    savePrepMarker(item.id, next)
+      .then(function () {
+        btn.disabled = false;
+      })
+      .catch(function () {
+        setMarkerPressed(btn, !next);
+        btn.disabled = false;
+        announce(label + " — couldn't save, change reverted.");
+      });
   });
 
   return btn;
@@ -540,6 +575,12 @@ function setStale(key, data) {
 // ---------------------------------------------------------------------------
 
 var API = "/api/tiles/";
+var WEEK_TILE = "week";
+
+// Which tiles this session actually loaded from the backend (vs. the offline
+// sample fallback). The prep-marker POST only fires for backend-backed rows, so
+// an offline preview toggles in-memory instead of trying — and failing — to save.
+var tileFromBackend = {};
 
 function fetchJson(url, options) {
   return fetch(url, options).then(function (res) {
@@ -560,10 +601,12 @@ function paintTile(key, model, data) {
 function loadTile(key) {
   return fetchJson(API + key, { headers: { "Accept": "application/json" } })
     .then(function (data) {
+      tileFromBackend[key] = true;
       paintTile(key, data.items || {}, data);
       return true;
     })
     .catch(function () {
+      tileFromBackend[key] = false;
       paintTile(key, MODEL[key], null);
       return false;
     });
@@ -624,6 +667,7 @@ function refreshTile(btn) {
 
   return fetchJson(API + key + "/refresh", { method: "POST", headers: { "Accept": "application/json" } })
     .then(function (data) {
+      tileFromBackend[key] = true;
       paintTile(key, data.items || {}, data);
       rememberOpenState();
       applyFilter(searchBox.value);

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -316,7 +316,7 @@ function prepMarkerButton(item) {
     announce(label + (next ? " marked all set." : " marked prep still needed."));
 
     // Only persist rows backed by the live server: they carry a real event id
-    // and the week tile loaded from the backend, not the offline sample model.
+    // and the prep tile loaded from the backend, not the offline sample model.
     // In sample mode the toggle stays an in-memory preview, as it was before.
     if (!item.id || !tileFromBackend.prep) {
       return;

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -593,6 +593,7 @@ details[open] > summary > .chev { transform: rotate(90deg); }
   background: color-mix(in srgb, var(--good) 15%, transparent);
 }
 .prep .marker:hover { border-color: currentColor; }
+.prep .marker[aria-disabled="true"] { cursor: progress; opacity: .6; }
 @media (prefers-reduced-motion: reduce) {
   .prep .marker { transition: none; }
 }

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -768,13 +768,13 @@ function Initialize-AzDevOpsDailyViewerCache {
 # ---------------------------------------------------------------------------
 # Prep "all set" marker store — durable per-project toggle state
 #
-# The week tile's prep rows carry an "all set" / "prep still needed" marker the
+# The prep tile's rows carry an "all set" / "prep still needed" marker the
 # viewer flips per meeting. That choice has to outlive a cache reload, so it
 # lives in its own tiny JSON file beside the tile cache (the set of "all set"
 # event ids), keyed by the stable Outlook event id. It sits under the same
 # active-project cache slice as the tiles, so it follows az-Use-AzDevOpsProject
 # and never leaks one project's choices into another. The read path overlays it
-# onto the week payload, so the store — not the tile cache — is the single
+# onto the prep payload, so the store — not the tile cache — is the single
 # source of truth for markers.
 # ---------------------------------------------------------------------------
 

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -1009,7 +1009,19 @@ function Read-AzDevOpsDailyViewerRequestJson {
 
     $maxBytes = $script:AzDevOpsDailyViewerMaxRequestBytes
 
-    if ($Request.ContentLength64 -gt $maxBytes) {
+    # A chunked / unknown-length body reports ContentLength64 -1 and would skip
+    # the size guard (ReadToEnd would buffer it all first), so reject it up front
+    # along with anything over the cap.
+    if ($Request.ContentLength64 -lt 0 -or $Request.ContentLength64 -gt $maxBytes) {
+        return $null
+    }
+
+    # Require a JSON content type. Beyond correctness this blunts cross-site POSTs:
+    # a browser can't set application/json cross-origin without a preflight this
+    # loopback server never satisfies, so a simple-request forgery can't reach the
+    # store — it lands here as a rejected body instead.
+    $contentType = [string]$Request.ContentType
+    if ($contentType -notlike '*application/json*') {
         return $null
     }
 

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -31,6 +31,10 @@ $script:AzDevOpsDailyViewerLoopbackAddress = '127.0.0.1'
 $script:AzDevOpsDailyViewerJsonDepth       = 10      # nesting the tile payloads / API responses serialize to
 $script:AzDevOpsDailyViewerPrepWindowDays  = 14      # "events to prepare for" look-ahead: the next two weeks
 $script:AzDevOpsDailyViewerMarkerNeeded    = 'needed'  # a newly-pulled meeting starts "prep still needed"
+$script:AzDevOpsDailyViewerMarkerSet       = 'set'     # the viewer toggled this meeting to "all set"
+$script:AzDevOpsDailyViewerWeekTile        = 'week'    # the tile whose prep list carries the toggle
+$script:AzDevOpsDailyViewerMarkerStoreFile = 'prep-markers.json'  # durable "all set" ids, beside the tile cache
+$script:AzDevOpsDailyViewerMaxRequestBytes = 4096      # cap on an API request body (the marker POST is tiny)
 
 # Strict Content-Security-Policy for the served app. The page loads styles.css +
 # app.js as external same-origin assets and fetches /api/tiles/* same-origin;
@@ -381,14 +385,16 @@ function Get-AzDevOpsDailyViewerAgendaItems {
 function Get-AzDevOpsDailyViewerPrepItems {
     # "Events to prepare for" = the next two weeks of meetings, widened from
     # today so nothing on the calendar sneaks up unprepared. Each row carries a
-    # short date chip, the meeting's ISO datetime, a default "prep still needed"
-    # marker the viewer can toggle to "all set", and a Teams join link when the
-    # meeting has one. Durable marker state is a follow-up — the model ships the
-    # default and the page owns the toggle.
+    # stable event id, a short date chip, the meeting's ISO datetime, a default
+    # "prep still needed" marker, and a Teams join link when the meeting has one.
+    # The builder always writes the default marker; the durable "all set" choice
+    # is overlaid by id on the way out (see Set-AzDevOpsDailyViewerPrepMarkersFromStore)
+    # so it survives a cache reload.
     $events = @(Get-AzDevOpsDailyViewerAgendaEvents -Days $script:AzDevOpsDailyViewerPrepWindowDays)
 
     $prep = @($events | ForEach-Object {
         $node = [ordered]@{
+            id       = [string]$_.Id
             title    = [string]$_.Subject
             date     = Format-AzDevOpsDailyViewerShortDate -When $_.Start
             datetime = $_.Start.ToString('o')
@@ -709,6 +715,14 @@ function Read-AzDevOpsDailyViewerTile {
         $null
     }
 
+    # The week tile's prep markers live in their own store, not the tile cache,
+    # so a toggle survives a reload without a re-query. Overlay it here — the one
+    # seam both the cheap GET and the POST /refresh return through (refresh ends
+    # by re-reading) — so every response reflects the marker the user last chose.
+    if ($Tile -eq $script:AzDevOpsDailyViewerWeekTile) {
+        Set-AzDevOpsDailyViewerPrepMarkersFromStore -Items $items
+    }
+
     $model = [ordered]@{
         tile       = $Tile
         writtenAt  = $writtenAt
@@ -732,6 +746,133 @@ function Initialize-AzDevOpsDailyViewerCache {
 
         if ($path -and -not (Test-Path -LiteralPath $path)) {
             $null = Write-AzDevOpsDailyViewerTile -Tile $name
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Prep "all set" marker store — durable per-project toggle state
+#
+# The week tile's prep rows carry an "all set" / "prep still needed" marker the
+# viewer flips per meeting. That choice has to outlive a cache reload, so it
+# lives in its own tiny JSON file beside the tile cache (the set of "all set"
+# event ids), keyed by the stable Outlook event id. It sits under the same
+# active-project cache slice as the tiles, so it follows az-Use-AzDevOpsProject
+# and never leaks one project's choices into another. The read path overlays it
+# onto the week payload, so the store — not the tile cache — is the single
+# source of truth for markers.
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsDailyViewerMarkerStorePath {
+    $dir = Get-AzDevOpsDailyViewerCacheDir
+    if (-not $dir) {
+        return $null
+    }
+
+    $path = Join-Path $dir $script:AzDevOpsDailyViewerMarkerStoreFile
+    return $path
+}
+
+
+function Read-AzDevOpsDailyViewerMarkerStore {
+    # The set of "all set" event ids as a hashtable used as a set (id -> $true),
+    # so callers test membership with .ContainsKey. Fails soft to an empty set
+    # when the file is missing or unreadable — a corrupt store never blocks a
+    # render, it just falls back to "nothing marked".
+    $set = @{}
+
+    $path = Get-AzDevOpsDailyViewerMarkerStorePath
+    if (-not $path -or -not (Test-Path -LiteralPath $path)) {
+        return $set
+    }
+
+    try {
+        $raw = Get-Content -LiteralPath $path -Raw
+        $record = $raw | ConvertFrom-Json
+
+        foreach ($id in @($record.setIds)) {
+            $key = [string]$id
+            if ($key) {
+                $set[$key] = $true
+            }
+        }
+    }
+    catch {
+        return @{}
+    }
+
+    return $set
+}
+
+
+function Save-AzDevOpsDailyViewerMarkerStore {
+    # Persist the "all set" id set wholesale — the set is small and the write is
+    # atomic through Write-AzDevOpsCacheFile. Throws when there's no active cache
+    # dir so the POST handler can answer rather than silently drop the toggle.
+    param([Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $SetIds)
+
+    $path = Get-AzDevOpsDailyViewerMarkerStorePath
+    if (-not $path) {
+        throw "Save-AzDevOpsDailyViewerMarkerStore: no active cache dir (run az-Connect-AzDevOps first)."
+    }
+
+    $dir = Split-Path -Parent $path
+    New-AzDevOpsDirectoryIfMissing -Path $dir
+
+    $record = [ordered]@{
+        setIds    = @($SetIds)
+        updatedAt = (Get-Date).ToString('o')
+    }
+
+    $json = $record | ConvertTo-Json -Depth $script:AzDevOpsDailyViewerJsonDepth
+    Write-AzDevOpsCacheFile -Path $path -Content $json
+}
+
+
+function Set-AzDevOpsDailyViewerPrepMarker {
+    # Flip one meeting's durable marker: add its id to the "all set" set, or drop
+    # it back to "prep still needed". Returns the marker that was stored so the
+    # caller can echo it back to the client.
+    param(
+        [Parameter(Mandatory)] [string] $Id,
+        [Parameter(Mandatory)] [string] $Marker
+    )
+
+    $store = Read-AzDevOpsDailyViewerMarkerStore
+
+    if ($Marker -eq $script:AzDevOpsDailyViewerMarkerSet) {
+        $store[$Id] = $true
+    } else {
+        $store.Remove($Id)
+    }
+
+    $ids = @($store.Keys)
+    Save-AzDevOpsDailyViewerMarkerStore -SetIds $ids
+
+    return $Marker
+}
+
+
+function Set-AzDevOpsDailyViewerPrepMarkersFromStore {
+    # Overlay the durable "all set" set onto a week payload's prep rows in place,
+    # so the marker the user last chose wins over the default the builder wrote.
+    # No-op when the payload has no prep list (an empty or legacy cache).
+    param([Parameter(Mandatory)] [AllowNull()] $Items)
+
+    if ($null -eq $Items -or $null -eq $Items.prep -or $null -eq $Items.prep.items) {
+        return
+    }
+
+    $store = Read-AzDevOpsDailyViewerMarkerStore
+
+    foreach ($item in @($Items.prep.items)) {
+        $id = [string]$item.id
+
+        $item.marker = if ($id -and $store.ContainsKey($id)) {
+            $script:AzDevOpsDailyViewerMarkerSet
+        } else {
+            $script:AzDevOpsDailyViewerMarkerNeeded
         }
     }
 }
@@ -859,9 +1000,46 @@ function Write-AzDevOpsDailyViewerError {
 # Request routing — cheap GET vs expensive POST /refresh kept distinct
 # ---------------------------------------------------------------------------
 
+function Read-AzDevOpsDailyViewerRequestJson {
+    # Parse a small JSON request body, bounded so a runaway/oversized POST can't
+    # exhaust memory. Returns the parsed object, or $null when the body is too
+    # large, empty, or not valid JSON — the caller answers 400 on $null. The
+    # store is never touched here, so a rejected body can't corrupt it.
+    param([Parameter(Mandatory)] [System.Net.HttpListenerRequest] $Request)
+
+    $maxBytes = $script:AzDevOpsDailyViewerMaxRequestBytes
+
+    if ($Request.ContentLength64 -gt $maxBytes) {
+        return $null
+    }
+
+    $reader = New-Object System.IO.StreamReader($Request.InputStream, $Request.ContentEncoding)
+    try {
+        $text = $reader.ReadToEnd()
+    }
+    finally {
+        $reader.Dispose()
+    }
+
+    if (-not $text -or $text.Length -gt $maxBytes) {
+        return $null
+    }
+
+    try {
+        $parsed = $text | ConvertFrom-Json
+    }
+    catch {
+        return $null
+    }
+
+    return $parsed
+}
+
+
 function Get-AzDevOpsDailyViewerTileRoute {
-    # Parse an /api/tiles/... path into { Tile; IsRefresh } or $null when it
-    # isn't a tile route. Keeps the router readable and the two API verbs apart.
+    # Parse an /api/tiles/... path into { Tile; IsRefresh; IsPrepMarker } or
+    # $null when it isn't a tile route. Keeps the router readable and the API
+    # verbs (cheap GET, expensive refresh, prep-marker write) apart.
     param([Parameter(Mandatory)] [string] $Path)
 
     $prefix = '/api/tiles/'
@@ -877,16 +1055,18 @@ function Get-AzDevOpsDailyViewerTileRoute {
     $segments = $rest -split '/'
     $tile = $segments[0]
 
-    $isRefresh = ($segments.Count -eq 2 -and $segments[1] -eq 'refresh')
-    $isPlain   = ($segments.Count -eq 1)
+    $isRefresh    = ($segments.Count -eq 2 -and $segments[1] -eq 'refresh')
+    $isPrepMarker = ($segments.Count -eq 2 -and $segments[1] -eq 'prep-marker')
+    $isPlain      = ($segments.Count -eq 1)
 
-    if (-not $isRefresh -and -not $isPlain) {
+    if (-not $isRefresh -and -not $isPrepMarker -and -not $isPlain) {
         return $null
     }
 
     $route = [PSCustomObject]@{
-        Tile      = $tile
-        IsRefresh = $isRefresh
+        Tile         = $tile
+        IsRefresh    = $isRefresh
+        IsPrepMarker = $isPrepMarker
     }
     return $route
 }
@@ -915,6 +1095,31 @@ function Invoke-AzDevOpsDailyViewerApiRequest {
 
         $model = Write-AzDevOpsDailyViewerTile -Tile $Route.Tile
         Write-AzDevOpsDailyViewerJson -Response $response -StatusCode 200 -Object $model
+        return
+    }
+
+    if ($Route.IsPrepMarker) {
+        if ($method -ne 'POST') {
+            Write-AzDevOpsDailyViewerError -Response $response -StatusCode 405 -Message 'Prep marker requires POST.'
+            return
+        }
+
+        $payload = Read-AzDevOpsDailyViewerRequestJson -Request $request
+
+        $id     = [string]$payload.id
+        $marker = [string]$payload.marker
+
+        $isKnownMarker = ($marker -eq $script:AzDevOpsDailyViewerMarkerSet -or $marker -eq $script:AzDevOpsDailyViewerMarkerNeeded)
+
+        if (-not $id -or -not $isKnownMarker) {
+            Write-AzDevOpsDailyViewerError -Response $response -StatusCode 400 -Message 'Prep marker needs an id and a marker of "set" or "needed".'
+            return
+        }
+
+        $stored = Set-AzDevOpsDailyViewerPrepMarker -Id $id -Marker $marker
+
+        $ack = [ordered]@{ id = $id; marker = $stored }
+        Write-AzDevOpsDailyViewerJson -Response $response -StatusCode 200 -Object $ack
         return
     }
 

--- a/powcuts_by_cli/outlook_agenda.ps1
+++ b/powcuts_by_cli/outlook_agenda.ps1
@@ -219,10 +219,13 @@ function Get-OutlookAppointmentId {
     # callers (the daily viewer's prep markers) can pin per-meeting state across
     # cache reloads. GlobalAppointmentID is preferred — it survives a rename or
     # reschedule and is identical across the organizer/attendee copies; EntryID
-    # is the fallback when the global id is unreadable. Each COM read is wrapped
-    # so a transient fault fails soft to the next candidate (and ultimately
-    # $null) rather than aborting the agenda pull. Unapproved verb is fine — not
-    # user-facing.
+    # is the fallback when the global id is unreadable. Note it is series-level:
+    # every occurrence of a recurring meeting shares one id, so marking one
+    # occurrence "all set" marks the series within the prep window — acceptable
+    # for the current two-week look-ahead; per-occurrence markers would be a
+    # follow-up. Each COM read is wrapped so a transient fault fails soft to the
+    # next candidate (and ultimately $null) rather than aborting the agenda pull.
+    # Unapproved verb is fine — not user-facing.
     param([Parameter(Mandatory)] $Appointment)
 
     $candidates = @('GlobalAppointmentID', 'EntryID')

--- a/powcuts_by_cli/outlook_agenda.ps1
+++ b/powcuts_by_cli/outlook_agenda.ps1
@@ -214,6 +214,36 @@ function Get-OutlookMeetingJoinUrl {
 }
 
 
+function Get-OutlookAppointmentId {
+    # Private. A stable identifier for a calendar appointment so downstream
+    # callers (the daily viewer's prep markers) can pin per-meeting state across
+    # cache reloads. GlobalAppointmentID is preferred — it survives a rename or
+    # reschedule and is identical across the organizer/attendee copies; EntryID
+    # is the fallback when the global id is unreadable. Each COM read is wrapped
+    # so a transient fault fails soft to the next candidate (and ultimately
+    # $null) rather than aborting the agenda pull. Unapproved verb is fine — not
+    # user-facing.
+    param([Parameter(Mandatory)] $Appointment)
+
+    $candidates = @('GlobalAppointmentID', 'EntryID')
+
+    foreach ($prop in $candidates) {
+        try {
+            $value = [string]$Appointment.$prop
+        }
+        catch {
+            $value = ''
+        }
+
+        if ($value) {
+            return $value
+        }
+    }
+
+    return $null
+}
+
+
 function ol-Get-OutlookAgenda {
     # Calendar events (recurrences expanded) as objects, from $Date's day start
     # through $Days days later. -Days defaults to 1 (today only), so the daily
@@ -253,8 +283,10 @@ function ol-Get-OutlookAgenda {
     foreach ($appointment in $restricted) {
         $responseText = ConvertFrom-OutlookResponseStatus -Status ([int]$appointment.ResponseStatus)
         $joinUrl = Get-OutlookMeetingJoinUrl -Appointment $appointment
+        $eventId = Get-OutlookAppointmentId -Appointment $appointment
 
         $row = [PSCustomObject]@{
+            Id             = $eventId
             Start          = $appointment.Start
             End            = $appointment.End
             Subject        = $appointment.Subject


### PR DESCRIPTION
<!-- toc:start -->
## Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #207 |
| [Changes](#changes) | ✅ 5 files |
| [Test Plan](#test-plan) | ✅ 4 checks |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4994127567) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4994150713) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4994146489) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4994143542) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](#issuecomment-4994143763) |
| ✅ Criteria Check | ✅ PASS (7/8, 8th is reviewer gate) — [View](#issuecomment-4994202667) |
| 📄 Docs Check | ✅ CURRENT — [View](#issuecomment-4994199443) |
| 📐 AzDO Diagrams Check | ✅ CURRENT — [View](#issuecomment-4994221173) |
| 💠 PowerShell Engineer Review (post-merge re-review) | ✅ APPROVE — [View](#issuecomment-4994427286) |
| 🎨 Front-End Engineer Review (post-merge re-review) | ✅ APPROVE — [View](#issuecomment-4994419300) |

_All reviews non-blocking — no HIGH/CRITICAL findings._
<!-- toc:end -->


<!-- pr-diagram:start -->
## How it works

The browser toggles a meeting to **All set** optimistically (`setMarkerPressed`) and, only for backend-backed rows (`item.id` and `tileFromBackend.prep`), POSTs the flip to `POST /api/tiles/prep/prep-marker` (`savePrepMarker`), reverting with an `aria-live` announcement if the save fails. The backend router recognizes the prep-marker action (`IsPrepMarker`), reads a bounded JSON-only body, and writes the id into `prep-markers.json` via `Set-AzDevOpsDailyViewerPrepMarker`. Durability comes from the read seam: every prep fetch — the cheap `GET /api/tiles/prep` and the `POST /refresh` alike — flows through `Read-AzDevOpsDailyViewerTile`, which overlays the store onto the new prep tile&#39;s flat `{ items }` payload (`Get-AzDevOpsDailyViewerPrepTileItems`) so the marker survives a reload. The store key is the stable Outlook id from `Get-OutlookAppointmentId`.

```mermaid
flowchart TD
    Click([prep toggle click]):::pub
    Optim[&#34;setMarkerPressed<br/>(optimistic flip)&#34;]
    Gate{&#34;item.id and<br/>tileFromBackend.prep?&#34;}
    Sample[&#34;in-memory only<br/>(offline sample)&#34;]
    Save[&#34;savePrepMarker<br/>POST /api/tiles/prep/prep-marker&#34;]:::pub

    Router{&#34;route parser<br/>IsPrepMarker?&#34;}
    Api[Invoke-AzDevOpsDailyViewerApiRequest]:::priv
    ReadReq[&#34;Read-AzDevOpsDailyViewerRequestJson<br/>(bounded, JSON-only)&#34;]:::priv
    SetMark[Set-AzDevOpsDailyViewerPrepMarker]:::priv
    Store[(prep-markers.json)]:::io
    Revert[&#34;revert flip +<br/>aria-live announce&#34;]

    GET([GET /api/tiles/prep]):::pub
    Refresh([POST /api/tiles/prep/refresh]):::pub
    PrepTile[&#34;Get-AzDevOpsDailyViewerPrepTileItems<br/>(flat items payload)&#34;]:::priv
    ReadTile[Read-AzDevOpsDailyViewerTile]:::pub
    Overlay[&#34;Set-AzDevOpsDailyViewerPrepMarkersFromStore<br/>(overlay store onto prep payload)&#34;]:::priv
    OutlookId[&#34;Get-OutlookAppointmentId<br/>(stable store key)&#34;]:::priv

    Click --&gt; Optim --&gt; Gate
    Gate -- no --&gt; Sample
    Gate -- yes --&gt; Save --&gt; Router
    Router -- yes --&gt; Api --&gt; ReadReq --&gt; SetMark
    SetMark --&gt; Store
    Save -. save fails .-&gt; Revert

    GET --&gt; ReadTile
    Refresh --&gt; PrepTile --&gt; ReadTile
    ReadTile --&gt; Overlay
    Store -. overlaid by id .-&gt; Overlay
    OutlookId -. supplies id .-&gt; PrepTile

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->


## Summary

The daily viewer&#39;s &#34;Events to prepare for&#34; tile lets you toggle each meeting to **&#34;All set&#34;**, but that state only lived on the button in the browser. Any reload of the events — a per-tile refresh, refresh-all, or a page reload — rebuilt the prep rows from the server payload (which always defaulted to &#34;prep still needed&#34;) and silently discarded the choice.

This makes the marker durable, keyed by a stable Outlook event id, so a meeting you mark &#34;all set&#34; stays that way across a cache reload. It&#39;s the follow-up #201 explicitly deferred.

## Issue

Closes #207

## Changes

- **`powcuts_by_cli/outlook_agenda.ps1`** — new `Get-OutlookAppointmentId` helper + a stable `Id` on every agenda row (`GlobalAppointmentID`, falling back to `EntryID`), so a meeting can be pinned across reloads even after a rename or reschedule.
- **`powcuts_by_cli/daily_viewer.ps1`** — prep nodes carry that `id`; a small `prep-markers.json` beside the tile cache holds the set of &#34;all set&#34; ids under the active project slice; `Read-AzDevOpsDailyViewerTile` overlays it onto the prep payload — the one seam both the cheap GET and the `POST /refresh` return through — so the store, not the tile cache, is the source of truth. A new `POST /api/tiles/prep/prep-marker` persists a single toggle, with a bounded request-body reader so an oversized/malformed body is rejected without touching the store.
- **`daily-viewer/app.js`** — prep rows POST the flip optimistically and revert (with an `aria-live` announcement) if the save fails; the POST only fires for backend-backed rows, so an offline sample-data preview still toggles in-memory.
- **`README.md`** — documents the new endpoint and that the choice now persists.

## Test Plan

Front-end verified end-to-end in Chromium against the API contract (toggle persists across tile refresh and full page reload; toggle-back persists; a forced save-failure reverts + announces). `node --check daily-viewer/app.js` clean. `pwsh` is not available in the CI sandbox, so the PowerShell parse gate was skipped — the backend was reviewed by hand (no `Set-StrictMode`, output-clean returns, normalized JSON round-trips).

On a Windows box with desktop Outlook + `az login`:

- [ ] `az-Start-AzDevOpsDailyViewer` — open a fresh PowerShell first so the profile dot-sources the changed `.ps1` files with no parse warnings.
- [ ] On **This Week&#39;s Focus**, mark a meeting **All set**, click the tile&#39;s refresh, then hard-reload the page — it stays **All set**.
- [ ] A `prep-markers.json` appears under `…/cache//daily-viewer/`.
- [ ] Toggle the meeting back to **Prep still needed**, reload — it stays reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4mootgmMJ62T3sEvfNjB6

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mootgmMJ62T3sEvfNjB6)_
