### PR TITLE
Add 30-day window and dismissible reviewed/prepped state to daily-viewer

### DIFF
--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -12,6 +12,16 @@
 // live `az boards` / Outlook output is a data change, not markup surgery.
 // ---------------------------------------------------------------------------
 
+var MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Sample activity timestamps are expressed relative to "now" so the 30-day
+// window demonstrates itself whenever the mock is opened: the six-week-old row
+// is always filtered out and the rest always land inside the window. Live data
+// ships real ISO dates from the server, so this helper is sample-only.
+function daysAgoISO(days) {
+  return new Date(Date.now() - days * MS_PER_DAY).toISOString();
+}
+
 var MODEL = {
   agenda: {
     events: [
@@ -73,24 +83,25 @@ var MODEL = {
         label: "Tagged discussions",
         open: true,
         items: [
-          { type: "Feature", id: 1180, url: "https://dev.azure.com/org/project/_workitems/edit/1180", title: "@you — “can you confirm the WIQL scope?”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1180?discussion", priority: 2, note: "1d ago" },
-          { type: "Story", id: 1240, url: "https://dev.azure.com/org/project/_workitems/edit/1240", title: "@you — “ready for review whenever”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1240?discussion", priority: 3, note: "3h ago" }
+          { type: "Feature", id: 1180, url: "https://dev.azure.com/org/project/_workitems/edit/1180", title: "@you — “can you confirm the WIQL scope?”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1180?discussion", priority: 2, note: "1d ago", changedDate: daysAgoISO(1) },
+          { type: "Story", id: 1240, url: "https://dev.azure.com/org/project/_workitems/edit/1240", title: "@you — “ready for review whenever”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1240?discussion", priority: 3, note: "3h ago", changedDate: daysAgoISO(0) }
         ]
       },
       {
         label: "Active story updates",
         open: false,
         items: [
-          { type: "Story", id: 1234, url: "https://dev.azure.com/org/project/_workitems/edit/1234", title: "State → In progress by A. Rivera", note: "2h ago" },
-          { type: "Bug", id: 1251, url: "https://dev.azure.com/org/project/_workitems/edit/1251", title: "Moved to In review", note: "4h ago" }
+          { type: "Story", id: 1234, url: "https://dev.azure.com/org/project/_workitems/edit/1234", title: "State → In progress by A. Rivera", note: "2h ago", changedDate: daysAgoISO(0) },
+          { type: "Bug", id: 1251, url: "https://dev.azure.com/org/project/_workitems/edit/1251", title: "Moved to In review", note: "4h ago", changedDate: daysAgoISO(0) },
+          { type: "Story", id: 1188, url: "https://dev.azure.com/org/project/_workitems/edit/1188", title: "Closed after release cut", note: "6w ago", changedDate: daysAgoISO(45) }
         ]
       },
       {
         label: "Current sprint",
         open: false,
         items: [
-          { type: "Task", id: 1209, url: "https://dev.azure.com/org/project/_workitems/edit/1209", title: "Update release notes", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1209", state: "In progress", priority: 2, note: "2h ago" },
-          { type: "Story", id: 1222, url: "https://dev.azure.com/org/project/_workitems/edit/1222", title: "Verify acceptance criteria signed off", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1222", state: "Active", priority: 1, note: "1d ago" }
+          { type: "Task", id: 1209, url: "https://dev.azure.com/org/project/_workitems/edit/1209", title: "Update release notes", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1209", state: "In progress", priority: 2, note: "2h ago", changedDate: daysAgoISO(0) },
+          { type: "Story", id: 1222, url: "https://dev.azure.com/org/project/_workitems/edit/1222", title: "Verify acceptance criteria signed off", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1222", state: "Active", priority: 1, note: "1d ago", changedDate: daysAgoISO(1) }
         ]
       }
     ]
@@ -139,6 +150,156 @@ var MARKER_SET = "set";
 var MARKER_NEEDED = "needed";
 var MARKER_SET_LABEL = "All set";
 var MARKER_NEEDED_LABEL = "Prep still needed";
+
+
+// Dismissal is a separate action from the prep marker above: the marker records
+// whether a meeting is prepped (and stays in the list), while dismissal removes
+// a handled row entirely. Recent updates get a "reviewed" dismissal; prep rows
+// get a "remove" dismissal alongside their marker. Both are the same pill-toggle
+// control — only the words and the bucket differ. Pressed means "handled".
+var REVIEW_LABELS = { off: "Mark reviewed", on: "Reviewed" };
+var PREP_DISMISS_LABELS = { off: "Remove", on: "Removed" };
+
+// Recent updates only surface activity from the last 30 days.
+var ACTIVITY_WINDOW_DAYS = 30;
+
+// When true, dismissed rows stay visible (dimmed, with an undo control) instead
+// of being filtered out — the toolbar's "Show reviewed" toggle flips this.
+var showReviewed = false;
+
+
+// ---------------------------------------------------------------------------
+// Dismissal store — "reviewed" recent updates and "removed" prep items persist
+// here so a handled item stays gone across refresh and reload. State is keyed by
+// item identity and namespaced by bucket; a recent update reappears only if it
+// changed after the moment it was reviewed (an inbox, not a permanent blocklist).
+// This is separate from the prep marker (which persists to the backend by id);
+// it's the client-side seam — swap localStorage for the server cache later and
+// nothing above this block has to change.
+// ---------------------------------------------------------------------------
+
+var DISMISS_STORE_KEY = "dailyViewer.dismissed.v1";
+
+var dismissStore = {
+  _load: function () {
+    try {
+      var raw = window.localStorage.getItem(DISMISS_STORE_KEY);
+      var parsed = raw ? JSON.parse(raw) : null;
+      if (parsed && typeof parsed === "object") {
+        return parsed;
+      }
+    } catch (err) {
+      // Corrupt or blocked storage — start clean rather than throw on boot.
+    }
+
+    return {};
+  },
+
+  _save: function (data) {
+    try {
+      window.localStorage.setItem(DISMISS_STORE_KEY, JSON.stringify(data));
+    } catch (err) {
+      // Storage full or blocked (private mode) — dismissal degrades to
+      // in-memory for this session instead of breaking the toggle.
+    }
+  },
+
+  _bucket: function (data, bucket) {
+    if (!data[bucket] || typeof data[bucket] !== "object") {
+      data[bucket] = {};
+    }
+
+    return data[bucket];
+  },
+
+  isDismissed: function (bucket, key, changedDate) {
+    var map = this._bucket(this._load(), bucket);
+    if (!Object.prototype.hasOwnProperty.call(map, key)) {
+      return false;
+    }
+
+    // Reappear when the item changed after it was reviewed (inbox model).
+    if (changedDate) {
+      var changed = Date.parse(changedDate);
+      var reviewed = Date.parse(map[key]);
+      if (!isNaN(changed) && !isNaN(reviewed) && changed > reviewed) {
+        return false;
+      }
+    }
+
+    return true;
+  },
+
+  dismiss: function (bucket, key) {
+    var data = this._load();
+    this._bucket(data, bucket)[key] = new Date().toISOString();
+    this._save(data);
+  },
+
+  restore: function (bucket, key) {
+    var data = this._load();
+    delete this._bucket(data, bucket)[key];
+    this._save(data);
+  }
+};
+
+
+// Identity keys for the two buckets. Both prefer a stable id (recent updates by
+// work-item id, prep by the event id #207 added for its marker); prep falls back
+// to title + time when the sample row carries no id.
+function activityKey(item) {
+  return String(item.id != null ? item.id : (item.title || ""));
+}
+
+function prepKey(item) {
+  if (item.id != null) {
+    return String(item.id);
+  }
+
+  return (item.title || "") + "|" + (item.datetime || item.date || "");
+}
+
+
+// Per-bucket config: the single source of truth for BOTH the filter and the
+// dismiss button. Filtering reads windowed/keyOf/changedOf; the button reads
+// className/labels/tileKey and builds its announcements from the row label.
+// Keeping the bucket name and its behavior in one object is what lets the
+// "activity"/"prep" string live in exactly one place.
+var ACTIVITY_SPEC = {
+  bucket: "activity",
+  windowed: true,
+  keyOf: activityKey,
+  changedOf: function (item) {
+    return item.changedDate;
+  },
+  className: "pill-toggle review",
+  labels: REVIEW_LABELS,
+  tileKey: "activity",
+  doneMessage: function (label) {
+    return label + " marked reviewed.";
+  },
+  undoMessage: function (label) {
+    return label + " restored to recent updates.";
+  }
+};
+
+var PREP_DISMISS_SPEC = {
+  bucket: "prep",
+  windowed: false,
+  keyOf: prepKey,
+  changedOf: function () {
+    return null;
+  },
+  className: "pill-toggle dismiss",
+  labels: PREP_DISMISS_LABELS,
+  tileKey: "prep",
+  doneMessage: function (label) {
+    return label + " removed from prep.";
+  },
+  undoMessage: function (label) {
+    return label + " restored to prep.";
+  }
+};
 
 
 // ---------------------------------------------------------------------------
@@ -262,6 +423,79 @@ function workItemRow(wi) {
 }
 
 
+// Both dismiss controls are the same pill: aria-pressed is the state, the
+// visible text is the action, and an aria-label folds in the item title so a
+// screen reader can tell one row's control from the next. The click hands off to
+// onToggle, which updates the store and repaints the tile — the button is rebuilt
+// from the fresh view model rather than mutating itself.
+function dismissButton(className, pressed, labels, ariaLabel, onToggle) {
+  var btn = el("button", {
+    type: "button",
+    class: className,
+    "aria-pressed": pressed ? "true" : "false",
+    "aria-label": ariaLabel,
+    text: pressed ? labels.on : labels.off
+  });
+
+  btn.addEventListener("click", onToggle);
+
+  return btn;
+}
+
+
+// Pressed means "handled" (reviewed / removed): restore brings the row back,
+// dismiss removes it. Every flip is announced through the shared aria-live
+// region so a screen reader hears which item changed, then the tile repaints.
+function applyDismissalToggle(opts) {
+  if (opts.pressed) {
+    dismissStore.restore(opts.bucket, opts.key);
+    announce(opts.undoMessage);
+  } else {
+    dismissStore.dismiss(opts.bucket, opts.key);
+    announce(opts.doneMessage);
+  }
+
+  repaintTile(opts.tileKey);
+}
+
+
+// One builder for both dismiss controls, driven by the bucket spec — the review
+// toggle and the prep remove differ only in that data, so they share this body.
+function dismissToggleButton(item, spec) {
+  var pressed = item._dismissed === true;
+  var label = item.title || "This item";
+  var ariaLabel = (pressed ? spec.labels.on : spec.labels.off) + " — " + label;
+
+  var btn = dismissButton(spec.className, pressed, spec.labels, ariaLabel, function () {
+    applyDismissalToggle({
+      bucket: spec.bucket,
+      key: spec.keyOf(item),
+      pressed: pressed,
+      tileKey: spec.tileKey,
+      doneMessage: spec.doneMessage(label),
+      undoMessage: spec.undoMessage(label)
+    });
+  });
+
+  return btn;
+}
+
+
+// A recent-update row is a work-item row plus the reviewed toggle. Dismissed
+// rows (only visible under "Show reviewed") render dimmed via .dismissed.
+function activityRow(item) {
+  var li = workItemRow(item);
+
+  if (item._dismissed) {
+    li.classList.add("dismissed");
+  }
+
+  li.appendChild(dismissToggleButton(item, ACTIVITY_SPEC));
+
+  return li;
+}
+
+
 // The prep marker is a real toggle button: aria-pressed carries the state (and
 // drives the chip color in CSS), the visible text is its accessible name, and
 // every flip is announced through the shared aria-live region so a screen reader
@@ -293,7 +527,7 @@ function prepMarkerButton(item) {
 
   var btn = el("button", {
     type: "button",
-    class: "marker",
+    class: "pill-toggle marker",
     "aria-pressed": pressed ? "true" : "false",
     text: markerText(pressed)
   });
@@ -394,8 +628,15 @@ function prepRow(item) {
   }
 
   children.push(prepMarkerButton(item));
+  children.push(dismissToggleButton(item, PREP_DISMISS_SPEC));
 
-  return el("li", { class: "wi prep" }, children);
+  var li = el("li", { class: "wi prep" }, children);
+
+  if (item._dismissed) {
+    li.classList.add("dismissed");
+  }
+
+  return li;
 }
 
 
@@ -542,7 +783,7 @@ function renderPrep(model) {
 
 function renderActivity(model) {
   return asArray(model.groups).map(function (group) {
-    return groupBlock(group, workItemRow);
+    return groupBlock(group, activityRow);
   });
 }
 
@@ -564,6 +805,87 @@ function renderFocus(model) {
 
   nodes.push(groupBlock(model.support || {}, workItemRow));
   return nodes;
+}
+
+
+// ---------------------------------------------------------------------------
+// View model — the recent-updates and prep collections are filtered before
+// render: the 30-day window and dismissed items are applied here, so the render
+// layer, the count badges, and the stat numbers all read the same post-filter
+// data and can't drift from each other.
+// ---------------------------------------------------------------------------
+
+function withinActivityWindow(item) {
+  if (!item.changedDate) {
+    return true;
+  }
+
+  var changed = Date.parse(item.changedDate);
+  if (isNaN(changed)) {
+    return true;
+  }
+
+  var cutoff = Date.now() - ACTIVITY_WINDOW_DAYS * MS_PER_DAY;
+  return changed >= cutoff;
+}
+
+
+// Drop items outside the window, then either hide dismissed items or — under
+// "show reviewed" — keep them flagged so the row can render dimmed with an undo.
+// Items are shallow-copied before flagging so the source MODEL (reused as the
+// offline fallback) is never mutated.
+function filterItems(items, spec) {
+  var out = [];
+
+  asArray(items).forEach(function (item) {
+    if (spec.windowed && !withinActivityWindow(item)) {
+      return;
+    }
+
+    var dismissed = dismissStore.isDismissed(spec.bucket, spec.keyOf(item), spec.changedOf(item));
+    if (dismissed && !showReviewed) {
+      return;
+    }
+
+    var copy = Object.assign({}, item);
+    copy._dismissed = dismissed;
+    out.push(copy);
+  });
+
+  return out;
+}
+
+
+function activityView(model) {
+  var groups = asArray(model.groups).map(function (group) {
+    var copy = Object.assign({}, group);
+    copy.items = filterItems(group.items, ACTIVITY_SPEC);
+    return copy;
+  });
+
+  return { groups: groups };
+}
+
+
+function prepView(model) {
+  var view = Object.assign({}, model);
+  view.items = filterItems(model.items, PREP_DISMISS_SPEC);
+  return view;
+}
+
+
+function viewModel(key, model) {
+  if (key === "activity") {
+    var av = activityView(model);
+    return av;
+  }
+
+  if (key === "prep") {
+    var pv = prepView(model);
+    return pv;
+  }
+
+  return model;
 }
 
 
@@ -601,6 +923,10 @@ var TILES = [
 
 var TILE_BY_KEY = {};
 TILES.forEach(function (t) { TILE_BY_KEY[t.key] = t; });
+
+// The last model + staleness each tile was painted with, so a dismissal toggle
+// or a "show reviewed" flip can repaint from data without re-fetching.
+var TILE_STATE = {};
 
 
 // ---------------------------------------------------------------------------
@@ -711,10 +1037,29 @@ function fetchJson(url, options) {
 }
 
 function paintTile(key, model, data) {
+  TILE_STATE[key] = { model: model, data: data };
+
   var conf = TILE_BY_KEY[key];
-  renderTileBody(key, model);
-  setStat(conf.stat, conf.statCount(model || {}));
+  var view = viewModel(key, model || {});
+
+  renderTileBody(key, view);
+  setStat(conf.stat, conf.statCount(view));
   setStale(key, data);
+}
+
+// Repaint a tile from its last-loaded model — after a dismissal toggle or a
+// "show reviewed" flip. Re-deriving the view model reapplies the 30-day window
+// and dismissals, then the open-state and active search filter the full render
+// dropped are restored (the same post-render fix-up the refresh path does).
+function repaintTile(key) {
+  var st = TILE_STATE[key];
+  if (!st) {
+    return;
+  }
+
+  paintTile(key, st.model, st.data);
+  rememberOpenState();
+  applyFilter(searchBox.value);
 }
 
 function loadTile(key) {
@@ -755,6 +1100,21 @@ document.getElementById("expandAll").addEventListener("click", function () {
 
 document.getElementById("collapseAll").addEventListener("click", function () {
   document.querySelectorAll(".tile > details").forEach(function (d) { d.open = false; });
+});
+
+
+// "Show reviewed" reveals dismissed rows (dimmed, with an undo) across the two
+// tiles that support dismissal — recent updates and prep — instead of filtering
+// them out.
+var showReviewedBtn = document.getElementById("showReviewed");
+showReviewedBtn.addEventListener("click", function () {
+  showReviewed = !showReviewed;
+  showReviewedBtn.setAttribute("aria-pressed", showReviewed ? "true" : "false");
+
+  repaintTile("activity");
+  repaintTile("prep");
+
+  announce(showReviewed ? "Showing reviewed and removed items." : "Hiding reviewed and removed items.");
 });
 
 

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -12,6 +12,16 @@
 // live `az boards` / Outlook output is a data change, not markup surgery.
 // ---------------------------------------------------------------------------
 
+var MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Sample activity timestamps are expressed relative to "now" so the 30-day
+// window demonstrates itself whenever the mock is opened: the six-week-old row
+// is always filtered out and the rest always land inside the window. Live data
+// ships real ISO dates from the server, so this helper is sample-only.
+function daysAgoISO(days) {
+  return new Date(Date.now() - days * MS_PER_DAY).toISOString();
+}
+
 var MODEL = {
   agenda: {
     events: [
@@ -48,10 +58,10 @@ var MODEL = {
       label: "Events to prepare for",
       open: true,
       items: [
-        { title: "Sprint Planning Sync", date: "Jul 16", datetime: "2026-07-16T09:00:00-05:00", marker: "needed" },
-        { title: "Architecture Design Review", date: "Jul 18", datetime: "2026-07-18T11:00:00-05:00", marker: "set" },
-        { title: "Cross-team API Contract Review", date: "Jul 22", datetime: "2026-07-22T14:00:00-05:00", marker: "needed", link: { text: "Join meeting", url: "https://teams.microsoft.com/l/meetup-join/example2" } },
-        { title: "Quarterly Roadmap Workshop", date: "Jul 27", datetime: "2026-07-27T10:00:00-05:00", marker: "needed" }
+        { title: "Sprint Planning Sync", date: "Jul 16", datetime: "2026-07-16T09:00:00-05:00" },
+        { title: "Architecture Design Review", date: "Jul 18", datetime: "2026-07-18T11:00:00-05:00" },
+        { title: "Cross-team API Contract Review", date: "Jul 22", datetime: "2026-07-22T14:00:00-05:00", link: { text: "Join meeting", url: "https://teams.microsoft.com/l/meetup-join/example2" } },
+        { title: "Quarterly Roadmap Workshop", date: "Jul 27", datetime: "2026-07-27T10:00:00-05:00" }
       ]
     }
   },
@@ -62,24 +72,25 @@ var MODEL = {
         label: "Tagged discussions",
         open: true,
         items: [
-          { type: "Feature", id: 1180, url: "https://dev.azure.com/org/project/_workitems/edit/1180", title: "@you — “can you confirm the WIQL scope?”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1180?discussion", priority: 2, note: "1d ago" },
-          { type: "Story", id: 1240, url: "https://dev.azure.com/org/project/_workitems/edit/1240", title: "@you — “ready for review whenever”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1240?discussion", priority: 3, note: "3h ago" }
+          { type: "Feature", id: 1180, url: "https://dev.azure.com/org/project/_workitems/edit/1180", title: "@you — “can you confirm the WIQL scope?”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1180?discussion", priority: 2, note: "1d ago", changedDate: daysAgoISO(1) },
+          { type: "Story", id: 1240, url: "https://dev.azure.com/org/project/_workitems/edit/1240", title: "@you — “ready for review whenever”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1240?discussion", priority: 3, note: "3h ago", changedDate: daysAgoISO(0) }
         ]
       },
       {
         label: "Active story updates",
         open: false,
         items: [
-          { type: "Story", id: 1234, url: "https://dev.azure.com/org/project/_workitems/edit/1234", title: "State → In progress by A. Rivera", note: "2h ago" },
-          { type: "Bug", id: 1251, url: "https://dev.azure.com/org/project/_workitems/edit/1251", title: "Moved to In review", note: "4h ago" }
+          { type: "Story", id: 1234, url: "https://dev.azure.com/org/project/_workitems/edit/1234", title: "State → In progress by A. Rivera", note: "2h ago", changedDate: daysAgoISO(0) },
+          { type: "Bug", id: 1251, url: "https://dev.azure.com/org/project/_workitems/edit/1251", title: "Moved to In review", note: "4h ago", changedDate: daysAgoISO(0) },
+          { type: "Story", id: 1188, url: "https://dev.azure.com/org/project/_workitems/edit/1188", title: "Closed after release cut", note: "6w ago", changedDate: daysAgoISO(45) }
         ]
       },
       {
         label: "Current sprint",
         open: false,
         items: [
-          { type: "Task", id: 1209, url: "https://dev.azure.com/org/project/_workitems/edit/1209", title: "Update release notes", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1209", state: "In progress", priority: 2, note: "2h ago" },
-          { type: "Story", id: 1222, url: "https://dev.azure.com/org/project/_workitems/edit/1222", title: "Verify acceptance criteria signed off", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1222", state: "Active", priority: 1, note: "1d ago" }
+          { type: "Task", id: 1209, url: "https://dev.azure.com/org/project/_workitems/edit/1209", title: "Update release notes", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1209", state: "In progress", priority: 2, note: "2h ago", changedDate: daysAgoISO(0) },
+          { type: "Story", id: 1222, url: "https://dev.azure.com/org/project/_workitems/edit/1222", title: "Verify acceptance criteria signed off", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1222", state: "Active", priority: 1, note: "1d ago", changedDate: daysAgoISO(1) }
         ]
       }
     ]
@@ -120,12 +131,106 @@ var STATE_CLASS = {
 
 var STAR_GLYPH = "★";
 
-// Prep-marker states. Meetings arrive "needed" (unprepared) and the user toggles
-// each to "set" (all set). Persistence is a follow-up — the toggle is in-memory
-// for now, so a refresh re-reads the model's default state.
-var MARKER_SET = "set";
-var MARKER_SET_LABEL = "All set";
-var MARKER_NEEDED_LABEL = "Prep still needed";
+// Dismissal labels for the two toggles. Both are the same control shape (a pill
+// button whose aria-pressed carries state); only the words and the bucket
+// differ. Pressed means "handled" — the row leaves the list.
+var REVIEW_LABELS = { off: "Mark reviewed", on: "Reviewed" };
+var PREP_LABELS = { off: "Prep still needed", on: "All set" };
+
+// Recent updates only surface activity from the last 30 days.
+var ACTIVITY_WINDOW_DAYS = 30;
+
+// When true, dismissed rows stay visible (dimmed, with an undo control) instead
+// of being filtered out — the toolbar's "Show reviewed" toggle flips this.
+var showReviewed = false;
+
+
+// ---------------------------------------------------------------------------
+// Dismissal store — "reviewed" recent updates and "all set" prep items persist
+// here so a handled item stays gone across refresh and reload. State is keyed by
+// item identity and namespaced by bucket; a recent update reappears only if it
+// changed after the moment it was reviewed (an inbox, not a permanent blocklist).
+// This is the model's persistence seam: swap localStorage for the server cache
+// later and nothing above this block has to change.
+// ---------------------------------------------------------------------------
+
+var DISMISS_STORE_KEY = "dailyViewer.dismissed.v1";
+
+var dismissStore = {
+  _load: function () {
+    try {
+      var raw = window.localStorage.getItem(DISMISS_STORE_KEY);
+      var parsed = raw ? JSON.parse(raw) : null;
+      if (parsed && typeof parsed === "object") {
+        return parsed;
+      }
+    } catch (err) {
+      // Corrupt or blocked storage — start clean rather than throw on boot.
+    }
+
+    return {};
+  },
+
+  _save: function (data) {
+    try {
+      window.localStorage.setItem(DISMISS_STORE_KEY, JSON.stringify(data));
+    } catch (err) {
+      // Storage full or blocked (private mode) — dismissal degrades to
+      // in-memory for this session instead of breaking the toggle.
+    }
+  },
+
+  _bucket: function (data, bucket) {
+    if (!data[bucket] || typeof data[bucket] !== "object") {
+      data[bucket] = {};
+    }
+
+    return data[bucket];
+  },
+
+  isDismissed: function (bucket, key, changedDate) {
+    var map = this._bucket(this._load(), bucket);
+    if (!Object.prototype.hasOwnProperty.call(map, key)) {
+      return false;
+    }
+
+    // Reappear when the item changed after it was reviewed (inbox model).
+    if (changedDate) {
+      var changed = Date.parse(changedDate);
+      var reviewed = Date.parse(map[key]);
+      if (!isNaN(changed) && !isNaN(reviewed) && changed > reviewed) {
+        return false;
+      }
+    }
+
+    return true;
+  },
+
+  dismiss: function (bucket, key) {
+    var data = this._load();
+    this._bucket(data, bucket)[key] = new Date().toISOString();
+    this._save(data);
+  },
+
+  restore: function (bucket, key) {
+    var data = this._load();
+    delete this._bucket(data, bucket)[key];
+    this._save(data);
+  }
+};
+
+
+// Identity keys for the two buckets. Recent updates key by work-item id (so a
+// later change to the same item can bring it back); prep items have no id, so
+// they key by title + time — which also means a rescheduled meeting reads as a
+// new item.
+function activityKey(item) {
+  return String(item.id != null ? item.id : (item.title || ""));
+}
+
+function prepKey(item) {
+  return (item.title || "") + "|" + (item.datetime || item.date || "");
+}
 
 
 // ---------------------------------------------------------------------------
@@ -249,33 +354,87 @@ function workItemRow(wi) {
 }
 
 
-// The prep marker is a real toggle button: aria-pressed carries the state (and
-// drives the chip color in CSS), the visible text is its accessible name, and
-// every flip is announced through the shared aria-live region so a screen reader
-// hears which meeting changed. State lives on the button only (persistence is a
-// follow-up), so a re-render resets it to the model's default.
-function markerText(pressed) {
-  return pressed ? MARKER_SET_LABEL : MARKER_NEEDED_LABEL;
+// A recent-update row is a work-item row plus the reviewed toggle. Dismissed
+// rows (only visible under "Show reviewed") render dimmed via .dismissed.
+function activityRow(item) {
+  var li = workItemRow(item);
+
+  if (item._dismissed) {
+    li.classList.add("dismissed");
+  }
+
+  li.appendChild(reviewToggleButton(item));
+
+  return li;
+}
+
+
+// Both toggles are the same control: a pill button whose aria-pressed is its
+// state and whose text is its accessible name. The click hands off to onToggle,
+// which updates the store and repaints the tile — so the button is rebuilt from
+// the fresh view model rather than mutating itself. One render path, no drift.
+function dismissButton(className, pressed, labels, onToggle) {
+  var btn = el("button", {
+    type: "button",
+    class: className,
+    "aria-pressed": pressed ? "true" : "false",
+    text: pressed ? labels.on : labels.off
+  });
+
+  btn.addEventListener("click", onToggle);
+
+  return btn;
+}
+
+
+// Pressed means "handled" (reviewed / all set): restore brings the row back,
+// dismiss removes it. Every flip is announced through the shared aria-live
+// region so a screen reader hears which item changed, then the tile repaints.
+function applyDismissalToggle(opts) {
+  if (opts.pressed) {
+    dismissStore.restore(opts.bucket, opts.key);
+    announce(opts.undoMessage);
+  } else {
+    dismissStore.dismiss(opts.bucket, opts.key);
+    announce(opts.doneMessage);
+  }
+
+  repaintTile(opts.tileKey);
+}
+
+
+function reviewToggleButton(item) {
+  var pressed = item._dismissed === true;
+
+  var btn = dismissButton("review", pressed, REVIEW_LABELS, function () {
+    var label = item.title || "This item";
+    applyDismissalToggle({
+      bucket: "activity",
+      key: activityKey(item),
+      pressed: pressed,
+      tileKey: "activity",
+      doneMessage: label + " marked reviewed.",
+      undoMessage: label + " restored to recent updates."
+    });
+  });
+
+  return btn;
 }
 
 
 function prepMarkerButton(item) {
-  var pressed = item.marker === MARKER_SET;
+  var pressed = item._dismissed === true;
 
-  var btn = el("button", {
-    type: "button",
-    class: "marker",
-    "aria-pressed": pressed ? "true" : "false",
-    text: markerText(pressed)
-  });
-
-  btn.addEventListener("click", function () {
-    var next = btn.getAttribute("aria-pressed") !== "true";
-    btn.setAttribute("aria-pressed", next ? "true" : "false");
-    btn.textContent = markerText(next);
-
+  var btn = dismissButton("marker", pressed, PREP_LABELS, function () {
     var label = item.title || "This item";
-    announce(label + (next ? " marked all set." : " marked prep still needed."));
+    applyDismissalToggle({
+      bucket: "prep",
+      key: prepKey(item),
+      pressed: pressed,
+      tileKey: "week",
+      doneMessage: label + " marked all set.",
+      undoMessage: label + " marked prep still needed."
+    });
   });
 
   return btn;
@@ -298,7 +457,13 @@ function prepRow(item) {
 
   children.push(prepMarkerButton(item));
 
-  return el("li", { class: "wi prep" }, children);
+  var li = el("li", { class: "wi prep" }, children);
+
+  if (item._dismissed) {
+    li.classList.add("dismissed");
+  }
+
+  return li;
 }
 
 
@@ -391,7 +556,7 @@ function renderWeek(model) {
 
 function renderActivity(model) {
   return asArray(model.groups).map(function (group) {
-    return groupBlock(group, workItemRow);
+    return groupBlock(group, activityRow);
   });
 }
 
@@ -413,6 +578,111 @@ function renderFocus(model) {
 
   nodes.push(groupBlock(model.support || {}, workItemRow));
   return nodes;
+}
+
+
+// ---------------------------------------------------------------------------
+// View model — the recent-updates and prep collections are filtered before
+// render: the 30-day window and dismissed items are applied here, so the render
+// layer, the count badges, and the stat numbers all read the same post-filter
+// data and can't drift from each other.
+// ---------------------------------------------------------------------------
+
+function withinActivityWindow(item) {
+  if (!item.changedDate) {
+    return true;
+  }
+
+  var changed = Date.parse(item.changedDate);
+  if (isNaN(changed)) {
+    return true;
+  }
+
+  var cutoff = Date.now() - ACTIVITY_WINDOW_DAYS * MS_PER_DAY;
+  return changed >= cutoff;
+}
+
+
+// Drop items outside the window, then either hide dismissed items or — under
+// "show reviewed" — keep them flagged so the row can render dimmed with an undo.
+// Items are shallow-copied before flagging so the source MODEL (reused as the
+// offline fallback) is never mutated.
+function filterItems(items, spec) {
+  var out = [];
+
+  asArray(items).forEach(function (item) {
+    if (spec.windowed && !withinActivityWindow(item)) {
+      return;
+    }
+
+    var dismissed = dismissStore.isDismissed(spec.bucket, spec.keyOf(item), spec.changedOf(item));
+    if (dismissed && !showReviewed) {
+      return;
+    }
+
+    var copy = Object.assign({}, item);
+    copy._dismissed = dismissed;
+    out.push(copy);
+  });
+
+  return out;
+}
+
+var ACTIVITY_SPEC = {
+  bucket: "activity",
+  windowed: true,
+  keyOf: activityKey,
+  changedOf: function (item) {
+    return item.changedDate;
+  }
+};
+
+var PREP_SPEC = {
+  bucket: "prep",
+  windowed: false,
+  keyOf: prepKey,
+  changedOf: function () {
+    return null;
+  }
+};
+
+
+function activityView(model) {
+  var groups = asArray(model.groups).map(function (group) {
+    var copy = Object.assign({}, group);
+    copy.items = filterItems(group.items, ACTIVITY_SPEC);
+    return copy;
+  });
+
+  return { groups: groups };
+}
+
+
+function weekView(model) {
+  var view = Object.assign({}, model);
+
+  if (model.prep) {
+    var prep = Object.assign({}, model.prep);
+    prep.items = filterItems(model.prep.items, PREP_SPEC);
+    view.prep = prep;
+  }
+
+  return view;
+}
+
+
+function viewModel(key, model) {
+  if (key === "activity") {
+    var av = activityView(model);
+    return av;
+  }
+
+  if (key === "week") {
+    var wv = weekView(model);
+    return wv;
+  }
+
+  return model;
 }
 
 
@@ -447,6 +717,10 @@ var TILES = [
 
 var TILE_BY_KEY = {};
 TILES.forEach(function (t) { TILE_BY_KEY[t.key] = t; });
+
+// The last model + staleness each tile was painted with, so a dismissal toggle
+// or a "show reviewed" flip can repaint from data without re-fetching.
+var TILE_STATE = {};
 
 
 // ---------------------------------------------------------------------------
@@ -551,10 +825,29 @@ function fetchJson(url, options) {
 }
 
 function paintTile(key, model, data) {
+  TILE_STATE[key] = { model: model, data: data };
+
   var conf = TILE_BY_KEY[key];
-  renderTileBody(key, model);
-  setStat(conf.stat, conf.statCount(model || {}));
+  var view = viewModel(key, model || {});
+
+  renderTileBody(key, view);
+  setStat(conf.stat, conf.statCount(view));
   setStale(key, data);
+}
+
+// Repaint a tile from its last-loaded model — after a dismissal toggle or a
+// "show reviewed" flip. Re-deriving the view model reapplies the 30-day window
+// and dismissals, then the open-state and active search filter the full render
+// dropped are restored (the same post-render fix-up the refresh path does).
+function repaintTile(key) {
+  var st = TILE_STATE[key];
+  if (!st) {
+    return;
+  }
+
+  paintTile(key, st.model, st.data);
+  rememberOpenState();
+  applyFilter(searchBox.value);
 }
 
 function loadTile(key) {
@@ -593,6 +886,20 @@ document.getElementById("expandAll").addEventListener("click", function () {
 
 document.getElementById("collapseAll").addEventListener("click", function () {
   document.querySelectorAll(".tile > details").forEach(function (d) { d.open = false; });
+});
+
+
+// "Show reviewed" reveals dismissed rows (dimmed, with an undo) across the two
+// tiles that support dismissal, instead of filtering them out.
+var showReviewedBtn = document.getElementById("showReviewed");
+showReviewedBtn.addEventListener("click", function () {
+  showReviewed = !showReviewed;
+  showReviewedBtn.setAttribute("aria-pressed", showReviewed ? "true" : "false");
+
+  repaintTile("activity");
+  repaintTile("week");
+
+  announce(showReviewed ? "Showing reviewed and completed items." : "Hiding reviewed and completed items.");
 });
 
 

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -260,11 +260,12 @@ function prepKey(item) {
 }
 
 
-// Per-bucket config: the single source of truth for BOTH the filter and the
-// dismiss button. Filtering reads windowed/keyOf/changedOf; the button reads
-// className/labels/tileKey and builds its announcements from the row label.
-// Keeping the bucket name and its behavior in one object is what lets the
-// "activity"/"prep" string live in exactly one place.
+// Per-bucket config: one object holds BOTH the filter inputs and the dismiss
+// button inputs so the two can't drift. Filtering reads windowed/keyOf/changedOf;
+// the button reads className/labels/tileKey and builds its announcements from the
+// row label. (The tile key still surfaces literally in viewModel's dispatch and
+// the toolbar handler; the spec keeps the per-item behavior together, not every
+// mention of the name.)
 var ACTIVITY_SPEC = {
   bucket: "activity",
   windowed: true,
@@ -459,14 +460,40 @@ function applyDismissalToggle(opts) {
 }
 
 
+// Repainting a tile rebuilds its body, so the just-clicked control is destroyed
+// and focus falls to <body>. Return focus to the same-position control of the
+// same kind (the row that slid into the removed row's place), falling back to the
+// tile's summary — so a keyboard user keeps their place in the list.
+function focusTileControl(tileKey, controlClass, index) {
+  var scope = tile(tileKey);
+  if (!scope) {
+    return;
+  }
+
+  var controls = scope.querySelectorAll("." + controlClass);
+  if (controls.length) {
+    controls[Math.min(index, controls.length - 1)].focus();
+  } else {
+    var summary = scope.querySelector("summary");
+    if (summary) {
+      summary.focus();
+    }
+  }
+}
+
+
 // One builder for both dismiss controls, driven by the bucket spec — the review
 // toggle and the prep remove differ only in that data, so they share this body.
 function dismissToggleButton(item, spec) {
   var pressed = item._dismissed === true;
   var label = item.title || "This item";
   var ariaLabel = (pressed ? spec.labels.on : spec.labels.off) + " — " + label;
+  var controlClass = spec.className.split(" ").pop();
 
   var btn = dismissButton(spec.className, pressed, spec.labels, ariaLabel, function () {
+    var peers = tile(spec.tileKey).querySelectorAll("." + controlClass);
+    var index = Array.prototype.indexOf.call(peers, btn);
+
     applyDismissalToggle({
       bucket: spec.bucket,
       key: spec.keyOf(item),
@@ -475,9 +502,19 @@ function dismissToggleButton(item, spec) {
       doneMessage: spec.doneMessage(label),
       undoMessage: spec.undoMessage(label)
     });
+
+    focusTileControl(spec.tileKey, controlClass, index < 0 ? 0 : index);
   });
 
   return btn;
+}
+
+
+// Dim a row whose item is dismissed (only reachable under "Show reviewed").
+function flagDismissed(li, item) {
+  if (item._dismissed) {
+    li.classList.add("dismissed");
+  }
 }
 
 
@@ -486,10 +523,7 @@ function dismissToggleButton(item, spec) {
 function activityRow(item) {
   var li = workItemRow(item);
 
-  if (item._dismissed) {
-    li.classList.add("dismissed");
-  }
-
+  flagDismissed(li, item);
   li.appendChild(dismissToggleButton(item, ACTIVITY_SPEC));
 
   return li;
@@ -632,9 +666,7 @@ function prepRow(item) {
 
   var li = el("li", { class: "wi prep" }, children);
 
-  if (item._dismissed) {
-    li.classList.add("dismissed");
-  }
+  flagDismissed(li, item);
 
   return li;
 }

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -233,6 +233,48 @@ function prepKey(item) {
 }
 
 
+// Per-bucket config: the single source of truth for BOTH the filter and the
+// toggle button. Filtering reads windowed/keyOf/changedOf; the button reads
+// className/labels/tileKey and builds its announcements from the row label.
+// Keeping the bucket name and its behavior in one object is what lets the
+// "activity"/"prep" string live in exactly one place.
+var ACTIVITY_SPEC = {
+  bucket: "activity",
+  windowed: true,
+  keyOf: activityKey,
+  changedOf: function (item) {
+    return item.changedDate;
+  },
+  className: "pill-toggle review",
+  labels: REVIEW_LABELS,
+  tileKey: "activity",
+  doneMessage: function (label) {
+    return label + " marked reviewed.";
+  },
+  undoMessage: function (label) {
+    return label + " restored to recent updates.";
+  }
+};
+
+var PREP_SPEC = {
+  bucket: "prep",
+  windowed: false,
+  keyOf: prepKey,
+  changedOf: function () {
+    return null;
+  },
+  className: "pill-toggle marker",
+  labels: PREP_LABELS,
+  tileKey: "week",
+  doneMessage: function (label) {
+    return label + " marked all set.";
+  },
+  undoMessage: function (label) {
+    return label + " marked prep still needed.";
+  }
+};
+
+
 // ---------------------------------------------------------------------------
 // DOM builder — the single, escaping-safe path from model to page. `text` sets
 // textContent and every other key goes through setAttribute, so a malicious
@@ -363,21 +405,24 @@ function activityRow(item) {
     li.classList.add("dismissed");
   }
 
-  li.appendChild(reviewToggleButton(item));
+  li.appendChild(dismissToggleButton(item, ACTIVITY_SPEC));
 
   return li;
 }
 
 
 // Both toggles are the same control: a pill button whose aria-pressed is its
-// state and whose text is its accessible name. The click hands off to onToggle,
-// which updates the store and repaints the tile — so the button is rebuilt from
-// the fresh view model rather than mutating itself. One render path, no drift.
-function dismissButton(className, pressed, labels, onToggle) {
+// state and whose visible text is the action. An explicit aria-label folds in
+// the item title so a screen reader can tell one row's toggle from the next
+// (visible text alone would read as a wall of identical "Mark reviewed"s). The
+// click hands off to onToggle, which updates the store and repaints the tile —
+// the button is rebuilt from the fresh view model rather than mutating itself.
+function dismissButton(className, pressed, labels, ariaLabel, onToggle) {
   var btn = el("button", {
     type: "button",
     class: className,
     "aria-pressed": pressed ? "true" : "false",
+    "aria-label": ariaLabel,
     text: pressed ? labels.on : labels.off
   });
 
@@ -403,37 +448,21 @@ function applyDismissalToggle(opts) {
 }
 
 
-function reviewToggleButton(item) {
+// One builder for both toggles, driven by the bucket spec — the review toggle
+// and the prep marker differ only in that data, so they share this body.
+function dismissToggleButton(item, spec) {
   var pressed = item._dismissed === true;
+  var label = item.title || "This item";
+  var ariaLabel = (pressed ? spec.labels.on : spec.labels.off) + " — " + label;
 
-  var btn = dismissButton("review", pressed, REVIEW_LABELS, function () {
-    var label = item.title || "This item";
+  var btn = dismissButton(spec.className, pressed, spec.labels, ariaLabel, function () {
     applyDismissalToggle({
-      bucket: "activity",
-      key: activityKey(item),
+      bucket: spec.bucket,
+      key: spec.keyOf(item),
       pressed: pressed,
-      tileKey: "activity",
-      doneMessage: label + " marked reviewed.",
-      undoMessage: label + " restored to recent updates."
-    });
-  });
-
-  return btn;
-}
-
-
-function prepMarkerButton(item) {
-  var pressed = item._dismissed === true;
-
-  var btn = dismissButton("marker", pressed, PREP_LABELS, function () {
-    var label = item.title || "This item";
-    applyDismissalToggle({
-      bucket: "prep",
-      key: prepKey(item),
-      pressed: pressed,
-      tileKey: "week",
-      doneMessage: label + " marked all set.",
-      undoMessage: label + " marked prep still needed."
+      tileKey: spec.tileKey,
+      doneMessage: spec.doneMessage(label),
+      undoMessage: spec.undoMessage(label)
     });
   });
 
@@ -455,7 +484,7 @@ function prepRow(item) {
     children.push(el("span", { class: "date", text: item.date }));
   }
 
-  children.push(prepMarkerButton(item));
+  children.push(dismissToggleButton(item, PREP_SPEC));
 
   var li = el("li", { class: "wi prep" }, children);
 
@@ -627,24 +656,6 @@ function filterItems(items, spec) {
 
   return out;
 }
-
-var ACTIVITY_SPEC = {
-  bucket: "activity",
-  windowed: true,
-  keyOf: activityKey,
-  changedOf: function (item) {
-    return item.changedDate;
-  }
-};
-
-var PREP_SPEC = {
-  bucket: "prep",
-  windowed: false,
-  keyOf: prepKey,
-  changedOf: function () {
-    return null;
-  }
-};
 
 
 function activityView(model) {

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -12,6 +12,16 @@
 // live `az boards` / Outlook output is a data change, not markup surgery.
 // ---------------------------------------------------------------------------
 
+var MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Sample activity timestamps are expressed relative to "now" so the 30-day
+// window demonstrates itself whenever the mock is opened: the six-week-old row
+// is always filtered out and the rest always land inside the window. Live data
+// ships real ISO dates from the server, so this helper is sample-only.
+function daysAgoISO(days) {
+  return new Date(Date.now() - days * MS_PER_DAY).toISOString();
+}
+
 var MODEL = {
   agenda: {
     events: [
@@ -53,16 +63,16 @@ var MODEL = {
     label: "Events to prepare for",
     open: true,
     items: [
-      { title: "Sprint Planning Sync", date: "Jul 16", datetime: "2026-07-16T09:00:00-05:00", marker: "needed",
+      { title: "Sprint Planning Sync", date: "Jul 16", datetime: "2026-07-16T09:00:00-05:00",
         time: { label: "9:00 AM", tz: "EST" },
         location: { badge: "Teams", urlLabel: "Join meeting →", url: "https://teams.microsoft.com/l/meetup-join/example" } },
-      { title: "Architecture Design Review", date: "Jul 18", datetime: "2026-07-18T11:00:00-05:00", marker: "set",
+      { title: "Architecture Design Review", date: "Jul 18", datetime: "2026-07-18T11:00:00-05:00",
         time: { label: "11:00 AM", tz: "EST" },
         location: { badge: "In person", text: "Room 132" } },
-      { title: "Cross-team API Contract Review", date: "Jul 22", datetime: "2026-07-22T14:00:00-05:00", marker: "needed",
+      { title: "Cross-team API Contract Review", date: "Jul 22", datetime: "2026-07-22T14:00:00-05:00",
         time: { label: "2:00 PM", tz: "EST" },
         location: { badge: "Teams", urlLabel: "Join meeting →", url: "https://teams.microsoft.com/l/meetup-join/example2" } },
-      { title: "Quarterly Roadmap Workshop", date: "Jul 27", datetime: "2026-07-27T10:00:00-05:00", marker: "needed" }
+      { title: "Quarterly Roadmap Workshop", date: "Jul 27", datetime: "2026-07-27T10:00:00-05:00" }
     ]
   },
 
@@ -72,24 +82,25 @@ var MODEL = {
         label: "Tagged discussions",
         open: true,
         items: [
-          { type: "Feature", id: 1180, url: "https://dev.azure.com/org/project/_workitems/edit/1180", title: "@you — “can you confirm the WIQL scope?”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1180?discussion", priority: 2, note: "1d ago" },
-          { type: "Story", id: 1240, url: "https://dev.azure.com/org/project/_workitems/edit/1240", title: "@you — “ready for review whenever”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1240?discussion", priority: 3, note: "3h ago" }
+          { type: "Feature", id: 1180, url: "https://dev.azure.com/org/project/_workitems/edit/1180", title: "@you — “can you confirm the WIQL scope?”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1180?discussion", priority: 2, note: "1d ago", changedDate: daysAgoISO(1) },
+          { type: "Story", id: 1240, url: "https://dev.azure.com/org/project/_workitems/edit/1240", title: "@you — “ready for review whenever”", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1240?discussion", priority: 3, note: "3h ago", changedDate: daysAgoISO(0) }
         ]
       },
       {
         label: "Active story updates",
         open: false,
         items: [
-          { type: "Story", id: 1234, url: "https://dev.azure.com/org/project/_workitems/edit/1234", title: "State → In progress by A. Rivera", note: "2h ago" },
-          { type: "Bug", id: 1251, url: "https://dev.azure.com/org/project/_workitems/edit/1251", title: "Moved to In review", note: "4h ago" }
+          { type: "Story", id: 1234, url: "https://dev.azure.com/org/project/_workitems/edit/1234", title: "State → In progress by A. Rivera", note: "2h ago", changedDate: daysAgoISO(0) },
+          { type: "Bug", id: 1251, url: "https://dev.azure.com/org/project/_workitems/edit/1251", title: "Moved to In review", note: "4h ago", changedDate: daysAgoISO(0) },
+          { type: "Story", id: 1188, url: "https://dev.azure.com/org/project/_workitems/edit/1188", title: "Closed after release cut", note: "6w ago", changedDate: daysAgoISO(45) }
         ]
       },
       {
         label: "Current sprint",
         open: false,
         items: [
-          { type: "Task", id: 1209, url: "https://dev.azure.com/org/project/_workitems/edit/1209", title: "Update release notes", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1209", state: "In progress", priority: 2, note: "2h ago" },
-          { type: "Story", id: 1222, url: "https://dev.azure.com/org/project/_workitems/edit/1222", title: "Verify acceptance criteria signed off", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1222", state: "Active", priority: 1, note: "1d ago" }
+          { type: "Task", id: 1209, url: "https://dev.azure.com/org/project/_workitems/edit/1209", title: "Update release notes", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1209", state: "In progress", priority: 2, note: "2h ago", changedDate: daysAgoISO(0) },
+          { type: "Story", id: 1222, url: "https://dev.azure.com/org/project/_workitems/edit/1222", title: "Verify acceptance criteria signed off", titleUrl: "https://dev.azure.com/org/project/_workitems/edit/1222", state: "Active", priority: 1, note: "1d ago", changedDate: daysAgoISO(1) }
         ]
       }
     ]
@@ -130,12 +141,148 @@ var STATE_CLASS = {
 
 var STAR_GLYPH = "★";
 
-// Prep-marker states. Meetings arrive "needed" (unprepared) and the user toggles
-// each to "set" (all set). Persistence is a follow-up — the toggle is in-memory
-// for now, so a refresh re-reads the model's default state.
-var MARKER_SET = "set";
-var MARKER_SET_LABEL = "All set";
-var MARKER_NEEDED_LABEL = "Prep still needed";
+// Dismissal labels for the two toggles. Both are the same control shape (a pill
+// button whose aria-pressed carries state); only the words and the bucket
+// differ. Pressed means "handled" — the row leaves the list.
+var REVIEW_LABELS = { off: "Mark reviewed", on: "Reviewed" };
+var PREP_LABELS = { off: "Prep still needed", on: "All set" };
+
+// Recent updates only surface activity from the last 30 days.
+var ACTIVITY_WINDOW_DAYS = 30;
+
+// When true, dismissed rows stay visible (dimmed, with an undo control) instead
+// of being filtered out — the toolbar's "Show reviewed" toggle flips this.
+var showReviewed = false;
+
+
+// ---------------------------------------------------------------------------
+// Dismissal store — "reviewed" recent updates and "all set" prep items persist
+// here so a handled item stays gone across refresh and reload. State is keyed by
+// item identity and namespaced by bucket; a recent update reappears only if it
+// changed after the moment it was reviewed (an inbox, not a permanent blocklist).
+// This is the model's persistence seam: swap localStorage for the server cache
+// later and nothing above this block has to change.
+// ---------------------------------------------------------------------------
+
+var DISMISS_STORE_KEY = "dailyViewer.dismissed.v1";
+
+var dismissStore = {
+  _load: function () {
+    try {
+      var raw = window.localStorage.getItem(DISMISS_STORE_KEY);
+      var parsed = raw ? JSON.parse(raw) : null;
+      if (parsed && typeof parsed === "object") {
+        return parsed;
+      }
+    } catch (err) {
+      // Corrupt or blocked storage — start clean rather than throw on boot.
+    }
+
+    return {};
+  },
+
+  _save: function (data) {
+    try {
+      window.localStorage.setItem(DISMISS_STORE_KEY, JSON.stringify(data));
+    } catch (err) {
+      // Storage full or blocked (private mode) — dismissal degrades to
+      // in-memory for this session instead of breaking the toggle.
+    }
+  },
+
+  _bucket: function (data, bucket) {
+    if (!data[bucket] || typeof data[bucket] !== "object") {
+      data[bucket] = {};
+    }
+
+    return data[bucket];
+  },
+
+  isDismissed: function (bucket, key, changedDate) {
+    var map = this._bucket(this._load(), bucket);
+    if (!Object.prototype.hasOwnProperty.call(map, key)) {
+      return false;
+    }
+
+    // Reappear when the item changed after it was reviewed (inbox model).
+    if (changedDate) {
+      var changed = Date.parse(changedDate);
+      var reviewed = Date.parse(map[key]);
+      if (!isNaN(changed) && !isNaN(reviewed) && changed > reviewed) {
+        return false;
+      }
+    }
+
+    return true;
+  },
+
+  dismiss: function (bucket, key) {
+    var data = this._load();
+    this._bucket(data, bucket)[key] = new Date().toISOString();
+    this._save(data);
+  },
+
+  restore: function (bucket, key) {
+    var data = this._load();
+    delete this._bucket(data, bucket)[key];
+    this._save(data);
+  }
+};
+
+
+// Identity keys for the two buckets. Recent updates key by work-item id (so a
+// later change to the same item can bring it back); prep items have no id, so
+// they key by title + time — which also means a rescheduled meeting reads as a
+// new item.
+function activityKey(item) {
+  return String(item.id != null ? item.id : (item.title || ""));
+}
+
+function prepKey(item) {
+  return (item.title || "") + "|" + (item.datetime || item.date || "");
+}
+
+
+// Per-bucket config: the single source of truth for BOTH the filter and the
+// toggle button. Filtering reads windowed/keyOf/changedOf; the button reads
+// className/labels/tileKey and builds its announcements from the row label.
+// Keeping the bucket name and its behavior in one object is what lets the
+// "activity"/"prep" string live in exactly one place.
+var ACTIVITY_SPEC = {
+  bucket: "activity",
+  windowed: true,
+  keyOf: activityKey,
+  changedOf: function (item) {
+    return item.changedDate;
+  },
+  className: "pill-toggle review",
+  labels: REVIEW_LABELS,
+  tileKey: "activity",
+  doneMessage: function (label) {
+    return label + " marked reviewed.";
+  },
+  undoMessage: function (label) {
+    return label + " restored to recent updates.";
+  }
+};
+
+var PREP_SPEC = {
+  bucket: "prep",
+  windowed: false,
+  keyOf: prepKey,
+  changedOf: function () {
+    return null;
+  },
+  className: "pill-toggle marker",
+  labels: PREP_LABELS,
+  tileKey: "prep",
+  doneMessage: function (label) {
+    return label + " marked all set.";
+  },
+  undoMessage: function (label) {
+    return label + " marked prep still needed.";
+  }
+};
 
 
 // ---------------------------------------------------------------------------
@@ -259,33 +406,74 @@ function workItemRow(wi) {
 }
 
 
-// The prep marker is a real toggle button: aria-pressed carries the state (and
-// drives the chip color in CSS), the visible text is its accessible name, and
-// every flip is announced through the shared aria-live region so a screen reader
-// hears which meeting changed. State lives on the button only (persistence is a
-// follow-up), so a re-render resets it to the model's default.
-function markerText(pressed) {
-  return pressed ? MARKER_SET_LABEL : MARKER_NEEDED_LABEL;
+// A recent-update row is a work-item row plus the reviewed toggle. Dismissed
+// rows (only visible under "Show reviewed") render dimmed via .dismissed.
+function activityRow(item) {
+  var li = workItemRow(item);
+
+  if (item._dismissed) {
+    li.classList.add("dismissed");
+  }
+
+  li.appendChild(dismissToggleButton(item, ACTIVITY_SPEC));
+
+  return li;
 }
 
 
-function prepMarkerButton(item) {
-  var pressed = item.marker === MARKER_SET;
-
+// Both toggles are the same control: a pill button whose aria-pressed is its
+// state and whose visible text is the action. An explicit aria-label folds in
+// the item title so a screen reader can tell one row's toggle from the next
+// (visible text alone would read as a wall of identical "Mark reviewed"s). The
+// click hands off to onToggle, which updates the store and repaints the tile —
+// the button is rebuilt from the fresh view model rather than mutating itself.
+function dismissButton(className, pressed, labels, ariaLabel, onToggle) {
   var btn = el("button", {
     type: "button",
-    class: "marker",
+    class: className,
     "aria-pressed": pressed ? "true" : "false",
-    text: markerText(pressed)
+    "aria-label": ariaLabel,
+    text: pressed ? labels.on : labels.off
   });
 
-  btn.addEventListener("click", function () {
-    var next = btn.getAttribute("aria-pressed") !== "true";
-    btn.setAttribute("aria-pressed", next ? "true" : "false");
-    btn.textContent = markerText(next);
+  btn.addEventListener("click", onToggle);
 
-    var label = item.title || "This item";
-    announce(label + (next ? " marked all set." : " marked prep still needed."));
+  return btn;
+}
+
+
+// Pressed means "handled" (reviewed / all set): restore brings the row back,
+// dismiss removes it. Every flip is announced through the shared aria-live
+// region so a screen reader hears which item changed, then the tile repaints.
+function applyDismissalToggle(opts) {
+  if (opts.pressed) {
+    dismissStore.restore(opts.bucket, opts.key);
+    announce(opts.undoMessage);
+  } else {
+    dismissStore.dismiss(opts.bucket, opts.key);
+    announce(opts.doneMessage);
+  }
+
+  repaintTile(opts.tileKey);
+}
+
+
+// One builder for both toggles, driven by the bucket spec — the review toggle
+// and the prep marker differ only in that data, so they share this body.
+function dismissToggleButton(item, spec) {
+  var pressed = item._dismissed === true;
+  var label = item.title || "This item";
+  var ariaLabel = (pressed ? spec.labels.on : spec.labels.off) + " — " + label;
+
+  var btn = dismissButton(spec.className, pressed, spec.labels, ariaLabel, function () {
+    applyDismissalToggle({
+      bucket: spec.bucket,
+      key: spec.keyOf(item),
+      pressed: pressed,
+      tileKey: spec.tileKey,
+      doneMessage: spec.doneMessage(label),
+      undoMessage: spec.undoMessage(label)
+    });
   });
 
   return btn;
@@ -344,9 +532,15 @@ function prepRow(item) {
     children.push(el("span", { class: "date", text: item.date }));
   }
 
-  children.push(prepMarkerButton(item));
+  children.push(dismissToggleButton(item, PREP_SPEC));
 
-  return el("li", { class: "wi prep" }, children);
+  var li = el("li", { class: "wi prep" }, children);
+
+  if (item._dismissed) {
+    li.classList.add("dismissed");
+  }
+
+  return li;
 }
 
 
@@ -493,7 +687,7 @@ function renderPrep(model) {
 
 function renderActivity(model) {
   return asArray(model.groups).map(function (group) {
-    return groupBlock(group, workItemRow);
+    return groupBlock(group, activityRow);
   });
 }
 
@@ -515,6 +709,87 @@ function renderFocus(model) {
 
   nodes.push(groupBlock(model.support || {}, workItemRow));
   return nodes;
+}
+
+
+// ---------------------------------------------------------------------------
+// View model — the recent-updates and prep collections are filtered before
+// render: the 30-day window and dismissed items are applied here, so the render
+// layer, the count badges, and the stat numbers all read the same post-filter
+// data and can't drift from each other.
+// ---------------------------------------------------------------------------
+
+function withinActivityWindow(item) {
+  if (!item.changedDate) {
+    return true;
+  }
+
+  var changed = Date.parse(item.changedDate);
+  if (isNaN(changed)) {
+    return true;
+  }
+
+  var cutoff = Date.now() - ACTIVITY_WINDOW_DAYS * MS_PER_DAY;
+  return changed >= cutoff;
+}
+
+
+// Drop items outside the window, then either hide dismissed items or — under
+// "show reviewed" — keep them flagged so the row can render dimmed with an undo.
+// Items are shallow-copied before flagging so the source MODEL (reused as the
+// offline fallback) is never mutated.
+function filterItems(items, spec) {
+  var out = [];
+
+  asArray(items).forEach(function (item) {
+    if (spec.windowed && !withinActivityWindow(item)) {
+      return;
+    }
+
+    var dismissed = dismissStore.isDismissed(spec.bucket, spec.keyOf(item), spec.changedOf(item));
+    if (dismissed && !showReviewed) {
+      return;
+    }
+
+    var copy = Object.assign({}, item);
+    copy._dismissed = dismissed;
+    out.push(copy);
+  });
+
+  return out;
+}
+
+
+function activityView(model) {
+  var groups = asArray(model.groups).map(function (group) {
+    var copy = Object.assign({}, group);
+    copy.items = filterItems(group.items, ACTIVITY_SPEC);
+    return copy;
+  });
+
+  return { groups: groups };
+}
+
+
+function prepView(model) {
+  var view = Object.assign({}, model);
+  view.items = filterItems(model.items, PREP_SPEC);
+  return view;
+}
+
+
+function viewModel(key, model) {
+  if (key === "activity") {
+    var av = activityView(model);
+    return av;
+  }
+
+  if (key === "prep") {
+    var pv = prepView(model);
+    return pv;
+  }
+
+  return model;
 }
 
 
@@ -552,6 +827,10 @@ var TILES = [
 
 var TILE_BY_KEY = {};
 TILES.forEach(function (t) { TILE_BY_KEY[t.key] = t; });
+
+// The last model + staleness each tile was painted with, so a dismissal toggle
+// or a "show reviewed" flip can repaint from data without re-fetching.
+var TILE_STATE = {};
 
 
 // ---------------------------------------------------------------------------
@@ -656,10 +935,29 @@ function fetchJson(url, options) {
 }
 
 function paintTile(key, model, data) {
+  TILE_STATE[key] = { model: model, data: data };
+
   var conf = TILE_BY_KEY[key];
-  renderTileBody(key, model);
-  setStat(conf.stat, conf.statCount(model || {}));
+  var view = viewModel(key, model || {});
+
+  renderTileBody(key, view);
+  setStat(conf.stat, conf.statCount(view));
   setStale(key, data);
+}
+
+// Repaint a tile from its last-loaded model — after a dismissal toggle or a
+// "show reviewed" flip. Re-deriving the view model reapplies the 30-day window
+// and dismissals, then the open-state and active search filter the full render
+// dropped are restored (the same post-render fix-up the refresh path does).
+function repaintTile(key) {
+  var st = TILE_STATE[key];
+  if (!st) {
+    return;
+  }
+
+  paintTile(key, st.model, st.data);
+  rememberOpenState();
+  applyFilter(searchBox.value);
 }
 
 function loadTile(key) {
@@ -698,6 +996,21 @@ document.getElementById("expandAll").addEventListener("click", function () {
 
 document.getElementById("collapseAll").addEventListener("click", function () {
   document.querySelectorAll(".tile > details").forEach(function (d) { d.open = false; });
+});
+
+
+// "Show reviewed" reveals dismissed rows (dimmed, with an undo) across the two
+// tiles that support dismissal — recent updates and prep — instead of filtering
+// them out.
+var showReviewedBtn = document.getElementById("showReviewed");
+showReviewedBtn.addEventListener("click", function () {
+  showReviewed = !showReviewed;
+  showReviewedBtn.setAttribute("aria-pressed", showReviewed ? "true" : "false");
+
+  repaintTile("activity");
+  repaintTile("prep");
+
+  announce(showReviewed ? "Showing reviewed and completed items." : "Hiding reviewed and completed items.");
 });
 
 

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -24,6 +24,7 @@
       <button class="btn" id="refreshAll" type="button">Refresh all</button>
       <button class="btn" id="collapseAll" type="button">Collapse all</button>
       <button class="btn" id="expandAll" type="button">Expand all</button>
+      <button class="btn" id="showReviewed" type="button" aria-pressed="false">Show reviewed</button>
       <button class="btn icon" id="themeToggle" type="button" aria-label="Toggle light or dark theme">
         <svg id="icon-sun" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="3.2" stroke="currentColor" stroke-width="1.5"/><path d="M8 1v1.6M8 13.4V15M1 8h1.6M13.4 8H15M3 3l1.1 1.1M11.9 11.9L13 13M13 3l-1.1 1.1M4.1 11.9L3 13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
         <svg id="icon-moon" class="is-hidden" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 9.5A5.5 5.5 0 1 1 6.5 2.5a4.5 4.5 0 0 0 7 7z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -566,10 +566,12 @@ details[open] > summary > .chev { transform: rotate(90deg); }
 
 .note { font-size: var(--fs-smd); color: var(--text-dim); }
 
-/* Prep marker toggle — "prep still needed" (warn) flips to "all set" (good) on
-   aria-pressed. State drives the color, so the JS only toggles the attribute;
-   both palettes carry over through the same theme tokens the chips already use. */
-.prep .marker {
+/* Dismissal toggles — the prep marker and the reviewed toggle are one control
+   (JS builds both from a bucket spec). This is their shared shape: layout, the
+   pressed="handled" green treatment, and the reduced-motion opt-out all live
+   here once; each variant below only sets its resting color and hover. State
+   drives color through theme tokens, so both palettes carry over untouched. */
+.pill-toggle {
   flex: none;
   font-family: inherit;
   font-size: var(--fs-2xs); font-weight: 700; letter-spacing: .03em;
@@ -577,53 +579,39 @@ details[open] > summary > .chev { transform: rotate(90deg); }
   display: inline-flex; align-items: center; gap: var(--space-2);
   padding: var(--space-0) var(--space-3);
   border-radius: var(--radius-pill);
+  transition: color .15s ease, background .15s ease, border-color .15s ease;
+}
+.pill-toggle[aria-pressed="true"] {
+  color: var(--good);
+  border-color: color-mix(in srgb, var(--good) 35%, transparent);
+  background: color-mix(in srgb, var(--good) 15%, transparent);
+}
+@media (prefers-reduced-motion: reduce) {
+  .pill-toggle { transition: none; }
+}
+
+/* Prep marker — "prep still needed" (warn) resting, with a status dot. */
+.prep .marker {
   color: var(--warn);
   border: 1px solid color-mix(in srgb, var(--warn) 35%, transparent);
   background: color-mix(in srgb, var(--warn) 15%, transparent);
-  transition: color .15s ease, background .15s ease, border-color .15s ease;
 }
 .prep .marker::before {
   content: ""; width: 0.4375rem; height: 0.4375rem; border-radius: 50%;
   background: currentColor;
   flex: none;
 }
-.prep .marker[aria-pressed="true"] {
-  color: var(--good);
-  border-color: color-mix(in srgb, var(--good) 35%, transparent);
-  background: color-mix(in srgb, var(--good) 15%, transparent);
-}
 .prep .marker:hover { border-color: currentColor; }
-@media (prefers-reduced-motion: reduce) {
-  .prep .marker { transition: none; }
-}
 
-/* Reviewed toggle on recent-update rows — same control shape as the prep
-   marker: aria-pressed carries state and drives the color through the shared
-   theme tokens. Pressed (reviewed) rows are only visible under "Show reviewed",
-   where .dismissed dims them to read as already handled. */
+/* Reviewed toggle on recent-update rows — neutral resting. Pressed (reviewed)
+   rows are only visible under "Show reviewed", where .dismissed dims them. */
 .wi .review {
-  flex: none;
-  font-family: inherit;
-  font-size: var(--fs-2xs); font-weight: 700; letter-spacing: .03em;
-  cursor: pointer;
-  display: inline-flex; align-items: center; gap: var(--space-2);
-  padding: var(--space-0) var(--space-3);
-  border-radius: var(--radius-pill);
   color: var(--text-dim);
   border: 1px solid var(--border);
   background: var(--surface-2);
-  transition: color .15s ease, background .15s ease, border-color .15s ease;
 }
 .wi .review:hover { color: var(--text); border-color: var(--border-strong); }
-.wi .review[aria-pressed="true"] {
-  color: var(--good);
-  border-color: color-mix(in srgb, var(--good) 35%, transparent);
-  background: color-mix(in srgb, var(--good) 15%, transparent);
-}
 .wi.dismissed { opacity: .55; }
-@media (prefers-reduced-motion: reduce) {
-  .wi .review { transition: none; }
-}
 
 /* Toolbar toggle (Show reviewed) reuses .btn; aria-pressed marks it active. */
 .btn[aria-pressed="true"] {

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -603,10 +603,11 @@ details[open] > summary > .chev { transform: rotate(90deg); }
 
 .note { font-size: var(--fs-smd); color: var(--text-dim); }
 
-/* Prep marker toggle — "prep still needed" (warn) flips to "all set" (good) on
-   aria-pressed. State drives the color, so the JS only toggles the attribute;
-   both palettes carry over through the same theme tokens the chips already use. */
-.prep .marker {
+/* Dismissal + prep-marker toggles share one pill shape. The base holds layout,
+   the pressed="handled" green treatment, and the reduced-motion opt-out; each
+   variant below sets only its resting color, hover, and any extras. State drives
+   color through theme tokens, so both palettes carry over untouched. */
+.pill-toggle {
   flex: none;
   font-family: inherit;
   font-size: var(--fs-2xs); font-weight: 700; letter-spacing: .03em;
@@ -614,25 +615,50 @@ details[open] > summary > .chev { transform: rotate(90deg); }
   display: inline-flex; align-items: center; gap: var(--space-2);
   padding: var(--space-0) var(--space-3);
   border-radius: var(--radius-pill);
+  transition: color .15s ease, background .15s ease, border-color .15s ease;
+}
+.pill-toggle[aria-pressed="true"] {
+  color: var(--good);
+  border-color: color-mix(in srgb, var(--good) 35%, transparent);
+  background: color-mix(in srgb, var(--good) 15%, transparent);
+}
+@media (prefers-reduced-motion: reduce) {
+  .pill-toggle { transition: none; }
+}
+
+/* Prep marker — "prep still needed" (warn) resting, with a status dot. Its
+   pressed="all set" (good) state comes from the shared .pill-toggle rule. */
+.prep .marker {
   color: var(--warn);
   border: 1px solid color-mix(in srgb, var(--warn) 35%, transparent);
   background: color-mix(in srgb, var(--warn) 15%, transparent);
-  transition: color .15s ease, background .15s ease, border-color .15s ease;
 }
 .prep .marker::before {
   content: ""; width: 0.4375rem; height: 0.4375rem; border-radius: 50%;
   background: currentColor;
   flex: none;
 }
-.prep .marker[aria-pressed="true"] {
-  color: var(--good);
-  border-color: color-mix(in srgb, var(--good) 35%, transparent);
-  background: color-mix(in srgb, var(--good) 15%, transparent);
-}
 .prep .marker:hover { border-color: currentColor; }
 .prep .marker[aria-disabled="true"] { cursor: progress; opacity: .6; }
-@media (prefers-reduced-motion: reduce) {
-  .prep .marker { transition: none; }
+
+/* Dismiss controls — the reviewed toggle on recent-update rows and the remove
+   control on prep rows. Neutral resting; pressed (handled) rows are only visible
+   under "Show reviewed", where .dismissed dims them. */
+.wi .review,
+.prep .dismiss {
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+}
+.wi .review:hover,
+.prep .dismiss:hover { color: var(--text); border-color: var(--border-strong); }
+.wi.dismissed { opacity: .55; }
+
+/* Toolbar toggle (Show reviewed) reuses .btn; aria-pressed marks it active. */
+.btn[aria-pressed="true"] {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  background: var(--accent-weak);
 }
 
 /* Prep tile list — a flat chronological list (the tile header already names the

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -597,6 +597,41 @@ details[open] > summary > .chev { transform: rotate(90deg); }
   .prep .marker { transition: none; }
 }
 
+/* Reviewed toggle on recent-update rows — same control shape as the prep
+   marker: aria-pressed carries state and drives the color through the shared
+   theme tokens. Pressed (reviewed) rows are only visible under "Show reviewed",
+   where .dismissed dims them to read as already handled. */
+.wi .review {
+  flex: none;
+  font-family: inherit;
+  font-size: var(--fs-2xs); font-weight: 700; letter-spacing: .03em;
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  padding: var(--space-0) var(--space-3);
+  border-radius: var(--radius-pill);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  transition: color .15s ease, background .15s ease, border-color .15s ease;
+}
+.wi .review:hover { color: var(--text); border-color: var(--border-strong); }
+.wi .review[aria-pressed="true"] {
+  color: var(--good);
+  border-color: color-mix(in srgb, var(--good) 35%, transparent);
+  background: color-mix(in srgb, var(--good) 15%, transparent);
+}
+.wi.dismissed { opacity: .55; }
+@media (prefers-reduced-motion: reduce) {
+  .wi .review { transition: none; }
+}
+
+/* Toolbar toggle (Show reviewed) reuses .btn; aria-pressed marks it active. */
+.btn[aria-pressed="true"] {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  background: var(--accent-weak);
+}
+
 .primary {
   display: flex; gap: var(--space-5); align-items: flex-start;
   padding: var(--space-5) var(--space-6); margin: var(--space-5) 0 var(--space-1);

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -603,10 +603,12 @@ details[open] > summary > .chev { transform: rotate(90deg); }
 
 .note { font-size: var(--fs-smd); color: var(--text-dim); }
 
-/* Prep marker toggle — "prep still needed" (warn) flips to "all set" (good) on
-   aria-pressed. State drives the color, so the JS only toggles the attribute;
-   both palettes carry over through the same theme tokens the chips already use. */
-.prep .marker {
+/* Dismissal toggles — the prep marker and the reviewed toggle are one control
+   (JS builds both from a bucket spec). This is their shared shape: layout, the
+   pressed="handled" green treatment, and the reduced-motion opt-out all live
+   here once; each variant below only sets its resting color and hover. State
+   drives color through theme tokens, so both palettes carry over untouched. */
+.pill-toggle {
   flex: none;
   font-family: inherit;
   font-size: var(--fs-2xs); font-weight: 700; letter-spacing: .03em;
@@ -614,24 +616,45 @@ details[open] > summary > .chev { transform: rotate(90deg); }
   display: inline-flex; align-items: center; gap: var(--space-2);
   padding: var(--space-0) var(--space-3);
   border-radius: var(--radius-pill);
+  transition: color .15s ease, background .15s ease, border-color .15s ease;
+}
+.pill-toggle[aria-pressed="true"] {
+  color: var(--good);
+  border-color: color-mix(in srgb, var(--good) 35%, transparent);
+  background: color-mix(in srgb, var(--good) 15%, transparent);
+}
+@media (prefers-reduced-motion: reduce) {
+  .pill-toggle { transition: none; }
+}
+
+/* Prep marker — "prep still needed" (warn) resting, with a status dot. */
+.prep .marker {
   color: var(--warn);
   border: 1px solid color-mix(in srgb, var(--warn) 35%, transparent);
   background: color-mix(in srgb, var(--warn) 15%, transparent);
-  transition: color .15s ease, background .15s ease, border-color .15s ease;
 }
 .prep .marker::before {
   content: ""; width: 0.4375rem; height: 0.4375rem; border-radius: 50%;
   background: currentColor;
   flex: none;
 }
-.prep .marker[aria-pressed="true"] {
-  color: var(--good);
-  border-color: color-mix(in srgb, var(--good) 35%, transparent);
-  background: color-mix(in srgb, var(--good) 15%, transparent);
-}
 .prep .marker:hover { border-color: currentColor; }
-@media (prefers-reduced-motion: reduce) {
-  .prep .marker { transition: none; }
+
+/* Reviewed toggle on recent-update rows — neutral resting. Pressed (reviewed)
+   rows are only visible under "Show reviewed", where .dismissed dims them. */
+.wi .review {
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+}
+.wi .review:hover { color: var(--text); border-color: var(--border-strong); }
+.wi.dismissed { opacity: .55; }
+
+/* Toolbar toggle (Show reviewed) reuses .btn; aria-pressed marks it active. */
+.btn[aria-pressed="true"] {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  background: var(--accent-weak);
 }
 
 /* Prep tile list — a flat chronological list (the tile header already names the

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -603,9 +603,10 @@ details[open] > summary > .chev { transform: rotate(90deg); }
 
 .note { font-size: var(--fs-smd); color: var(--text-dim); }
 
-/* Dismissal + prep-marker toggles share one pill shape. The base holds layout,
-   the pressed="handled" green treatment, and the reduced-motion opt-out; each
-   variant below sets only its resting color, hover, and any extras. State drives
+/* Dismissal + prep-marker toggles share one pill shape. The base holds layout
+   and the reduced-motion opt-out; each variant below sets only its resting color
+   and hover. The pressed="handled" green treatment is defined last (see below)
+   so it wins over the variant resting rules at equal specificity. State drives
    color through theme tokens, so both palettes carry over untouched. */
 .pill-toggle {
   flex: none;
@@ -617,17 +618,12 @@ details[open] > summary > .chev { transform: rotate(90deg); }
   border-radius: var(--radius-pill);
   transition: color .15s ease, background .15s ease, border-color .15s ease;
 }
-.pill-toggle[aria-pressed="true"] {
-  color: var(--good);
-  border-color: color-mix(in srgb, var(--good) 35%, transparent);
-  background: color-mix(in srgb, var(--good) 15%, transparent);
-}
 @media (prefers-reduced-motion: reduce) {
   .pill-toggle { transition: none; }
 }
 
 /* Prep marker — "prep still needed" (warn) resting, with a status dot. Its
-   pressed="all set" (good) state comes from the shared .pill-toggle rule. */
+   pressed="all set" (good) state comes from the shared .pill-toggle rule below. */
 .prep .marker {
   color: var(--warn);
   border: 1px solid color-mix(in srgb, var(--warn) 35%, transparent);
@@ -653,6 +649,15 @@ details[open] > summary > .chev { transform: rotate(90deg); }
 .wi .review:hover,
 .prep .dismiss:hover { color: var(--text); border-color: var(--border-strong); }
 .wi.dismissed { opacity: .55; }
+
+/* Pressed = "handled": all set (marker), reviewed, removed. Defined after the
+   variant resting rules so it wins at equal specificity — the marker's "all set"
+   turning green depends on this order. */
+.pill-toggle[aria-pressed="true"] {
+  color: var(--good);
+  border-color: color-mix(in srgb, var(--good) 35%, transparent);
+  background: color-mix(in srgb, var(--good) 15%, transparent);
+}
 
 /* Toolbar toggle (Show reviewed) reuses .btn; aria-pressed marks it active. */
 .btn[aria-pressed="true"] {


### PR DESCRIPTION
<!-- toc:start -->
## Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #206 |
| [Changes](#changes) | ✅ 3 files |
| [Test Plan](#test-plan) | ✅ 20/20 |
| **Skill Reports** (latest verdict) | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4994371300) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4994385637) |
| 🛡️ Security Audit | ✅ APPROVE — [re-review](#issuecomment-4994687023) |
| 🎨 Front-End Engineer Review | ✅ APPROVE (2 MEDIUMs fixed) — [re-review](#issuecomment-4994707550) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [re-review](#issuecomment-4994691002) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-4994443824) |

> Reviews ran twice: once on the original diff, then again after this branch was reconciled with the separately-merged #207 (see Summary). The re-review links carry the current verdicts.
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

On boot, `loadTile` fetches each tile from the local cache (falling back to the sample `MODEL` when the backend is unreachable) and hands off to `paintTile`, which runs the model through the `viewModel` filter layer — `activityView`/`prepView` call `filterItems`, applying the 30-day `withinActivityWindow` cutoff and `dismissStore.isDismissed` before `renderTileBody` draws rows and derives the count/stat. Dismissal controls (the per-row `dismissToggleButton` and the toolbar **Show reviewed** toggle) mutate the `localStorage`-backed `dismissStore` (or the `showReviewed` flag) and call `repaintTile`, which re-derives the view model from the last-loaded data with no re-fetch. #207's prep marker (`prepMarkerButton` → `savePrepMarker`) is a separate, backend-persisted concern that leaves the row in place.

```mermaid
flowchart TD
    Boot([Boot: load all tiles]):::pub
    Toggle([dismissToggleButton]):::pub
    ShowRev([Show reviewed toggle]):::pub

    LoadTile[loadTile]:::pub
    Paint[paintTile]:::pub
    VM[viewModel<br/>activityView / prepView]:::priv
    Filter[filterItems]:::priv
    Window{within 30-day<br/>window?}
    Render[renderTileBody<br/>+ setStat + setStale]:::priv
    Repaint[repaintTile]:::pub
    Apply[applyDismissalToggle]:::priv

    Fetch["GET /api/tiles/:key"]:::io
    Sample[(MODEL sample<br/>fallback)]:::io
    Store[(dismissStore<br/>localStorage)]:::io

    Boot --> LoadTile
    LoadTile --> Fetch
    Fetch -- ok --> Paint
    Fetch -. offline .-> Sample
    Sample --> Paint

    Paint --> VM
    VM --> Filter
    Filter --> Window
    Window -- inside --> Store
    Window -. stale, drop .-> Filter
    Filter --> Render

    Toggle -.handoff.-> Apply
    Apply --> Store
    Apply -.repaint.-> Repaint
    ShowRev -.toggle showReviewed.-> Repaint
    Repaint --> Paint

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Bounds the daily-viewer "Recent updates" tile to the last 30 days and makes handled items dismissible so the tiles stay a short, current worklist. Recent-update rows get a **reviewed** toggle that removes the row; prep rows get a **Remove** control that removes the row. Dismissed items persist across refresh + reload via a `localStorage`-backed store (the client-side persistence seam for the eventual server cache) and a reviewed update reappears only if it changed after it was reviewed (inbox model). A **Show reviewed** toolbar toggle reveals dismissed rows dimmed, with per-row undo.

Browser-facing `daily-viewer/` surface only — no bash/PowerShell shortcut changes, so no shell parity applies (matches the issue's parity note).

> **Reconciled onto the current `main` (twice).** After this branch was cut, `main` split prep into its own tile, then merged **#207** ("persist prep 'all set' markers across cache reloads"). Per product decision, prep now keeps **both**: #207's persist-marker (`Prep still needed` ↔ `All set`, backend-persisted, **stays visible**) **and** this PR's separate **Remove** control (localStorage dismissal, drops the row). The feature was re-applied onto that base and re-reviewed; the front-end re-review's two MEDIUMs (a marker pressed-color CSS cascade regression and focus lost on repaint) are fixed.

## Issue

Closes #206

## Changes

- **`daily-viewer/app.js`**
  - `dismissStore` — `localStorage`-backed, bucket-namespaced dismissal (separate from #207's backend marker); a reviewed item reappears only on a newer `changedDate`
  - Per-bucket `ACTIVITY_SPEC` / `PREP_DISMISS_SPEC` drive both the filter and one shared `dismissToggleButton` (per-row `aria-label`, focus restored after the repaint)
  - 30-day window + a **view-model filter layer** (`activityView`, `prepView`) so render, count badges, and the stat read the same post-filter data
  - `activityRow` (reviewed toggle) and `prepRow` (keeps #207's `prepMarkerButton`, adds the Remove control); `flagDismissed` shared helper; `repaintTile` + `TILE_STATE`; `showReviewed` repaints activity + prep
  - Sample `changedDate` values (incl. one >30 days) so the window self-demonstrates
- **`daily-viewer/styles.css`** — shared `.pill-toggle` base (marker + reviewed + remove) with the pressed="handled" green defined last so it wins the cascade; `.wi.dismissed` dim; `.btn[aria-pressed]` active; #207's marker `aria-disabled` rule preserved
- **`daily-viewer/index.html`** — "Show reviewed" toolbar button

## Test Plan

Verified by driving the page in Chromium against a local static server (**20/20** automated checks passed):

- [x] Recent Activity shows 6 rows — the >30-day row is filtered out
- [x] "Mark reviewed" removes the row (stat/count drop, `aria-live` announced); focus returns to a control, not `<body>`
- [x] Reload — reviewed row stays gone (`localStorage`)
- [x] "Show reviewed" reveals the row dimmed with a pressed toggle; undo restores it
- [x] Prep marker toggles "all set" **in place** (row stays; #207 preserved) and renders green vs warn
- [x] Prep "Remove" drops the row and survives reload; undo brings it back
- [x] Per-row `aria-label`s; all three controls share `.pill-toggle`; no `innerHTML` (XSS smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfbrzhBsxf4egroGPoDxtx