### PR TITLE
Daily Viewer: refresh all tiles on first run of the day + -Refresh switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,9 +687,12 @@ Supported `type` values: `string`, `int`, `picklist`, `bool`, `date`, `multiline
 az-Start-AzDevOpsDailyViewer            # serve on http://127.0.0.1:8770/ and open the browser
 az-Start-AzDevOpsDailyViewer -Port 9000 # pick a different loopback port
 az-Start-AzDevOpsDailyViewer -NoBrowser # serve without auto-opening the browser (scripted / curl checks)
+az-Start-AzDevOpsDailyViewer -Refresh   # force-rebuild all four tiles at startup, regardless of the daily refresh
 ```
 
 The server is a built-in `System.Net.HttpListener` (no external modules) bound to `127.0.0.1` only — never `0.0.0.0` — and your `az login` / PAT stays inside the server process; responses carry only work-item and agenda data. Press `Ctrl+C` to stop it.
+
+The **first startup of each calendar day** rebuilds all four tiles before serving, so the dashboard opens on today's real agenda and work instead of yesterday's cache (a small `refreshed-on.json` stamp beside the tile cache records the day). Same-day restarts skip the rebuild and only fill any missing tile, so they stay instant; pass `-Refresh` to force a full rebuild on demand. A tile whose source is unavailable during the daily rebuild fails soft — the other tiles still refresh and the server still starts.
 
 Each tile is backed by one JSON file under the active project's cache slice — `~/.bashcuts-az-devops-app/cache/<project-slug>/daily-viewer/{agenda,week,activity,focus}.json` (or the unsegmented `cache/daily-viewer/` for single-project use) — so it follows `az-Use-AzDevOpsProject` exactly like the synced datasets. Staleness is derived from each file's modified time and returned to the page. The API keeps the cheap and expensive paths distinct:
 

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -31,6 +31,8 @@ $script:AzDevOpsDailyViewerLoopbackAddress = '127.0.0.1'
 $script:AzDevOpsDailyViewerJsonDepth       = 10      # nesting the tile payloads / API responses serialize to
 $script:AzDevOpsDailyViewerPrepWindowDays  = 14      # "events to prepare for" look-ahead: the next two weeks
 $script:AzDevOpsDailyViewerMarkerNeeded    = 'needed'  # a newly-pulled meeting starts "prep still needed"
+$script:AzDevOpsDailyViewerRefreshStampFile = 'refreshed-on.json'  # per-day full-refresh marker beside the tile cache
+$script:AzDevOpsDailyViewerDayKeyFormat     = 'yyyy-MM-dd'         # calendar-day granularity the daily refresh gates on
 
 # Strict Content-Security-Policy for the served app. The page loads styles.css +
 # app.js as external same-origin assets and fetches /api/tiles/* same-origin;
@@ -738,6 +740,109 @@ function Initialize-AzDevOpsDailyViewerCache {
 
 
 # ---------------------------------------------------------------------------
+# Daily full-refresh gating — rebuild every tile once per calendar day
+# ---------------------------------------------------------------------------
+
+function Get-AzDevOpsDailyViewerRefreshStampPath {
+    # Path to the per-day full-refresh stamp, alongside the tile cache under the
+    # active project slice. $null when no cache dir resolves (not connected yet).
+    $dir = Get-AzDevOpsDailyViewerCacheDir
+    if (-not $dir) {
+        return $null
+    }
+
+    $path = Join-Path $dir $script:AzDevOpsDailyViewerRefreshStampFile
+    return $path
+}
+
+
+function Get-AzDevOpsDailyViewerDayKey {
+    # Today's calendar-day key ("2026-07-16") — the unit the daily refresh gates
+    # on, so a rebuild happens at most once per day but on the first startup of it.
+    param([datetime] $When = (Get-Date))
+
+    $key = $When.ToString($script:AzDevOpsDailyViewerDayKeyFormat)
+    return $key
+}
+
+
+function Read-AzDevOpsDailyViewerRefreshDay {
+    # The day key recorded by the last full refresh, or $null when the stamp is
+    # missing / unreadable (the due check treats that as "never refreshed").
+    $path = Get-AzDevOpsDailyViewerRefreshStampPath
+    if (-not $path -or -not (Test-Path -LiteralPath $path)) {
+        return $null
+    }
+
+    try {
+        $raw    = Get-Content -LiteralPath $path -Raw
+        $record = $raw | ConvertFrom-Json
+
+        $day = $record.day
+        return $day
+    }
+    catch {
+        return $null
+    }
+}
+
+
+function Write-AzDevOpsDailyViewerRefreshStamp {
+    # Record that a full refresh ran today, so same-day restarts skip the rebuild.
+    $path = Get-AzDevOpsDailyViewerRefreshStampPath
+    if (-not $path) {
+        return
+    }
+
+    $dir = Split-Path -Parent $path
+    New-AzDevOpsDirectoryIfMissing -Path $dir
+
+    $record = [ordered]@{
+        day         = Get-AzDevOpsDailyViewerDayKey
+        refreshedAt = (Get-Date).ToString('o')
+    }
+
+    $json = $record | ConvertTo-Json -Depth $script:AzDevOpsDailyViewerJsonDepth
+    Write-AzDevOpsCacheFile -Path $path -Content $json
+}
+
+
+function Test-AzDevOpsDailyViewerRefreshDue {
+    # $true when no full refresh has run today (stamp missing or from a prior day)
+    # — this is what makes the first viewer startup of the day rebuild every tile.
+    $recorded = Read-AzDevOpsDailyViewerRefreshDay
+    if (-not $recorded) {
+        return $true
+    }
+
+    $today = Get-AzDevOpsDailyViewerDayKey
+    $isDue = ($recorded -ne $today)
+    return $isDue
+}
+
+
+function Update-AzDevOpsDailyViewerAllTiles {
+    # EXPENSIVE: rebuild every tile's cache, then stamp today's date. Each tile is
+    # isolated in its own try/catch so one failing source (a lapsed az login,
+    # Outlook unreachable) rebuilds the rest and never aborts startup; the
+    # per-tile builders already fail soft, this guards the rare hard throw.
+    # Per-tile failures are logged server-side for later diagnosis.
+    $names = Get-AzDevOpsDailyViewerTileNames
+
+    foreach ($name in $names) {
+        try {
+            $null = Write-AzDevOpsDailyViewerTile -Tile $name
+        }
+        catch {
+            Write-AzDevOpsSyncLog "daily-viewer: full refresh of tile '$name' failed: $($_.Exception.Message)"
+        }
+    }
+
+    Write-AzDevOpsDailyViewerRefreshStamp
+}
+
+
+# ---------------------------------------------------------------------------
 # Static asset serving
 # ---------------------------------------------------------------------------
 
@@ -1037,15 +1142,27 @@ function az-Start-AzDevOpsDailyViewer {
         az login / PAT never leaves this process; responses carry only work-item
         and agenda data. Press Ctrl+C to stop.
 
+        On the first startup of each calendar day every tile is rebuilt before
+        serving, so the dashboard opens on today's real agenda and work instead
+        of yesterday's cache. Same-day restarts skip the rebuild (and only fill
+        any missing tile) so they stay instant. Pass -Refresh to force a full
+        rebuild on demand regardless of the day.
+
     .PARAMETER Port
         Loopback TCP port to listen on. Defaults to 8770.
 
     .PARAMETER NoBrowser
         Skip auto-opening the default browser (useful for scripted / curl checks).
+
+    .PARAMETER Refresh
+        Force a full rebuild of all four tiles at startup, regardless of whether
+        the daily refresh has already run. Use it to reload the whole dashboard
+        without waiting for the next day or clicking refresh on each tile.
     #>
     param(
         [int]    $Port = $script:AzDevOpsDailyViewerDefaultPort,
-        [switch] $NoBrowser
+        [switch] $NoBrowser,
+        [switch] $Refresh
     )
 
     $staticRoot = Get-AzDevOpsDailyViewerStaticRoot
@@ -1060,7 +1177,12 @@ function az-Start-AzDevOpsDailyViewer {
         return
     }
 
-    Initialize-AzDevOpsDailyViewerCache
+    if ($Refresh -or (Test-AzDevOpsDailyViewerRefreshDue)) {
+        Write-Host 'Refreshing all tiles for today...' -ForegroundColor Cyan
+        Update-AzDevOpsDailyViewerAllTiles
+    } else {
+        Initialize-AzDevOpsDailyViewerCache
+    }
 
     $prefix = Get-AzDevOpsDailyViewerPrefix -Port $Port
     $listener = New-Object System.Net.HttpListener

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -826,19 +826,25 @@ function Update-AzDevOpsDailyViewerAllTiles {
     # isolated in its own try/catch so one failing source (a lapsed az login,
     # Outlook unreachable) rebuilds the rest and never aborts startup; the
     # per-tile builders already fail soft, this guards the rare hard throw.
-    # Per-tile failures are logged server-side for later diagnosis.
+    # Per-tile failures are logged server-side for later diagnosis. The day is
+    # stamped only when at least one tile rebuilt, so a startup where every tile
+    # hard-throws doesn't burn the day's refresh — the next startup retries.
     $names = Get-AzDevOpsDailyViewerTileNames
 
+    $rebuilt = 0
     foreach ($name in $names) {
         try {
             $null = Write-AzDevOpsDailyViewerTile -Tile $name
+            $rebuilt++
         }
         catch {
             Write-AzDevOpsSyncLog "daily-viewer: full refresh of tile '$name' failed: $($_.Exception.Message)"
         }
     }
 
-    Write-AzDevOpsDailyViewerRefreshStamp
+    if ($rebuilt -gt 0) {
+        Write-AzDevOpsDailyViewerRefreshStamp
+    }
 }
 
 


### PR DESCRIPTION
<!-- toc:start -->
## Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #212 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | ✅ 5 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-4994379484) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-4994390223) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-4994388211) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-4994392245) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](#issuecomment-4994382608) |
| 📚 Docs Check | ✅ CURRENT — [View](#issuecomment-4994414622) |
| ✅ Criteria Check | ✅ PASS (7/8, 1 needs local pwsh parse) — [View](#issuecomment-4994420860) |
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

`az-Start-AzDevOpsDailyViewer` now gates a full tile rebuild on the first startup of each calendar day (or whenever `-Refresh` is passed). A `refreshed-on.json` day stamp beside the tile cache drives the decision: when a rebuild is due, every tile is rewritten fail-soft and the day is stamped only if at least one tile succeeded, so a startup where every source hard-throws doesn't burn the day's refresh. Same-day, non-forced restarts fall back to the cheap gap-fill seed so they stay instant.

```mermaid
flowchart TD
    Entry([az-Start-AzDevOpsDailyViewer<br/>-Refresh?]):::pub

    Gate{-Refresh forced<br/>or refresh due?}
    DueChk[Test-AzDevOpsDailyViewerRefreshDue]:::priv
    ReadDay[Read-AzDevOpsDailyViewerRefreshDay]:::priv
    DayKey[Get-AzDevOpsDailyViewerDayKey<br/>today yyyy-MM-dd]:::priv
    Stamp[(refreshed-on.json<br/>day stamp)]:::io

    UpdateAll[Update-AzDevOpsDailyViewerAllTiles]:::priv
    TileNames[Get-AzDevOpsDailyViewerTileNames]:::priv
    WriteTile["Write-AzDevOpsDailyViewerTile<br/>per tile, fail-soft try/catch"]:::io
    Rebuilt{1+ tile rebuilt?}
    WriteStamp[Write-AzDevOpsDailyViewerRefreshStamp]:::priv

    GapFill[Initialize-AzDevOpsDailyViewerCache<br/>gap-fill only]:::priv
    Serve([serve dashboard on 127.0.0.1]):::pub

    Entry --> Gate
    Gate -. due check .-> DueChk
    DueChk --> ReadDay --> Stamp
    DueChk -. compares .-> DayKey

    Gate -- yes --> UpdateAll
    UpdateAll --> TileNames --> WriteTile --> Rebuilt
    Rebuilt -- yes --> WriteStamp --> Stamp
    WriteStamp --> Serve
    Rebuilt -- no --> Serve

    Gate -- no --> GapFill --> Serve

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
`az-Start-AzDevOpsDailyViewer` seeded its cache with `Initialize-AzDevOpsDailyViewerCache`, which only *fills gaps* — it never rewrote a tile that already existed, so starting the viewer in the morning served yesterday&#39;s agenda until each tile was refreshed by hand. This PR rebuilds **all four tiles on the first startup of each calendar day** (gated by a `refreshed-on.json` day stamp beside the tile cache) and adds a **`-Refresh` switch** to force a full rebuild on demand. Same-day restarts fall back to the cheap gap-fill seed so they stay instant.

PowerShell-only — the daily viewer is a served PS app with no bash counterpart.

## Issue
Closes #212

## Changes
- **`powcuts_by_cli/daily_viewer.ps1`**
  - New constants: `AzDevOpsDailyViewerRefreshStampFile` (`refreshed-on.json`), `AzDevOpsDailyViewerDayKeyFormat` (`yyyy-MM-dd`)
  - New &#34;Daily full-refresh gating&#34; helpers:
    - `Get-AzDevOpsDailyViewerRefreshStampPath` — stamp path under the active project cache slice
    - `Get-AzDevOpsDailyViewerDayKey` — today&#39;s `yyyy-MM-dd` day key
    - `Read-AzDevOpsDailyViewerRefreshDay` — last-refresh day from the stamp (`$null` if missing/unreadable)
    - `Write-AzDevOpsDailyViewerRefreshStamp` — record today&#39;s refresh
    - `Test-AzDevOpsDailyViewerRefreshDue` — `$true` when no full refresh has run today
    - `Update-AzDevOpsDailyViewerAllTiles` — rebuild every tile (fail-soft per tile via try/catch + `Write-AzDevOpsSyncLog`), then stamp
  - `az-Start-AzDevOpsDailyViewer` gains a `-Refresh` switch (+ comment-based help); startup now does a full rebuild when `-Refresh` is passed **or** the daily refresh is due, otherwise the existing gap-fill seed
- **`README.md`** — documented the daily auto-refresh, the `refreshed-on.json` stamp, and the `-Refresh` flag in the daily-viewer section

## Test Plan
- [ ] `pwsh -NoProfile -Command &#34;[System.Management.Automation.Language.Parser]::ParseFile(&#39;powcuts_by_cli/daily_viewer.ps1&#39;,[ref]$null,[ref]$null)&#34;` — parses clean *(couldn&#39;t run in CI env; `pwsh` unavailable)*
- [ ] Fresh cache / delete `refreshed-on.json`, run `az-Start-AzDevOpsDailyViewer` → &#34;Refreshing all tiles for today...&#34;; all four tile `writtenAt` advance; stamp written with today&#39;s date
- [ ] Same-day restart → no rebuild, tiles keep their `writtenAt`
- [ ] `az-Start-AzDevOpsDailyViewer -Refresh` → rebuilds all four regardless of the stamp
- [ ] With `az logout`, startup rebuild fails soft — other tiles still rebuild and the server still serves

---
_Generated by [Claude Code](https://claude.ai/code/session_01BctyacfVBXEXYawmCAerbx)_