### PR TITLE
Daily Viewer: limit "This Week's Focus" to completable work items (User Story + Bug)

### DIFF
--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -44,6 +44,9 @@ var MODEL = {
     ]
   },
 
+  // "This Week's Focus" is scoped to completable work — User Story and Bug only.
+  // The live backend filters assigned rows to $script:AzDevOpsDailyViewerWeekTypes,
+  // so keep this sample list to those two types (no Task/Feature) to stay in parity.
   week: {
     stories: {
       label: "Stories to complete",

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -55,6 +55,10 @@ $script:AzDevOpsDailyViewerTitleDash = "$([char]0x2014)"   # em dash — "Story 
 $script:AzDevOpsDailyViewerMiddot    = "$([char]0x00B7)"   # middle dot — "<sub> · <state>"
 $script:AzDevOpsDailyViewerJoinLabel = "Join meeting $([char]0x2192)"   # right arrow
 
+# The week tile is "Stories to complete" — the work the user personally finishes.
+# Assigned Tasks/Features are excluded; only these completable types survive the filter.
+$script:AzDevOpsDailyViewerWeekTypes = @('User Story', 'Bug')
+
 $script:AzDevOpsDailyViewerMimeTypes = @{
     '.html' = 'text/html; charset=utf-8'
     '.css'  = 'text/css; charset=utf-8'
@@ -432,7 +436,10 @@ function Get-AzDevOpsDailyViewerWeekItems {
     $assigned = @(Get-AzDevOpsDailyViewerAssignedRows)
 
     $activeRows = Get-AzDevOpsDailyViewerActiveRows -Rows $assigned
-    $storyItems = @($activeRows | ForEach-Object {
+
+    $completableRows = @($activeRows | Where-Object { $_.Type -in $script:AzDevOpsDailyViewerWeekTypes })
+
+    $storyItems = @($completableRows | ForEach-Object {
         New-AzDevOpsDailyViewerWorkItemNode -Row $_ -LinkTitle -Date $_.TargetDate
     })
 


### PR DESCRIPTION
<!-- toc:start -->
| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #216 |
| [Changes](#changes) | ✅ 2 files |
| [Test Plan](#test-plan) | ✅ 3 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/217#issuecomment-4997731600) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/217#issuecomment-4997735836) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/217#issuecomment-4997726968) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/217#issuecomment-4997736615) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/217#issuecomment-4997735266) |
| ✅ Criteria Check | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/217#issuecomment-4997751061) |
<!-- toc:end -->

## Summary

The "This Week's Focus" tile is labeled *"Stories to complete"* but `Get-AzDevOpsDailyViewerWeekItems` filtered your assigned rows only by **state** — never by work-item **type** — so assigned Tasks/Features due this week leaked into it. This scopes the tile to the work you personally complete: **User Story + Bug**.

## Issue

Closes #216

## Changes

| File | Change |
|------|--------|
| `powcuts_by_cli/daily_viewer.ps1` | Added `$script:AzDevOpsDailyViewerWeekTypes = @('User Story', 'Bug')` allow-list near the other `$script:` constants; `Get-AzDevOpsDailyViewerWeekItems` now filters active rows by `.Type` against it before projecting to nodes. `@()`-wrapped so an all-excluded result stays an empty array (empty state renders, no `$null`-unroll). |
| `daily-viewer/app.js` | Comment on `MODEL.week` documenting the Story+Bug contract so a Task/Feature isn't reintroduced. Sample data already conformed (2 Stories + 1 Bug). |

PowerShell + browser surface only — the daily viewer has no bash counterpart, so no `bashcuts_by_cli/` changes.

## Test Plan

- [ ] `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('powcuts_by_cli/daily_viewer.ps1', [ref]$null, [ref]$null)"` — parses clean
- [ ] Assign yourself a **Task** and a **Bug** due this week, refresh the week tile — the Bug (and any User Stories) appears; the Task does not
- [ ] Open `daily-viewer/index.html` — "This Week's Focus" lists the two Stories + the Bug, no Task/Feature; count derives from the list length

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Te9FQT74VSdNVVLGr6ysr8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Te9FQT74VSdNVVLGr6ysr8)_