### PR TITLE
Daily Viewer: scope focus tiles to the current sprint iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ Supported `type` values: `string`, `int`, `picklist`, `bool`, `date`, `multiline
 
 ### Daily viewer (local dashboard)
 
-`az-Start-AzDevOpsDailyViewer` (in `powcuts_by_cli/daily_viewer.ps1`, tab-tab on `az-` to discover it) serves the `daily-viewer/` dashboard from your machine so the four agenda tiles (Today's Agenda, This Week's Focus, Recent Activity, Today's Focus) render instantly from a local cache and only hit Azure DevOps when you refresh a tile.
+`az-Start-AzDevOpsDailyViewer` (in `powcuts_by_cli/daily_viewer.ps1`, tab-tab on `az-` to discover it) serves the `daily-viewer/` dashboard from your machine so the five tiles — **Today's Agenda** and **Events to Prepare For** (Calendar) plus **This Sprint's Focus**, **Recent Activity**, and **Today's Focus** (Azure DevOps) — render instantly from a local cache and only hit their live source when you refresh a tile.
 
 ```powershell
 az-Start-AzDevOpsDailyViewer            # serve on http://127.0.0.1:8770/ and open the browser
@@ -694,7 +694,7 @@ The server is a built-in `System.Net.HttpListener` (no external modules) bound t
 
 The **first startup of each calendar day** rebuilds every tile before serving, so the dashboard opens on today's real agenda and work instead of yesterday's cache (a small `refreshed-on.json` stamp beside the tile cache records the day). Same-day restarts skip the rebuild and only fill any missing tile, so they stay instant; pass `-Refresh` to force a full rebuild on demand. A tile whose source is unavailable during the daily rebuild fails soft — the other tiles still refresh and the server still starts.
 
-Each tile is backed by one JSON file under the active project's cache slice — `~/.bashcuts-az-devops-app/cache/<project-slug>/daily-viewer/{agenda,week,activity,focus}.json` (or the unsegmented `cache/daily-viewer/` for single-project use) — so it follows `az-Use-AzDevOpsProject` exactly like the synced datasets. Staleness is derived from each file's modified time and returned to the page. The API keeps the cheap and expensive paths distinct:
+Each tile is backed by one JSON file under the active project's cache slice — `~/.bashcuts-az-devops-app/cache/<project-slug>/daily-viewer/{agenda,prep,week,activity,focus}.json` (or the unsegmented `cache/daily-viewer/` for single-project use) — so it follows `az-Use-AzDevOpsProject` exactly like the synced datasets. Staleness is derived from each file's modified time and returned to the page. The API keeps the cheap and expensive paths distinct:
 
 - `GET /` — the page and its static assets.
 - `GET /api/tiles/<name>` — that tile's cached JSON, plus its `ageSeconds` / `stale` staleness (cheap read).
@@ -704,7 +704,8 @@ Each tile is backed by one JSON file under the active project's cache slice — 
 Each tile is populated from a real source, reusing the same WIQL defaults and Outlook module the rest of the toolkit uses:
 
 - **Today's Agenda** — today's calendar events from `ol-Get-OutlookAgenda` (desktop Outlook), with the Teams join link when the meeting carries one.
-- **This Week's Focus** — your active assigned stories (the `assigned` WIQL) plus an "events to prepare for" list spanning the next two weeks of meetings, each row carrying a date and a marker you can toggle between "prep still needed" and "all set." That choice is saved server-side by the meeting's event id (a small `prep-markers.json` beside the tile cache), so a meeting you mark "all set" stays that way when the cache reloads.
+- **Events to Prepare For** — the next two weeks of meetings, each row carrying a date, a Teams join link when the meeting has one, and a marker you can toggle between "prep still needed" and "all set." That choice is saved server-side by the meeting's event id (a small `prep-markers.json` beside the tile cache), so a meeting you mark "all set" stays that way when the cache reloads.
+- **This Sprint's Focus** — your active current-sprint assigned stories (the `assigned` WIQL), scoped to the iteration that brackets today (falling back to all active assigned stories when none match).
 - **Recent Activity** — @-mention discussions (the `mentions` WIQL), your recent updates (the `activity` WIQL), and your current-sprint items (the `activity` rows scoped to the iteration that brackets today). The current-sprint group reads `[System.IterationPath]` off the `activity` WIQL; the seeded default already selects it, but if you seeded your `activity.wiql` before this field was added, open `o-az-devops-queries-config-dir`, add `[System.IterationPath]` to the `SELECT` in `activity.wiql`, and re-run `az-Sync-AzDevOpsCache` so the group can populate.
 - **Today's Focus** — the pinned work item you set in `$global:AzDevOpsDailyFocus` (a work-item id), plus an "assigned & unplanned support" bucket. Set it in your `$profile`, e.g. `$global:AzDevOpsDailyFocus = 1234`; leave it unset and the tile shows the support bucket alone.
 

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -44,6 +44,9 @@ var MODEL = {
     ]
   },
 
+  // This Sprint's Focus. The backend scopes these to the current sprint
+  // iteration (System.IterationPath), so every row here is an in-sprint item;
+  // when no current iteration resolves it falls back to all active assigned work.
   week: {
     stories: {
       label: "Stories to complete",
@@ -943,7 +946,7 @@ var TILES = [
     empty: "No meetings to prepare for in the next two weeks.",
     statCount: function (m) { return asArray(m.items).length; } },
   { key: "week",     render: renderWeek,     stat: "tile-week",
-    empty: "No stories to complete this week.",
+    empty: "No stories in the current sprint.",
     statCount: function (m) { return asArray(m.stories && m.stories.items).length; } },
   { key: "activity", render: renderActivity, stat: "tile-activity",
     empty: "No recent activity.",

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -41,7 +41,7 @@
       <button class="stat p" type="button" data-target="tile-prep"><span class="n"></span><span class="l">Events to prep</span></button>
       <button class="stat g" type="button" data-target="tile-focus"><span class="n"></span><span class="l">Support &amp; focus items</span></button>
       <button class="stat s" type="button" data-target="tile-activity"><span class="n"></span><span class="l">Recent updates</span></button>
-      <button class="stat f" type="button" data-target="tile-week"><span class="n"></span><span class="l">Stories due this week</span></button>
+      <button class="stat f" type="button" data-target="tile-week"><span class="n"></span><span class="l">Stories in current sprint</span></button>
     </section>
 
     <!-- Tiles group under two collapsible parent sections by data source: Calendar
@@ -106,15 +106,15 @@
 
         <div class="grid">
 
-          <!-- This Week's Focus -->
+          <!-- This Sprint's Focus -->
           <section class="tile" id="tile-week" data-tile="week" aria-labelledby="h-week">
             <details open>
               <summary>
                 <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h3 id="h-week">This Week&rsquo;s Focus</h3><span class="count"></span></span>
+                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h3 id="h-week">This Sprint&rsquo;s Focus</h3><span class="count"></span></span>
                 <span class="tile-meta">
                   <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 2h ago</span>
-                  <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Week&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                  <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Sprint&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
                 </span>
               </summary>
               <div class="body"></div>

--- a/docs/azure-devops-diagrams.md
+++ b/docs/azure-devops-diagrams.md
@@ -1183,6 +1183,8 @@ graph LR
     DVAgenda --> DVQuery
     DVActivity --> DVQuery
     DVActivity --> DVSprint
+    DVWeek --> DVSprint
+    DVFocus --> DVSprint
     DVSprint --> CurCache
     DVSprint --> IterPathEnv
     DVFocus --> DVQuery

--- a/powcuts_by_cli/daily_viewer.ps1
+++ b/powcuts_by_cli/daily_viewer.ps1
@@ -434,7 +434,8 @@ function Get-AzDevOpsDailyViewerWeekItems {
     $assigned = @(Get-AzDevOpsDailyViewerAssignedRows)
 
     $activeRows = Get-AzDevOpsDailyViewerActiveRows -Rows $assigned
-    $storyItems = @($activeRows | ForEach-Object {
+    $sprintRows = Get-AzDevOpsDailyViewerCurrentSprintRows -Rows $activeRows -FallbackToAllActive
+    $storyItems = @($sprintRows | ForEach-Object {
         New-AzDevOpsDailyViewerWorkItemNode -Row $_ -LinkTitle -Date $_.TargetDate
     })
 
@@ -487,15 +488,20 @@ function New-AzDevOpsDailyViewerActivityGroup {
 
 
 function Get-AzDevOpsDailyViewerCurrentSprintRows {
-    # Filter activity rows to the current sprint. The iteration path comes from
-    # the cache-only Resolve-AzDevOpsCurrentIterationFromCache (no live `az`
-    # callout, honoring the viewer's read path), falling back to $env:AZ_ITERATION;
-    # when neither resolves, the group renders empty rather than guessing a sprint.
-    # Exact-path match mirrors Get-AzDevOpsDayViewRows. Comma-wrapped returns so an
-    # empty result stays an empty array through the caller's assignment instead of
-    # unrolling to $null (which the -Rows [object[]] bind would reject).
+    # Filter rows to the current sprint. The iteration path comes from the
+    # cache-only Resolve-AzDevOpsCurrentIterationFromCache (no live `az` callout,
+    # honoring the viewer's read path), falling back to $env:AZ_ITERATION. When
+    # neither resolves the default is to return empty rather than guessing a
+    # sprint (the Recent Activity "Current sprint" group), but the focus tiles pass
+    # -FallbackToAllActive to get the input rows back unfiltered instead, so a
+    # stale or empty iteration cache widens scope to all active items rather than
+    # blanking the tile. Exact-path match mirrors Get-AzDevOpsDayViewRows.
+    # Comma-wrapped returns so an empty result stays an empty array through the
+    # caller's assignment instead of unrolling to $null (which the -Rows
+    # [object[]] bind would reject).
     param(
-        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Rows
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Rows,
+        [switch] $FallbackToAllActive
     )
 
     $current = Resolve-AzDevOpsCurrentIterationFromCache
@@ -503,6 +509,10 @@ function Get-AzDevOpsDailyViewerCurrentSprintRows {
     $iterationPath = Resolve-AzDevOpsIterationPathOrEnv -Current $current
 
     if (-not $iterationPath) {
+        if ($FallbackToAllActive) {
+            return ,$Rows
+        }
+
         return ,@()
     }
 
@@ -602,7 +612,8 @@ function Get-AzDevOpsDailyViewerFocusItems {
     $focusId = Get-AzDevOpsDailyFocusId
 
     $activeRows = Get-AzDevOpsDailyViewerActiveRows -Rows $assigned
-    $supportRows = @($activeRows | Where-Object {
+    $sprintRows = Get-AzDevOpsDailyViewerCurrentSprintRows -Rows $activeRows -FallbackToAllActive
+    $supportRows = @($sprintRows | Where-Object {
         -not $focusId -or [int]$_.Id -ne $focusId
     })
     $supportItems = @($supportRows | ForEach-Object {


### PR DESCRIPTION

## Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #218 |
| [Changes](#changes) | ✅ 5 files |
| [Scope notes](#scope-notes) | ✅ |
| [Test Plan](#test-plan) | 0/4 items |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-5003862804) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-5003879420) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-5003871434) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-5003883471) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](#issuecomment-5003880020) |
| 🔍 Criteria Check | ✅ PASS — [View](#issuecomment-5003901811) |

<!-- pr-diagram:start -->
## How it works

No new public (`az-*`) surface — the delta is internal wiring. Both focus tiles (`Get-AzDevOpsDailyViewerWeekItems` and the `support` bucket of `Get-AzDevOpsDailyViewerFocusItems`) now route their active assigned rows through the shared `Get-AzDevOpsDailyViewerCurrentSprintRows` helper with the new `-FallbackToAllActive` switch, which resolves the current iteration from cache (then `$env:AZ_ITERATION`) and filters by `System.IterationPath` — falling back to the unfiltered input rows instead of a blank tile when no iteration resolves.

```mermaid
flowchart TD
    Week([Get-AzDevOpsDailyViewerWeekItems]):::pub
    Focus([Get-AzDevOpsDailyViewerFocusItems<br/>support bucket]):::pub

    Sprint[Get-AzDevOpsDailyViewerCurrentSprintRows<br/>-FallbackToAllActive]:::priv
    Cache[(Resolve current iteration<br/>from cache)]:::io
    Env[fallback: $env:AZ_ITERATION]:::priv
    GateIter{iteration<br/>resolved?}
    Filter[filter rows by<br/>System.IterationPath]
    GateFallback{-FallbackToAllActive?}

    DoneFiltered([return in-sprint rows]):::pub
    DoneAll([return input rows<br/>unfiltered]):::pub
    DoneEmpty([return empty set]):::pub
    Tile[/This Sprint's Focus tile<br/>index.html + app.js relabel/]:::io

    Week --> Sprint
    Focus --> Sprint
    Sprint --> Cache --> Env --> GateIter
    GateIter -- yes --> Filter --> DoneFiltered
    GateIter -- no --> GateFallback
    GateFallback -- yes --> DoneAll
    GateFallback -- no --> DoneEmpty
    DoneFiltered -.render.-> Tile
    DoneAll -.render.-> Tile

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
The daily viewer's **This Week's Focus** tile and the **Today's Focus** "Assigned &amp; unplanned support" bucket listed every assigned, active work item regardless of iteration. This scopes both to the **current sprint iteration** (`System.IterationPath`), reusing the resolver the Recent Activity "Current sprint" group already uses, and relabels the front-end from "week" to "sprint" wording.

## Issue
Closes #218

## Changes
- **`powcuts_by_cli/daily_viewer.ps1`**
  - Added a `-FallbackToAllActive` switch to `Get-AzDevOpsDailyViewerCurrentSprintRows`. When no current iteration resolves from cache **and** `$env:AZ_ITERATION` is unset, it returns the input rows unfiltered instead of an empty set — so a stale/empty iteration cache widens scope back to all active work rather than blanking the tile.
  - Routed `Get-AzDevOpsDailyViewerWeekItems` and the `support` bucket in `Get-AzDevOpsDailyViewerFocusItems` through that helper with the fallback. The pinned Today's Focus `primary` item is untouched.
- **`daily-viewer/index.html`** — week tile heading + refresh `aria-label` → **This Sprint's Focus**; stat label → **Stories in current sprint**.
- **`daily-viewer/app.js`** — tile empty-state → "No stories in the current sprint."; annotated the mock `week` model to document the sprint-scoping + fallback.

## Scope notes
- **No bash counterpart** — daily-viewer is PowerShell backend + front-end only; no `bashcuts_by_cli/` parity work.
- **WPF prototype not touched** — `daily-viewer/wpf/` is a reference surface (HTML is primary per `CLAUDE.md`) with no sprint-scoping backend, so its "This Week's Focus" wording was intentionally left as-is; a follow-up can align it if desired.

## Test Plan
- [ ] `pwsh` parses `powcuts_by_cli/daily_viewer.ps1` with zero errors *(pwsh unavailable in the build env — needs a local parse)*
- [ ] Fresh PowerShell terminal after `reinit`: with a current sprint resolvable, `Get-AzDevOpsDailyViewerWeekItems` returns only rows whose `Iteration` equals the current iteration path
- [ ] With the iteration cache cleared and `$env:AZ_ITERATION` unset, the week + focus-support tiles fall back to all active assigned rows (no blank tile)
- [ ] Open `daily-viewer/index.html` in a browser — tile reads **This Sprint's Focus**, stat reads **Stories in current sprint**; collapse/expand, stat-jump, live filter, theme, and refresh all still work

---
_Generated by [Claude Code](https://claude.ai/code/session_016xEyDQ8BKJ7yKArD3tyfuB)_