### PR TITLE
Daily Viewer — merge the two Outlook tiles into one Calendar tile with collapsible Agenda / Prep sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ Supported `type` values: `string`, `int`, `picklist`, `bool`, `date`, `multiline
 
 ### Daily viewer (local dashboard)
 
-`az-Start-AzDevOpsDailyViewer` (in `powcuts_by_cli/daily_viewer.ps1`, tab-tab on `az-` to discover it) serves the `daily-viewer/` dashboard from your machine so the five tiles — **Today's Agenda** and **Events to Prepare For** (Calendar) plus **This Sprint's Focus**, **Recent Activity**, and **Today's Focus** (Azure DevOps) — render instantly from a local cache and only hit their live source when you refresh a tile.
+`az-Start-AzDevOpsDailyViewer` (in `powcuts_by_cli/daily_viewer.ps1`, tab-tab on `az-` to discover it) serves the `daily-viewer/` dashboard from your machine so the tiles — a **Calendar** tile grouping **Today's Agenda** and **Events to Prepare For** as collapsible sections, plus **This Sprint's Focus**, **Recent Activity**, and **Today's Focus** (Azure DevOps) — render instantly from a local cache and only hit their live source when you refresh a tile.
 
 ```powershell
 az-Start-AzDevOpsDailyViewer            # serve on http://127.0.0.1:8770/ and open the browser

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -934,6 +934,10 @@ function viewModel(key, model) {
 // What counts as a "row" across mount, count badges, and the live filter.
 var ROW_SELECTOR = ".wi, .event";
 
+// The live filter's placeholder, re-added after every (re)render. Named so the
+// per-tile and calendar render paths can't drift on the wording.
+var NOMATCH_TEXT = "No matching items in this tile.";
+
 function activityTotal(model) {
   return asArray(model.groups).reduce(function (sum, group) {
     return sum + asArray(group.items).length;
@@ -1001,10 +1005,19 @@ function renderTileBody(key, model) {
 
   // Re-add the filter's no-match note after each (re)render so the live filter
   // has its placeholder whether the body came from cache or a refresh.
-  body.appendChild(el("p", { class: "nomatch", text: "No matching items in this tile." }));
+  body.appendChild(el("p", { class: "nomatch", text: NOMATCH_TEXT }));
 
-  tile(key).querySelector(".tt .count").textContent =
-    String(body.querySelectorAll(ROW_SELECTOR).length);
+  paintRowCount(key);
+}
+
+
+// The tile-header count is always the number of visible rows in the body — one
+// derivation shared by the per-tile render and the calendar tile, so the badge
+// can never drift from a hand-authored literal.
+function paintRowCount(key) {
+  var scope = tile(key);
+  var rows = scope.querySelector(".body").querySelectorAll(ROW_SELECTOR).length;
+  scope.querySelector(".tt .count").textContent = String(rows);
 }
 
 
@@ -1036,8 +1049,12 @@ CALENDAR_PANELS.forEach(function (p) { CALENDAR_PANEL_BY_KEY[p.key] = p; });
 // its combined count and oldest-age staleness.
 var calendarPanelState = {};
 
-function panelScope(panelKey) {
-  return document.querySelector('.group[data-panel="' + panelKey + '"]');
+// Store a panel's backend payload: mark it backend-backed and keep its model +
+// staleness. The load and refresh success paths share this; only the failure
+// handling differs (load falls back to sample, refresh keeps the last-good data).
+function storePanelPayload(panelKey, data) {
+  tileFromBackend[panelKey] = true;
+  calendarPanelState[panelKey] = { model: data.items || {}, data: data };
 }
 
 
@@ -1068,23 +1085,12 @@ function buildCalendarPanel(panel, view, open) {
 }
 
 
-// The tile-level count sums the visible rows across both panels (same row
-// selector as every other tile), so it stays a derived total, not a second literal.
-function setCalendarCount() {
-  var body = tile(CALENDAR_KEY).querySelector(".body");
-  tile(CALENDAR_KEY).querySelector(".tt .count").textContent =
-    String(body.querySelectorAll(ROW_SELECTOR).length);
-}
-
-
 // One staleness label for two sources: show the older of the two cache ages (and
 // warn if either is stale). If either panel fell back to the sample model, the
 // tile reads "sample data" — the same signal a single tile gives on fallback.
 function setCalendarStale() {
   var stale = tile(CALENDAR_KEY).querySelector(".stale");
   var label = staleLabelNode(CALENDAR_KEY);
-
-  stale.classList.remove("busy");
 
   var ages = [];
   var anyStale = false;
@@ -1102,15 +1108,8 @@ function setCalendarStale() {
     }
   });
 
-  if (anySample || ages.length === 0) {
-    label.textContent = "sample data";
-    stale.classList.remove("warn");
-    return;
-  }
-
-  var oldest = Math.max.apply(null, ages);
-  label.textContent = "cached " + formatAge(oldest);
-  stale.classList.toggle("warn", anyStale);
+  var age = (anySample || ages.length === 0) ? null : Math.max.apply(null, ages);
+  applyStaleLabel(stale, label, age, anyStale);
 }
 
 
@@ -1128,9 +1127,9 @@ function paintCalendar() {
     setStat(panel.stat, panel.statCount(view));
   });
 
-  body.appendChild(el("p", { class: "nomatch", text: "No matching items in this tile." }));
+  body.appendChild(el("p", { class: "nomatch", text: NOMATCH_TEXT }));
 
-  setCalendarCount();
+  paintRowCount(CALENDAR_KEY);
   setCalendarStale();
 }
 
@@ -1145,7 +1144,7 @@ function repaintCalendarPanel(panelKey) {
     return;
   }
 
-  var existing = panelScope(panelKey);
+  var existing = tile(panelKey);
   var open = existing ? existing.open : true;
 
   var view = viewModel(panelKey, st.model || {});
@@ -1156,7 +1155,7 @@ function repaintCalendarPanel(panelKey) {
   }
 
   setStat(panel.stat, panel.statCount(view));
-  setCalendarCount();
+  paintRowCount(CALENDAR_KEY);
 }
 
 
@@ -1165,8 +1164,7 @@ function repaintCalendarPanel(panelKey) {
 function loadCalendarPanel(panelKey) {
   return fetchJson(API + panelKey, { headers: { "Accept": "application/json" } })
     .then(function (data) {
-      tileFromBackend[panelKey] = true;
-      calendarPanelState[panelKey] = { model: data.items || {}, data: data };
+      storePanelPayload(panelKey, data);
       return true;
     })
     .catch(function () {
@@ -1198,18 +1196,12 @@ function refreshCalendar(btn) {
   var stale = tile(CALENDAR_KEY).querySelector(".stale");
   var label = staleLabelNode(CALENDAR_KEY);
 
-  btn.disabled = true;
-  btn.classList.add("spinning");
-  stale.classList.remove("warn");
-  stale.classList.add("busy");
-  label.textContent = "refreshing…";
-  announce("Refreshing Calendar…");
+  beginRefreshSpinner(btn, stale, label, "Calendar");
 
   var refreshes = CALENDAR_PANELS.map(function (panel) {
     return fetchJson(API + panel.key + "/refresh", { method: "POST", headers: { "Accept": "application/json" } })
       .then(function (data) {
-        tileFromBackend[panel.key] = true;
-        calendarPanelState[panel.key] = { model: data.items || {}, data: data };
+        storePanelPayload(panel.key, data);
         return true;
       })
       .catch(function () {
@@ -1230,8 +1222,7 @@ function refreshCalendar(btn) {
       announce("Calendar refresh failed for one or more sections.");
     }
   }).then(function () {
-    btn.classList.remove("spinning");
-    btn.disabled = false;
+    endRefreshSpinner(btn);
   });
 }
 
@@ -1265,19 +1256,27 @@ function staleLabelNode(key) {
   return stale.childNodes[stale.childNodes.length - 1];
 }
 
-function setStale(key, data) {
-  var stale = tile(key).querySelector(".stale");
-  var label = staleLabelNode(key);
-
+// Paint one staleness label: "cached N ago" (warn-tinted if stale) when an age is
+// known, else "sample data". `ageSeconds` is null when the tile fell back. Shared
+// by the single-source tiles and the calendar tile's oldest-of-two label.
+function applyStaleLabel(stale, label, ageSeconds, isStale) {
   stale.classList.remove("busy");
 
-  if (data && typeof data.ageSeconds === "number") {
-    label.textContent = "cached " + formatAge(data.ageSeconds);
-    stale.classList.toggle("warn", !!data.stale);
+  if (typeof ageSeconds === "number") {
+    label.textContent = "cached " + formatAge(ageSeconds);
+    stale.classList.toggle("warn", !!isStale);
   } else {
     label.textContent = "sample data";
     stale.classList.remove("warn");
   }
+}
+
+function setStale(key, data) {
+  var stale = tile(key).querySelector(".stale");
+  var label = staleLabelNode(key);
+
+  var age = (data && typeof data.ageSeconds === "number") ? data.ageSeconds : null;
+  applyStaleLabel(stale, label, age, data && data.stale);
 }
 
 
@@ -1402,6 +1401,22 @@ function tileNameFromButton(btn) {
   return name;
 }
 
+// Refresh spinner lifecycle — the button spin, the "refreshing…" busy label, and
+// the announcement, shared by the single-tile and calendar refresh paths.
+function beginRefreshSpinner(btn, stale, label, name) {
+  btn.disabled = true;
+  btn.classList.add("spinning");
+  stale.classList.remove("warn");
+  stale.classList.add("busy");
+  label.textContent = "refreshing…";
+  announce("Refreshing " + name + "…");
+}
+
+function endRefreshSpinner(btn) {
+  btn.classList.remove("spinning");
+  btn.disabled = false;
+}
+
 function refreshTile(btn) {
   if (btn.disabled) {
     return Promise.resolve();
@@ -1416,12 +1431,7 @@ function refreshTile(btn) {
   var label = staleLabelNode(key);
   var name = tileNameFromButton(btn);
 
-  btn.disabled = true;
-  btn.classList.add("spinning");
-  stale.classList.remove("warn");
-  stale.classList.add("busy");
-  label.textContent = "refreshing…";
-  announce("Refreshing " + name + "…");
+  beginRefreshSpinner(btn, stale, label, name);
 
   return fetchJson(API + key + "/refresh", { method: "POST", headers: { "Accept": "application/json" } })
     .then(function (data) {
@@ -1438,8 +1448,7 @@ function refreshTile(btn) {
       announce(name + " refresh failed.");
     })
     .then(function () {
-      btn.classList.remove("spinning");
-      btn.disabled = false;
+      endRefreshSpinner(btn);
     });
 }
 

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -940,13 +940,10 @@ function activityTotal(model) {
   }, 0);
 }
 
+// The Azure DevOps tiles. The two Outlook tiles (agenda, prep) are not here —
+// they render as panels inside the single Calendar tile (see the Calendar module),
+// which owns its own load / refresh / paint path.
 var TILES = [
-  { key: "agenda",   render: renderAgenda,   stat: "tile-agenda",
-    empty: "No meetings today.",
-    statCount: function (m) { return asArray(m.events).length; } },
-  { key: "prep",     render: renderPrep,     stat: "tile-prep",
-    empty: "No meetings to prepare for in the next two weeks.",
-    statCount: function (m) { return asArray(m.items).length; } },
   { key: "week",     render: renderWeek,     stat: "tile-week",
     empty: "No stories in the current sprint.",
     statCount: function (m) { return asArray(m.stories && m.stories.items).length; } },
@@ -971,12 +968,18 @@ var TILE_STATE = {};
 // the count badge, and drop a friendly note when the tile is genuinely empty.
 // ---------------------------------------------------------------------------
 
+// A key resolves to a whole tile, or — for a Calendar panel key (agenda / prep) —
+// to that panel's <details> inside the merged tile, so the dismissal/marker code
+// can scope and repaint a single panel without disturbing its sibling.
 function tile(key) {
-  return document.querySelector('.tile[data-tile="' + key + '"]');
+  return document.querySelector('.tile[data-tile="' + key + '"]') ||
+    document.querySelector('.group[data-panel="' + key + '"]');
 }
 
+// The number binds by data-stat (each stat is unique); data-target is only where
+// clicking it jumps — the two calendar stats share one jump target.
 function setStat(statId, count) {
-  var number = document.querySelector('.stat[data-target="' + statId + '"] .n');
+  var number = document.querySelector('.stat[data-stat="' + statId + '"] .n');
   if (number) {
     number.textContent = String(count);
   }
@@ -1002,6 +1005,234 @@ function renderTileBody(key, model) {
 
   tile(key).querySelector(".tt .count").textContent =
     String(body.querySelectorAll(ROW_SELECTOR).length);
+}
+
+
+// ---------------------------------------------------------------------------
+// Calendar tile — a composite of two panels (Today's Agenda, Events to Prepare
+// For) rendered as collapsible groups inside one tile. Each panel keeps its own
+// endpoint, model slice, stat, and empty note; the tile has one refresh (fanning
+// out to both) and one staleness label (the older of the two cache ages). Panels
+// render and repaint independently, so a prep dismissal leaves the agenda group
+// untouched. This mirrors the per-tile engine above, scoped to a shared tile.
+// ---------------------------------------------------------------------------
+
+var CALENDAR_KEY = "calendar";
+
+var CALENDAR_PANELS = [
+  { key: "agenda", label: "Today’s Agenda", render: renderAgenda,
+    empty: "No meetings today.", stat: "tile-agenda",
+    statCount: function (m) { return asArray(m.events).length; } },
+  { key: "prep", label: "Events to Prepare For", render: renderPrep,
+    empty: "No meetings to prepare for in the next two weeks.", stat: "tile-prep",
+    statCount: function (m) { return asArray(m.items).length; } }
+];
+
+var CALENDAR_PANEL_BY_KEY = {};
+CALENDAR_PANELS.forEach(function (p) { CALENDAR_PANEL_BY_KEY[p.key] = p; });
+
+// Each panel's last-loaded raw model + staleness, so a panel can repaint from data
+// (a dismissal / show-reviewed flip) without refetching, and the tile can recompute
+// its combined count and oldest-age staleness.
+var calendarPanelState = {};
+
+function panelScope(panelKey) {
+  return document.querySelector('.group[data-panel="' + panelKey + '"]');
+}
+
+
+// Build one panel as a .group <details> — the same collapsible shell the Azure
+// DevOps tiles use for their drill-in groups, so the disclosure caret, summary,
+// and count badge all match. The count is derived from the filtered view, so it
+// can't drift from the rows or the stat.
+function buildCalendarPanel(panel, view, open) {
+  var count = panel.statCount(view);
+
+  var body = el("div", { class: "panel-body" }, panel.render(view));
+  if (count === 0) {
+    body.appendChild(el("p", { class: "empty-note", text: panel.empty }));
+  }
+
+  var summary = el("summary", null, [
+    chevron(),
+    el("span", { class: "glabel", text: panel.label }),
+    el("span", { class: "count", text: String(count) })
+  ]);
+
+  var opts = { class: "group", "data-panel": panel.key };
+  if (open) {
+    opts.open = "";
+  }
+
+  return el("details", opts, [ summary, body ]);
+}
+
+
+// The tile-level count sums the visible rows across both panels (same row
+// selector as every other tile), so it stays a derived total, not a second literal.
+function setCalendarCount() {
+  var body = tile(CALENDAR_KEY).querySelector(".body");
+  tile(CALENDAR_KEY).querySelector(".tt .count").textContent =
+    String(body.querySelectorAll(ROW_SELECTOR).length);
+}
+
+
+// One staleness label for two sources: show the older of the two cache ages (and
+// warn if either is stale). If either panel fell back to the sample model, the
+// tile reads "sample data" — the same signal a single tile gives on fallback.
+function setCalendarStale() {
+  var stale = tile(CALENDAR_KEY).querySelector(".stale");
+  var label = staleLabelNode(CALENDAR_KEY);
+
+  stale.classList.remove("busy");
+
+  var ages = [];
+  var anyStale = false;
+  var anySample = false;
+
+  CALENDAR_PANELS.forEach(function (panel) {
+    var data = (calendarPanelState[panel.key] || {}).data;
+    if (data && typeof data.ageSeconds === "number") {
+      ages.push(data.ageSeconds);
+      if (data.stale) {
+        anyStale = true;
+      }
+    } else {
+      anySample = true;
+    }
+  });
+
+  if (anySample || ages.length === 0) {
+    label.textContent = "sample data";
+    stale.classList.remove("warn");
+    return;
+  }
+
+  var oldest = Math.max.apply(null, ages);
+  label.textContent = "cached " + formatAge(oldest);
+  stale.classList.toggle("warn", anyStale);
+}
+
+
+// Full paint: rebuild both panels (default open), refresh both stats and the
+// tile count + staleness. Used on load and after a refresh.
+function paintCalendar() {
+  var body = tile(CALENDAR_KEY).querySelector(".body");
+  body.textContent = "";
+
+  CALENDAR_PANELS.forEach(function (panel) {
+    var st = calendarPanelState[panel.key] || { model: {}, data: null };
+    var view = viewModel(panel.key, st.model || {});
+
+    body.appendChild(buildCalendarPanel(panel, view, true));
+    setStat(panel.stat, panel.statCount(view));
+  });
+
+  body.appendChild(el("p", { class: "nomatch", text: "No matching items in this tile." }));
+
+  setCalendarCount();
+  setCalendarStale();
+}
+
+
+// Repaint a single panel from its stored model — the dismissal / show-reviewed
+// path for prep. Only the target panel's node is replaced (preserving its current
+// open state), so the sibling agenda group is left exactly as it was.
+function repaintCalendarPanel(panelKey) {
+  var panel = CALENDAR_PANEL_BY_KEY[panelKey];
+  var st = calendarPanelState[panelKey];
+  if (!panel || !st) {
+    return;
+  }
+
+  var existing = panelScope(panelKey);
+  var open = existing ? existing.open : true;
+
+  var view = viewModel(panelKey, st.model || {});
+  var next = buildCalendarPanel(panel, view, open);
+
+  if (existing) {
+    existing.replaceWith(next);
+  }
+
+  setStat(panel.stat, panel.statCount(view));
+  setCalendarCount();
+}
+
+
+// Load one panel from its endpoint, falling back to the sample model on any
+// failure — independently, so one endpoint being down doesn't blank the other.
+function loadCalendarPanel(panelKey) {
+  return fetchJson(API + panelKey, { headers: { "Accept": "application/json" } })
+    .then(function (data) {
+      tileFromBackend[panelKey] = true;
+      calendarPanelState[panelKey] = { model: data.items || {}, data: data };
+      return true;
+    })
+    .catch(function () {
+      tileFromBackend[panelKey] = false;
+      calendarPanelState[panelKey] = { model: MODEL[panelKey], data: null };
+      return false;
+    });
+}
+
+
+// Boot load: fetch both endpoints, paint once. Returns false if either panel fell
+// back to sample data, so the boot handler can announce it (parity with loadTile).
+function loadCalendar() {
+  var loads = CALENDAR_PANELS.map(function (panel) {
+    return loadCalendarPanel(panel.key);
+  });
+
+  return Promise.all(loads).then(function (results) {
+    paintCalendar();
+    return results.indexOf(false) === -1;
+  });
+}
+
+
+// One refresh button, both sources: fan out to each panel's POST /refresh, then
+// repaint the whole tile. A single spinner + staleness label covers both; if
+// either source fails the label warns and the announcement says so.
+function refreshCalendar(btn) {
+  var stale = tile(CALENDAR_KEY).querySelector(".stale");
+  var label = staleLabelNode(CALENDAR_KEY);
+
+  btn.disabled = true;
+  btn.classList.add("spinning");
+  stale.classList.remove("warn");
+  stale.classList.add("busy");
+  label.textContent = "refreshing…";
+  announce("Refreshing Calendar…");
+
+  var refreshes = CALENDAR_PANELS.map(function (panel) {
+    return fetchJson(API + panel.key + "/refresh", { method: "POST", headers: { "Accept": "application/json" } })
+      .then(function (data) {
+        tileFromBackend[panel.key] = true;
+        calendarPanelState[panel.key] = { model: data.items || {}, data: data };
+        return true;
+      })
+      .catch(function () {
+        return false;
+      });
+  });
+
+  return Promise.all(refreshes).then(function (results) {
+    paintCalendar();
+    rememberOpenState();
+    applyFilter(searchBox.value);
+
+    if (results.indexOf(false) === -1) {
+      announce("Calendar updated — cached just now.");
+    } else {
+      stale.classList.remove("busy");
+      stale.classList.add("warn");
+      announce("Calendar refresh failed for one or more sections.");
+    }
+  }).then(function () {
+    btn.classList.remove("spinning");
+    btn.disabled = false;
+  });
 }
 
 
@@ -1089,6 +1320,13 @@ function paintTile(key, model, data) {
 // and dismissals, then the open-state and active search filter the full render
 // dropped are restored (the same post-render fix-up the refresh path does).
 function repaintTile(key) {
+  if (CALENDAR_PANEL_BY_KEY[key]) {
+    repaintCalendarPanel(key);
+    rememberOpenState();
+    applyFilter(searchBox.value);
+    return;
+  }
+
   var st = TILE_STATE[key];
   if (!st) {
     return;
@@ -1170,6 +1408,10 @@ function refreshTile(btn) {
   }
 
   var key = btn.getAttribute("data-tile");
+  if (key === CALENDAR_KEY) {
+    return refreshCalendar(btn);
+  }
+
   var stale = tile(key).querySelector(".stale");
   var label = staleLabelNode(key);
   var name = tileNameFromButton(btn);
@@ -1234,6 +1476,15 @@ document.querySelectorAll(".stat").forEach(function (stat) {
     var details = target.querySelector("details");
     if (details) {
       details.open = true;
+    }
+
+    // A calendar stat also opens its matching inner panel so the jump lands on
+    // the right group, not just the tile.
+    if (stat.dataset.group) {
+      var panel = target.querySelector('.group[data-panel="' + stat.dataset.group + '"]');
+      if (panel) {
+        panel.open = true;
+      }
     }
 
     target.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -1363,7 +1614,10 @@ paintTodayDate();
 // record open state so the filter can restore it.
 // ---------------------------------------------------------------------------
 
-Promise.all(TILES.map(function (t) { return loadTile(t.key); })).then(function (results) {
+var bootLoads = TILES.map(function (t) { return loadTile(t.key); });
+bootLoads.push(loadCalendar());
+
+Promise.all(bootLoads).then(function (results) {
   rememberOpenState();
 
   // Screen-reader parity with the refresh path: if any tile couldn't reach the

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -34,64 +34,41 @@
 
   <main>
 
-    <!-- Stat numbers (.n) are filled from the model at render time; blank in markup so
-         they can never drift from the collections they summarize. -->
+    <!-- Stat numbers (.n) are filled from the model at render time; blank in markup
+         so they can never drift from the collections they summarize. Each number
+         binds via data-stat, while data-target is where clicking jumps — the two
+         calendar stats share one target (the merged tile) and use data-group to
+         open the matching inner panel. -->
     <section class="stats" aria-label="Summary counts">
-      <button class="stat a" type="button" data-target="tile-agenda"><span class="n"></span><span class="l">Meetings today</span></button>
-      <button class="stat p" type="button" data-target="tile-prep"><span class="n"></span><span class="l">Events to prep</span></button>
-      <button class="stat g" type="button" data-target="tile-focus"><span class="n"></span><span class="l">Support &amp; focus items</span></button>
-      <button class="stat s" type="button" data-target="tile-activity"><span class="n"></span><span class="l">Recent updates</span></button>
-      <button class="stat f" type="button" data-target="tile-week"><span class="n"></span><span class="l">Stories in current sprint</span></button>
+      <button class="stat a" type="button" data-stat="tile-agenda" data-target="tile-calendar" data-group="agenda"><span class="n"></span><span class="l">Meetings today</span></button>
+      <button class="stat p" type="button" data-stat="tile-prep" data-target="tile-calendar" data-group="prep"><span class="n"></span><span class="l">Events to prep</span></button>
+      <button class="stat g" type="button" data-stat="tile-focus" data-target="tile-focus"><span class="n"></span><span class="l">Support &amp; focus items</span></button>
+      <button class="stat s" type="button" data-stat="tile-activity" data-target="tile-activity"><span class="n"></span><span class="l">Recent updates</span></button>
+      <button class="stat f" type="button" data-stat="tile-week" data-target="tile-week"><span class="n"></span><span class="l">Stories in current sprint</span></button>
     </section>
 
-    <!-- Tiles group under two collapsible parent sections by data source: Calendar
-         (Outlook) and Azure DevOps (az boards). Each parent is a <details> so the
-         whole group collapses with JS off. Each tile inside is itself a static
-         shell — header chrome, staleness, refresh button — whose .count badge and
-         .body rows are rendered from the model in app.js. -->
+    <!-- Two tile groupings: one Calendar tile (all Outlook items) and the Azure
+         DevOps parent section (az boards). The Calendar tile's body renders two
+         collapsible <details> groups — Today's Agenda and Events to Prepare For —
+         from app.js; the Azure DevOps <details> collapses its whole group with JS
+         off. Each tile is a static shell — header chrome, staleness, refresh — whose
+         .count badge and .body rows are rendered from the model. -->
 
-    <!-- Calendar — Outlook-derived tiles -->
-    <section class="section cal" aria-labelledby="sec-calendar">
+    <!-- Calendar — one tile holding both Outlook-derived groups. The body renders
+         two collapsible groups (Today's Agenda, Events to Prepare For), each fed by
+         its own endpoint; the tile has one refresh (fanning out to both) and one
+         staleness label (the older of the two cache ages). -->
+    <section class="tile" id="tile-calendar" data-tile="calendar" aria-labelledby="h-calendar">
       <details open>
         <summary>
           <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          <svg class="sicon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>
-          <h2 class="section-title" id="sec-calendar">Calendar</h2>
+          <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h3 id="h-calendar">Calendar</h3><span class="count"></span></span>
+          <span class="tile-meta">
+            <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 12m ago</span>
+            <button class="refresh-btn" type="button" data-tile="calendar" aria-label="Refresh Calendar"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+          </span>
         </summary>
-
-        <div class="grid">
-
-          <!-- Today's Agenda -->
-          <section class="tile" id="tile-agenda" data-tile="agenda" aria-labelledby="h-agenda">
-            <details open>
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h3 id="h-agenda">Today&rsquo;s Agenda</h3><span class="count"></span></span>
-                <span class="tile-meta">
-                  <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 12m ago</span>
-                  <button class="refresh-btn" type="button" data-tile="agenda" aria-label="Refresh Today&rsquo;s Agenda"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-                </span>
-              </summary>
-              <div class="body"></div>
-            </details>
-          </section>
-
-          <!-- Events to Prepare For -->
-          <section class="tile" id="tile-prep" data-tile="prep" aria-labelledby="h-prep">
-            <details open>
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="3" y="2.5" width="10" height="12" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M6 1.5h4v2H6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/><path d="M5.5 7.6l1.2 1.2 2.3-2.6M5.5 11h5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg><h3 id="h-prep">Events to Prepare For</h3><span class="count"></span></span>
-                <span class="tile-meta">
-                  <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 15m ago</span>
-                  <button class="refresh-btn" type="button" data-tile="prep" aria-label="Refresh Events to Prepare For"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-                </span>
-              </summary>
-              <div class="body"></div>
-            </details>
-          </section>
-
-        </div>
+        <div class="body"></div>
       </details>
     </section>
 

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -305,7 +305,6 @@ button:focus-visible {
 .section { margin-bottom: var(--space-8); }
 .section:last-of-type { margin-bottom: 0; }
 .section.section-empty { display: none; }
-.section.cal { --tint: var(--epic); }
 .section.ado { --tint: var(--story); }
 
 .section > details > summary {
@@ -356,8 +355,9 @@ button:focus-visible {
   box-shadow: var(--shadow);
   overflow: hidden;
 }
-.tile[data-tile="agenda"]   { --tint: var(--accent); }
-.tile[data-tile="prep"]     { --tint: var(--epic); }
+/* The Calendar tile stands alone above the Azure DevOps section, so it carries
+   its own bottom margin (the .section below supplies its own). */
+.tile[data-tile="calendar"] { --tint: var(--accent); margin-bottom: var(--space-8); }
 .tile[data-tile="week"]     { --tint: var(--feature); }
 .tile[data-tile="activity"] { --tint: var(--story); }
 .tile[data-tile="focus"]    { --tint: var(--warn); }
@@ -534,6 +534,12 @@ details[open] > summary > .chev { transform: rotate(90deg); }
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+}
+
+/* Calendar panels (agenda / prep) render their own list into this wrapper, so it
+   carries the group's left indent while the lists keep their own row layout. */
+.panel-body {
+  padding: 0 0 var(--space-5) var(--space-9);
 }
 
 /* ---------- work item rows ---------- */


### PR DESCRIPTION

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #220 |
| [Changes](#changes) | ✅ 3 files |
| [Behavior preserved](#behavior-preserved) | ✅ |
| [Test Plan](#test-plan) | 0/5 checked |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-5004372269) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-5004372713) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-5004381035) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](#issuecomment-5004391551) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-5004397578) |
| 📚 Docs Check | ✅ CURRENT — [View](#issuecomment-5004443476) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-5004452049) |


<!-- pr-diagram:start -->
## How it works

The daily-viewer gains a **Calendar module** in `app.js`: boot fires `loadCalendar` alongside the per-tile `loadTile` loop, fetching both `/api/tiles/agenda` and `/api/tiles/prep` (each panel falling back to its sample `MODEL` independently) and painting the two collapsible groups into the single merged tile. One refresh button fans out to both `/refresh` endpoints, and dismissing a prep item repaints only its panel — the agenda group is left untouched. A clean-code pass lifts the shared scaffolding (`storePanelPayload`, `begin/endRefreshSpinner`, `applyStaleLabel`, `paintRowCount`) so the calendar and single-tile paths can't drift.

```mermaid
flowchart TD
    %% Entry points (new public/module functions)
    Boot[boot loader] -.alongside loadTile loop.-> LoadCal
    Dispatch[refreshTile / repaintTile<br/>dispatch on calendar + panel keys]

    LoadCal([loadCalendar]):::pub
    RefreshCal([refreshCalendar]):::pub
    RepaintPanel([repaintCalendarPanel]):::pub

    %% Shared scaffolding extracted in the clean-code pass
    LoadPanel[loadCalendarPanel]:::priv
    Store[storePanelPayload]:::priv
    Paint[paintCalendar]:::priv
    Build[buildCalendarPanel]:::priv
    SetStale[setCalendarStale]:::priv
    ApplyStale[applyStaleLabel]:::priv
    RowCount[paintRowCount]:::priv
    Spinner[begin/endRefreshSpinner]:::priv

    %% External I/O
    Api["/api/tiles/agenda + /prep<br/>GET load, POST /refresh"]:::io
    Sample[(sample MODEL)]:::io

    %% Load path
    LoadCal --> LoadPanel
    LoadPanel --> Api
    LoadPanel -- ok --> Store
    LoadPanel -- fail --> Sample
    LoadCal --> Paint

    %% Refresh path
    Dispatch -.calendar key.-> RefreshCal
    RefreshCal --> Spinner
    RefreshCal --> Api
    RefreshCal -- each ok --> Store
    RefreshCal --> Paint

    %% Panel-scoped repaint (prep dismissal)
    Dispatch -.prep panel.-> RepaintPanel
    RepaintPanel --> Build
    RepaintPanel --> RowCount

    %% Shared paint fan-out
    Paint --> Build
    Paint --> RowCount
    Paint --> SetStale
    SetStale --> ApplyStale

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary

Consolidates the daily-viewer&#39;s two side-by-side Outlook tiles (`tile-agenda`, `tile-prep`) and their `.section.cal` parent wrapper into a **single Calendar tile** whose body renders two collapsible `` groups — **Today&#39;s Agenda** and **Events to Prepare For**. Front-end only: the tile fetches both existing endpoints (`/api/tiles/agenda`, `/api/tiles/prep`) and each group falls back to its sample model independently. No backend/PowerShell changes.

## Issue

Closes #220 (child of epic #189; reworks the layout shipped in #208, leaves #213&#39;s backend work valid).

## Changes

- **`daily-viewer/index.html`** — one `#tile-calendar` in place of the `.section.cal` wrapper and its two tiles. Both calendar stats retargeted to the merged tile with a `data-group` hint; stats now bind their number via `data-stat` so two stats can share one jump target.
- **`daily-viewer/app.js`** — dropped agenda/prep from the per-tile `TILES` registry; added a **Calendar module**: two panels, fetch-both load, fan-out refresh, oldest-age staleness, panel-scoped repaint. `tile()` / `setStat()` / `repaintTile()` / the stat-jump handler are panel-aware, so prep dismissal and the marker toggle scope to the prep group and leave the agenda group untouched.
- **`daily-viewer/styles.css`** — calendar tile tint + bottom margin, `.panel-body` indent; removed the now-dead agenda/prep tile tints and the `.section.cal` rule.

## Behavior preserved

- Both &#34;Meetings today&#34; and &#34;Events to prep&#34; stats stay and jump to the right inner group.
- One tile refresh fans out to both endpoints; one staleness label shows the older cache age (or &#34;sample data&#34; on fallback).
- Prep &#34;all set&#34; marker + &#34;Remove&#34;/dismiss + &#34;Show reviewed&#34; still work, scoped to the prep group.
- All rendering stays through `el()`/`safeUrl()` (no `innerHTML`); native `` collapse works with JS off.

## Test Plan

- [ ] Open `daily-viewer/index.html` — one Calendar tile shows two independently-collapsible groups (Agenda, Prep)
- [ ] Both stat cards show correct counts and jump to the matching inner group
- [ ] The single refresh button + &#34;Refresh all&#34; update both groups; staleness shows one label
- [ ] Toggle a prep &#34;all set&#34; marker and a &#34;Remove&#34; — both work; the agenda group is undisturbed
- [ ] Live filter and Collapse/Expand all work across the merged tile

Verified end-to-end in headless Chromium against the sample-fallback path: 30 behavioral assertions pass (structure, panel labels/counts, both stats, independent collapse, stat-jump-opens-panel, prep-dismiss-scoped-to-prep, marker flip, combined count/staleness) with no uncaught JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VioMTNRs142TbJR2xEkEhN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VioMTNRs142TbJR2xEkEhN)_