### PR TITLE
Daily Viewer — merge the three Azure DevOps tiles into one container tile; Azure DevOps top-left, Calendar top-right

### DIFF
--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -927,15 +927,13 @@ function viewModel(key, model) {
 
 
 // ---------------------------------------------------------------------------
-// Tile registry — the render function, stat target, and stat count for each
-// tile in one place, so mount and refresh iterate a single list.
+// Shared render constants — what counts as a "row" (mount, count badges, live
+// filter) and the live filter's placeholder, named so every render path shares
+// the same wording.
 // ---------------------------------------------------------------------------
 
-// What counts as a "row" across mount, count badges, and the live filter.
 var ROW_SELECTOR = ".wi, .event";
 
-// The live filter's placeholder, re-added after every (re)render. Named so the
-// per-tile and calendar render paths can't drift on the wording.
 var NOMATCH_TEXT = "No matching items in this tile.";
 
 function activityTotal(model) {
@@ -944,44 +942,23 @@ function activityTotal(model) {
   }, 0);
 }
 
-// The Azure DevOps tiles. The two Outlook tiles (agenda, prep) are not here —
-// they render as panels inside the single Calendar tile (see the Calendar module),
-// which owns its own load / refresh / paint path.
-var TILES = [
-  { key: "week",     render: renderWeek,     stat: "tile-week",
-    empty: "No stories in the current sprint.",
-    statCount: function (m) { return asArray(m.stories && m.stories.items).length; } },
-  { key: "activity", render: renderActivity, stat: "tile-activity",
-    empty: "No recent activity.",
-    statCount: activityTotal },
-  { key: "focus",    render: renderFocus,    stat: "tile-focus",
-    empty: "Nothing pinned. Set $global:AzDevOpsDailyFocus to a work-item id.",
-    statCount: function (m) { return asArray(m.support && m.support.items).length; } }
-];
-
-var TILE_BY_KEY = {};
-TILES.forEach(function (t) { TILE_BY_KEY[t.key] = t; });
-
-// The last model + staleness each tile was painted with, so a dismissal toggle
-// or a "show reviewed" flip can repaint from data without re-fetching.
-var TILE_STATE = {};
-
 
 // ---------------------------------------------------------------------------
-// Mount — render one tile body from its data model: clear, render rows, derive
-// the count badge, and drop a friendly note when the tile is genuinely empty.
+// Mount helpers — resolve a tile/panel node, set a stat number, derive the
+// tile-header row count. Shared by every composite tile's paint path.
 // ---------------------------------------------------------------------------
 
-// A key resolves to a whole tile, or — for a Calendar panel key (agenda / prep) —
-// to that panel's <details> inside the merged tile, so the dismissal/marker code
-// can scope and repaint a single panel without disturbing its sibling.
+// A key resolves to a whole tile, or — for a panel key (agenda / prep / week /
+// activity / focus) — to that panel's <details> inside its composite tile, so the
+// dismissal/marker code can scope and repaint a single panel without disturbing
+// its siblings.
 function tile(key) {
   return document.querySelector('.tile[data-tile="' + key + '"]') ||
     document.querySelector('.group[data-panel="' + key + '"]');
 }
 
 // The number binds by data-stat (each stat is unique); data-target is only where
-// clicking it jumps — the two calendar stats share one jump target.
+// clicking it jumps — the stats that share a composite tile share one jump target.
 function setStat(statId, count) {
   var number = document.querySelector('.stat[data-stat="' + statId + '"] .n');
   if (number) {
@@ -989,31 +966,10 @@ function setStat(statId, count) {
   }
 }
 
-function renderTileBody(key, model) {
-  var conf = TILE_BY_KEY[key];
-  var body = tile(key).querySelector(".body");
-
-  body.textContent = "";
-  conf.render(model || {}).forEach(function (node) { body.appendChild(node); });
-
-  // "empty" counts the primary too so a focus tile with a pinned item but no
-  // support rows isn't mislabeled as empty; the count badge stays row-only.
-  var meaningful = body.querySelectorAll(ROW_SELECTOR + ", .primary").length;
-  if (meaningful === 0) {
-    body.appendChild(el("p", { class: "empty-note", text: conf.empty }));
-  }
-
-  // Re-add the filter's no-match note after each (re)render so the live filter
-  // has its placeholder whether the body came from cache or a refresh.
-  body.appendChild(el("p", { class: "nomatch", text: NOMATCH_TEXT }));
-
-  paintRowCount(key);
-}
-
 
 // The tile-header count is always the number of visible rows in the body — one
-// derivation shared by the per-tile render and the calendar tile, so the badge
-// can never drift from a hand-authored literal.
+// derivation shared by every composite tile, so the badge can never drift from a
+// hand-authored literal.
 function paintRowCount(key) {
   var scope = tile(key);
   var rows = scope.querySelector(".body").querySelectorAll(ROW_SELECTOR).length;
@@ -1022,15 +978,14 @@ function paintRowCount(key) {
 
 
 // ---------------------------------------------------------------------------
-// Calendar tile — a composite of two panels (Today's Agenda, Events to Prepare
-// For) rendered as collapsible groups inside one tile. Each panel keeps its own
-// endpoint, model slice, stat, and empty note; the tile has one refresh (fanning
-// out to both) and one staleness label (the older of the two cache ages). Panels
-// render and repaint independently, so a prep dismissal leaves the agenda group
-// untouched. This mirrors the per-tile engine above, scoped to a shared tile.
+// Composite tiles — a tile whose body holds N panels rendered as collapsible
+// groups. Each panel keeps its own endpoint, model slice, stat, and empty note;
+// its tile has one refresh (fanning out to every panel) and one staleness label
+// (the oldest of the panel cache ages). Panels render and repaint independently,
+// so one panel's dismissal leaves its siblings untouched. Both the Calendar tile
+// (Outlook agenda + prep) and the Azure DevOps tile (this sprint's focus, recent
+// activity, today's focus) are composites driven by this one engine.
 // ---------------------------------------------------------------------------
-
-var CALENDAR_KEY = "calendar";
 
 var CALENDAR_PANELS = [
   { key: "agenda", label: "Today’s Agenda", render: renderAgenda,
@@ -1041,39 +996,70 @@ var CALENDAR_PANELS = [
     statCount: function (m) { return asArray(m.items).length; } }
 ];
 
-var CALENDAR_PANEL_BY_KEY = {};
-CALENDAR_PANELS.forEach(function (p) { CALENDAR_PANEL_BY_KEY[p.key] = p; });
+var ADO_PANELS = [
+  { key: "week", label: "This Sprint’s Focus", render: renderWeek,
+    empty: "No stories in the current sprint.", stat: "tile-week",
+    statCount: function (m) { return asArray(m.stories && m.stories.items).length; } },
+  { key: "activity", label: "Recent Activity", render: renderActivity,
+    empty: "No recent activity.", stat: "tile-activity",
+    statCount: activityTotal },
+  { key: "focus", label: "Today’s Focus", render: renderFocus,
+    empty: "Nothing pinned. Set $global:AzDevOpsDailyFocus to a work-item id.", stat: "tile-focus",
+    statCount: function (m) { return asArray(m.support && m.support.items).length; } }
+];
+
+var COMPOSITES = [
+  { key: "calendar",    name: "Calendar",     panels: CALENDAR_PANELS },
+  { key: "azuredevops", name: "Azure DevOps", panels: ADO_PANELS }
+];
+
+// Panel-key lookups: which panel config a key names, and which composite tile it
+// lives in — so a single-panel repaint (dismissal / show-reviewed) can find its
+// render config and its owning tile for the combined count.
+var COMPOSITE_BY_KEY = {};
+var PANEL_BY_KEY = {};
+var COMPOSITE_BY_PANEL = {};
+COMPOSITES.forEach(function (composite) {
+  COMPOSITE_BY_KEY[composite.key] = composite;
+  composite.panels.forEach(function (panel) {
+    PANEL_BY_KEY[panel.key] = panel;
+    COMPOSITE_BY_PANEL[panel.key] = composite;
+  });
+});
 
 // Each panel's last-loaded raw model + staleness, so a panel can repaint from data
-// (a dismissal / show-reviewed flip) without refetching, and the tile can recompute
+// (a dismissal / show-reviewed flip) without refetching, and its tile can recompute
 // its combined count and oldest-age staleness.
-var calendarPanelState = {};
+var panelState = {};
 
 // Store a panel's backend payload: mark it backend-backed and keep its model +
 // staleness. The load and refresh success paths share this; only the failure
 // handling differs (load falls back to sample, refresh keeps the last-good data).
 function storePanelPayload(panelKey, data) {
   tileFromBackend[panelKey] = true;
-  calendarPanelState[panelKey] = { model: data.items || {}, data: data };
+  panelState[panelKey] = { model: data.items || {}, data: data };
 }
 
 
-// Build one panel as a .group <details> — the same collapsible shell the Azure
-// DevOps tiles use for their drill-in groups, so the disclosure caret, summary,
-// and count badge all match. The count is derived from the filtered view, so it
-// can't drift from the rows or the stat.
-function buildCalendarPanel(panel, view, open) {
-  var count = panel.statCount(view);
-
+// Build one panel as a .group <details> — the same collapsible shell the drill-in
+// groups use, so the disclosure caret, summary, and count badge all match. The
+// count and the empty-note decision are both derived from the rendered rows, so
+// the badge can't drift from the list and a focus panel with a pinned item (but no
+// support rows) still counts as non-empty.
+function buildCompositePanel(panel, view, open) {
   var body = el("div", { class: "panel-body" }, panel.render(view));
-  if (count === 0) {
+
+  var meaningful = body.querySelectorAll(ROW_SELECTOR + ", .primary").length;
+  if (meaningful === 0) {
     body.appendChild(el("p", { class: "empty-note", text: panel.empty }));
   }
+
+  var rows = body.querySelectorAll(ROW_SELECTOR).length;
 
   var summary = el("summary", null, [
     chevron(),
     el("span", { class: "glabel", text: panel.label }),
-    el("span", { class: "count", text: String(count) })
+    el("span", { class: "count", text: String(rows) })
   ]);
 
   var opts = { class: "group", "data-panel": panel.key };
@@ -1085,19 +1071,19 @@ function buildCalendarPanel(panel, view, open) {
 }
 
 
-// One staleness label for two sources: show the older of the two cache ages (and
-// warn if either is stale). If either panel fell back to the sample model, the
-// tile reads "sample data" — the same signal a single tile gives on fallback.
-function setCalendarStale() {
-  var stale = tile(CALENDAR_KEY).querySelector(".stale");
-  var label = staleLabelNode(CALENDAR_KEY);
+// One staleness label for N sources: show the oldest of the panel cache ages (and
+// warn if any is stale). If any panel fell back to the sample model, the tile
+// reads "sample data" — the same signal a single-source tile gives on fallback.
+function setCompositeStale(composite) {
+  var stale = tile(composite.key).querySelector(".stale");
+  var label = staleLabelNode(composite.key);
 
   var ages = [];
   var anyStale = false;
   var anySample = false;
 
-  CALENDAR_PANELS.forEach(function (panel) {
-    var data = (calendarPanelState[panel.key] || {}).data;
+  composite.panels.forEach(function (panel) {
+    var data = (panelState[panel.key] || {}).data;
     if (data && typeof data.ageSeconds === "number") {
       ages.push(data.ageSeconds);
       if (data.stale) {
@@ -1113,34 +1099,35 @@ function setCalendarStale() {
 }
 
 
-// Full paint: rebuild both panels (default open), refresh both stats and the
-// tile count + staleness. Used on load and after a refresh.
-function paintCalendar() {
-  var body = tile(CALENDAR_KEY).querySelector(".body");
+// Full paint: rebuild every panel (default open), refresh each panel's stat and
+// the tile count + staleness. Used on load and after a refresh.
+function paintComposite(composite) {
+  var body = tile(composite.key).querySelector(".body");
   body.textContent = "";
 
-  CALENDAR_PANELS.forEach(function (panel) {
-    var st = calendarPanelState[panel.key] || { model: {}, data: null };
+  composite.panels.forEach(function (panel) {
+    var st = panelState[panel.key] || { model: {}, data: null };
     var view = viewModel(panel.key, st.model || {});
 
-    body.appendChild(buildCalendarPanel(panel, view, true));
+    body.appendChild(buildCompositePanel(panel, view, true));
     setStat(panel.stat, panel.statCount(view));
   });
 
   body.appendChild(el("p", { class: "nomatch", text: NOMATCH_TEXT }));
 
-  paintRowCount(CALENDAR_KEY);
-  setCalendarStale();
+  paintRowCount(composite.key);
+  setCompositeStale(composite);
 }
 
 
 // Repaint a single panel from its stored model — the dismissal / show-reviewed
-// path for prep. Only the target panel's node is replaced (preserving its current
-// open state), so the sibling agenda group is left exactly as it was.
-function repaintCalendarPanel(panelKey) {
-  var panel = CALENDAR_PANEL_BY_KEY[panelKey];
-  var st = calendarPanelState[panelKey];
-  if (!panel || !st) {
+// path. Only the target panel's node is replaced (preserving its current open
+// state), so its sibling panels are left exactly as they were.
+function repaintCompositePanel(panelKey) {
+  var panel = PANEL_BY_KEY[panelKey];
+  var composite = COMPOSITE_BY_PANEL[panelKey];
+  var st = panelState[panelKey];
+  if (!panel || !composite || !st) {
     return;
   }
 
@@ -1148,20 +1135,20 @@ function repaintCalendarPanel(panelKey) {
   var open = existing ? existing.open : true;
 
   var view = viewModel(panelKey, st.model || {});
-  var next = buildCalendarPanel(panel, view, open);
+  var next = buildCompositePanel(panel, view, open);
 
   if (existing) {
     existing.replaceWith(next);
   }
 
   setStat(panel.stat, panel.statCount(view));
-  paintRowCount(CALENDAR_KEY);
+  paintRowCount(composite.key);
 }
 
 
 // Load one panel from its endpoint, falling back to the sample model on any
-// failure — independently, so one endpoint being down doesn't blank the other.
-function loadCalendarPanel(panelKey) {
+// failure — independently, so one endpoint being down doesn't blank the others.
+function loadCompositePanel(panelKey) {
   return fetchJson(API + panelKey, { headers: { "Accept": "application/json" } })
     .then(function (data) {
       storePanelPayload(panelKey, data);
@@ -1169,36 +1156,36 @@ function loadCalendarPanel(panelKey) {
     })
     .catch(function () {
       tileFromBackend[panelKey] = false;
-      calendarPanelState[panelKey] = { model: MODEL[panelKey], data: null };
+      panelState[panelKey] = { model: MODEL[panelKey], data: null };
       return false;
     });
 }
 
 
-// Boot load: fetch both endpoints, paint once. Returns false if either panel fell
-// back to sample data, so the boot handler can announce it (parity with loadTile).
-function loadCalendar() {
-  var loads = CALENDAR_PANELS.map(function (panel) {
-    return loadCalendarPanel(panel.key);
+// Boot load: fetch every panel, paint once. Returns false if any panel fell back
+// to sample data, so the boot handler can announce it.
+function loadComposite(composite) {
+  var loads = composite.panels.map(function (panel) {
+    return loadCompositePanel(panel.key);
   });
 
   return Promise.all(loads).then(function (results) {
-    paintCalendar();
+    paintComposite(composite);
     return results.indexOf(false) === -1;
   });
 }
 
 
-// One refresh button, both sources: fan out to each panel's POST /refresh, then
-// repaint the whole tile. A single spinner + staleness label covers both; if
-// either source fails the label warns and the announcement says so.
-function refreshCalendar(btn) {
-  var stale = tile(CALENDAR_KEY).querySelector(".stale");
-  var label = staleLabelNode(CALENDAR_KEY);
+// One refresh button, every source: fan out to each panel's POST /refresh, then
+// repaint the whole tile. A single spinner + staleness label covers them all; if
+// any source fails the label warns and the announcement says so.
+function refreshComposite(btn, composite) {
+  var stale = tile(composite.key).querySelector(".stale");
+  var label = staleLabelNode(composite.key);
 
-  beginRefreshSpinner(btn, stale, label, "Calendar");
+  beginRefreshSpinner(btn, stale, label, composite.name);
 
-  var refreshes = CALENDAR_PANELS.map(function (panel) {
+  var refreshes = composite.panels.map(function (panel) {
     return fetchJson(API + panel.key + "/refresh", { method: "POST", headers: { "Accept": "application/json" } })
       .then(function (data) {
         storePanelPayload(panel.key, data);
@@ -1210,16 +1197,16 @@ function refreshCalendar(btn) {
   });
 
   return Promise.all(refreshes).then(function (results) {
-    paintCalendar();
+    paintComposite(composite);
     rememberOpenState();
     applyFilter(searchBox.value);
 
     if (results.indexOf(false) === -1) {
-      announce("Calendar updated — cached just now.");
+      announce(composite.name + " updated — cached just now.");
     } else {
       stale.classList.remove("busy");
       stale.classList.add("warn");
-      announce("Calendar refresh failed for one or more sections.");
+      announce(composite.name + " refresh failed for one or more sections.");
     }
   }).then(function () {
     endRefreshSpinner(btn);
@@ -1271,14 +1258,6 @@ function applyStaleLabel(stale, label, ageSeconds, isStale) {
   }
 }
 
-function setStale(key, data) {
-  var stale = tile(key).querySelector(".stale");
-  var label = staleLabelNode(key);
-
-  var age = (data && typeof data.ageSeconds === "number") ? data.ageSeconds : null;
-  applyStaleLabel(stale, label, age, data && data.stale);
-}
-
 
 // ---------------------------------------------------------------------------
 // Data layer — cheap GET on load, expensive POST /refresh on demand. Both hit
@@ -1303,51 +1282,18 @@ function fetchJson(url, options) {
   });
 }
 
-function paintTile(key, model, data) {
-  TILE_STATE[key] = { model: model, data: data };
-
-  var conf = TILE_BY_KEY[key];
-  var view = viewModel(key, model || {});
-
-  renderTileBody(key, view);
-  setStat(conf.stat, conf.statCount(view));
-  setStale(key, data);
-}
-
-// Repaint a tile from its last-loaded model — after a dismissal toggle or a
-// "show reviewed" flip. Re-deriving the view model reapplies the 30-day window
-// and dismissals, then the open-state and active search filter the full render
-// dropped are restored (the same post-render fix-up the refresh path does).
+// Repaint a single panel from its last-loaded model — after a dismissal toggle or
+// a "show reviewed" flip. Re-deriving the view model reapplies the 30-day window
+// and dismissals, then the open-state and the active search filter the full
+// repaint dropped are restored (the same post-render fix-up the refresh path does).
 function repaintTile(key) {
-  if (CALENDAR_PANEL_BY_KEY[key]) {
-    repaintCalendarPanel(key);
-    rememberOpenState();
-    applyFilter(searchBox.value);
+  if (!PANEL_BY_KEY[key]) {
     return;
   }
 
-  var st = TILE_STATE[key];
-  if (!st) {
-    return;
-  }
-
-  paintTile(key, st.model, st.data);
+  repaintCompositePanel(key);
   rememberOpenState();
   applyFilter(searchBox.value);
-}
-
-function loadTile(key) {
-  return fetchJson(API + key, { headers: { "Accept": "application/json" } })
-    .then(function (data) {
-      tileFromBackend[key] = true;
-      paintTile(key, data.items || {}, data);
-      return true;
-    })
-    .catch(function () {
-      tileFromBackend[key] = false;
-      paintTile(key, MODEL[key], null);
-      return false;
-    });
 }
 
 
@@ -1392,15 +1338,6 @@ showReviewedBtn.addEventListener("click", function () {
 });
 
 
-// Per-tile refresh: the only expensive path. The cheap render is already on
-// screen from cache; this re-runs that tile's az / Outlook query server-side
-// via POST and swaps in the fresh data, count, and "cached just now" stamp.
-function tileNameFromButton(btn) {
-  var label = btn.getAttribute("aria-label") || "This tile";
-  var name = label.replace(/^Refresh\s+/, "");
-  return name;
-}
-
 // Refresh spinner lifecycle — the button spin, the "refreshing…" busy label, and
 // the announcement, shared by the single-tile and calendar refresh paths.
 function beginRefreshSpinner(btn, stale, label, name) {
@@ -1417,39 +1354,19 @@ function endRefreshSpinner(btn) {
   btn.disabled = false;
 }
 
+// Every tile is a composite (Calendar, Azure DevOps); the button's data-tile
+// names which one, and refreshComposite fans out to that tile's panels.
 function refreshTile(btn) {
   if (btn.disabled) {
     return Promise.resolve();
   }
 
-  var key = btn.getAttribute("data-tile");
-  if (key === CALENDAR_KEY) {
-    return refreshCalendar(btn);
+  var composite = COMPOSITE_BY_KEY[btn.getAttribute("data-tile")];
+  if (!composite) {
+    return Promise.resolve();
   }
 
-  var stale = tile(key).querySelector(".stale");
-  var label = staleLabelNode(key);
-  var name = tileNameFromButton(btn);
-
-  beginRefreshSpinner(btn, stale, label, name);
-
-  return fetchJson(API + key + "/refresh", { method: "POST", headers: { "Accept": "application/json" } })
-    .then(function (data) {
-      tileFromBackend[key] = true;
-      paintTile(key, data.items || {}, data);
-      rememberOpenState();
-      applyFilter(searchBox.value);
-      announce(name + " updated — cached just now.");
-    })
-    .catch(function () {
-      stale.classList.remove("busy");
-      stale.classList.add("warn");
-      label.textContent = "refresh failed";
-      announce(name + " refresh failed.");
-    })
-    .then(function () {
-      endRefreshSpinner(btn);
-    });
+  return refreshComposite(btn, composite);
 }
 
 document.querySelectorAll(".refresh-btn").forEach(function (btn) {
@@ -1465,8 +1382,8 @@ document.getElementById("refreshAll").addEventListener("click", function () {
 });
 
 
-// Stat strip: open and scroll to the tile a stat summarizes. Open the parent
-// section first so a collapsed Calendar / Azure DevOps group reveals the tile.
+// Stat strip: open and scroll to the composite tile a stat summarizes, then open
+// its matching inner panel so the jump lands on the right group, not just the tile.
 document.querySelectorAll(".stat").forEach(function (stat) {
   stat.addEventListener("click", function () {
     var target = document.getElementById(stat.dataset.target);
@@ -1474,21 +1391,11 @@ document.querySelectorAll(".stat").forEach(function (stat) {
       return;
     }
 
-    var section = target.closest(".section");
-    if (section) {
-      var sectionDetails = section.querySelector("details");
-      if (sectionDetails) {
-        sectionDetails.open = true;
-      }
-    }
-
     var details = target.querySelector("details");
     if (details) {
       details.open = true;
     }
 
-    // A calendar stat also opens its matching inner panel so the jump lands on
-    // the right group, not just the tile.
     if (stat.dataset.group) {
       var panel = target.querySelector('.group[data-panel="' + stat.dataset.group + '"]');
       if (panel) {
@@ -1574,20 +1481,6 @@ function applyFilter(raw) {
     t.classList.toggle("empty", !!q && !anyVisible);
   });
 
-  // A whole parent section drops out when a search empties every tile inside it,
-  // so the filtered view isn't padded with empty Calendar / Azure DevOps headers.
-  document.querySelectorAll(".section").forEach(function (section) {
-    var anyTileVisible = false;
-
-    section.querySelectorAll(".tile").forEach(function (t) {
-      if (!t.classList.contains("empty")) {
-        anyTileVisible = true;
-      }
-    });
-
-    section.classList.toggle("section-empty", !!q && !anyTileVisible);
-  });
-
   if (q) {
     announce(matchTotal + (matchTotal === 1 ? " item matches." : " items match."));
   }
@@ -1619,12 +1512,11 @@ paintTodayDate();
 
 
 // ---------------------------------------------------------------------------
-// Boot — load every tile from cache (falling back to the sample model), then
-// record open state so the filter can restore it.
+// Boot — load every composite tile from cache (falling back to the sample
+// model), then record open state so the filter can restore it.
 // ---------------------------------------------------------------------------
 
-var bootLoads = TILES.map(function (t) { return loadTile(t.key); });
-bootLoads.push(loadCalendar());
+var bootLoads = COMPOSITES.map(loadComposite);
 
 Promise.all(bootLoads).then(function (results) {
   rememberOpenState();

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -56,7 +56,7 @@
          header chrome, one staleness label, one refresh — whose .count badge and
          .body panels are rendered from the model. On narrow screens the two tiles
          stack, Azure DevOps first. -->
-    <div class="grid grid-top">
+    <div class="grid">
 
       <!-- Azure DevOps — one tile holding the three az boards-derived panels. The
            body renders three collapsible groups (This Sprint's Focus, Recent
@@ -67,7 +67,7 @@
         <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l6 3.2-6 3.2-6-3.2z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/><path d="M2 8l6 3.2L14 8M2 11.3l6 3.2 6-3.2" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h3 id="h-azuredevops">Azure DevOps</h3><span class="count"></span></span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l6 3.2-6 3.2-6-3.2z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/><path d="M2 8l6 3.2L14 8M2 11.3l6 3.2 6-3.2" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h2 id="h-azuredevops">Azure DevOps</h2><span class="count"></span></span>
             <span class="tile-meta">
               <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 5m ago</span>
               <button class="refresh-btn" type="button" data-tile="azuredevops" aria-label="Refresh Azure DevOps"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -85,7 +85,7 @@
         <details open>
           <summary>
             <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h3 id="h-calendar">Calendar</h3><span class="count"></span></span>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h2 id="h-calendar">Calendar</h2><span class="count"></span></span>
             <span class="tile-meta">
               <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 12m ago</span>
               <button class="refresh-btn" type="button" data-tile="calendar" aria-label="Refresh Calendar"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>

--- a/daily-viewer/index.html
+++ b/daily-viewer/index.html
@@ -36,101 +36,66 @@
 
     <!-- Stat numbers (.n) are filled from the model at render time; blank in markup
          so they can never drift from the collections they summarize. Each number
-         binds via data-stat, while data-target is where clicking jumps — the two
-         calendar stats share one target (the merged tile) and use data-group to
-         open the matching inner panel. -->
+         binds via data-stat, while data-target is where clicking jumps — the stats
+         that share a composite tile point at that tile and use data-group to open
+         the matching inner panel (both calendar stats → the Calendar tile; all
+         three Azure DevOps stats → the Azure DevOps tile). -->
     <section class="stats" aria-label="Summary counts">
       <button class="stat a" type="button" data-stat="tile-agenda" data-target="tile-calendar" data-group="agenda"><span class="n"></span><span class="l">Meetings today</span></button>
       <button class="stat p" type="button" data-stat="tile-prep" data-target="tile-calendar" data-group="prep"><span class="n"></span><span class="l">Events to prep</span></button>
-      <button class="stat g" type="button" data-stat="tile-focus" data-target="tile-focus"><span class="n"></span><span class="l">Support &amp; focus items</span></button>
-      <button class="stat s" type="button" data-stat="tile-activity" data-target="tile-activity"><span class="n"></span><span class="l">Recent updates</span></button>
-      <button class="stat f" type="button" data-stat="tile-week" data-target="tile-week"><span class="n"></span><span class="l">Stories in current sprint</span></button>
+      <button class="stat g" type="button" data-stat="tile-focus" data-target="tile-azuredevops" data-group="focus"><span class="n"></span><span class="l">Support &amp; focus items</span></button>
+      <button class="stat s" type="button" data-stat="tile-activity" data-target="tile-azuredevops" data-group="activity"><span class="n"></span><span class="l">Recent updates</span></button>
+      <button class="stat f" type="button" data-stat="tile-week" data-target="tile-azuredevops" data-group="week"><span class="n"></span><span class="l">Stories in current sprint</span></button>
     </section>
 
-    <!-- Two tile groupings: one Calendar tile (all Outlook items) and the Azure
-         DevOps parent section (az boards). The Calendar tile's body renders two
-         collapsible <details> groups — Today's Agenda and Events to Prepare For —
-         from app.js; the Azure DevOps <details> collapses its whole group with JS
-         off. Each tile is a static shell — header chrome, staleness, refresh — whose
-         .count badge and .body rows are rendered from the model. -->
+    <!-- Two composite container tiles side by side: the Azure DevOps tile
+         (top-left) and the Calendar tile (top-right). Each holds several
+         collapsible <details> panels rendered from the model by app.js — Azure
+         DevOps: This Sprint's Focus / Recent Activity / Today's Focus; Calendar:
+         Today's Agenda / Events to Prepare For. Each tile is a static shell —
+         header chrome, one staleness label, one refresh — whose .count badge and
+         .body panels are rendered from the model. On narrow screens the two tiles
+         stack, Azure DevOps first. -->
+    <div class="grid grid-top">
 
-    <!-- Calendar — one tile holding both Outlook-derived groups. The body renders
-         two collapsible groups (Today's Agenda, Events to Prepare For), each fed by
-         its own endpoint; the tile has one refresh (fanning out to both) and one
-         staleness label (the older of the two cache ages). -->
-    <section class="tile" id="tile-calendar" data-tile="calendar" aria-labelledby="h-calendar">
-      <details open>
-        <summary>
-          <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h3 id="h-calendar">Calendar</h3><span class="count"></span></span>
-          <span class="tile-meta">
-            <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 12m ago</span>
-            <button class="refresh-btn" type="button" data-tile="calendar" aria-label="Refresh Calendar"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-          </span>
-        </summary>
-        <div class="body"></div>
-      </details>
-    </section>
+      <!-- Azure DevOps — one tile holding the three az boards-derived panels. The
+           body renders three collapsible groups (This Sprint's Focus, Recent
+           Activity, Today's Focus), each fed by its own endpoint; the tile has one
+           refresh (fanning out to all three) and one staleness label (the oldest of
+           the three cache ages). -->
+      <section class="tile" id="tile-azuredevops" data-tile="azuredevops" aria-labelledby="h-azuredevops">
+        <details open>
+          <summary>
+            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l6 3.2-6 3.2-6-3.2z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/><path d="M2 8l6 3.2L14 8M2 11.3l6 3.2 6-3.2" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h3 id="h-azuredevops">Azure DevOps</h3><span class="count"></span></span>
+            <span class="tile-meta">
+              <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 5m ago</span>
+              <button class="refresh-btn" type="button" data-tile="azuredevops" aria-label="Refresh Azure DevOps"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+            </span>
+          </summary>
+          <div class="body"></div>
+        </details>
+      </section>
 
-    <!-- Azure DevOps — az boards-derived tiles -->
-    <section class="section ado" aria-labelledby="sec-azuredevops">
-      <details open>
-        <summary>
-          <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          <svg class="sicon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l6 3.2-6 3.2-6-3.2z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/><path d="M2 8l6 3.2L14 8M2 11.3l6 3.2 6-3.2" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
-          <h2 class="section-title" id="sec-azuredevops">Azure DevOps</h2>
-        </summary>
+      <!-- Calendar — one tile holding both Outlook-derived groups (Today's Agenda,
+           Events to Prepare For), each fed by its own endpoint; the tile has one
+           refresh (fanning out to both) and one staleness label (the older of the
+           two cache ages). -->
+      <section class="tile" id="tile-calendar" data-tile="calendar" aria-labelledby="h-calendar">
+        <details open>
+          <summary>
+            <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M2 6h12M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg><h3 id="h-calendar">Calendar</h3><span class="count"></span></span>
+            <span class="tile-meta">
+              <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 12m ago</span>
+              <button class="refresh-btn" type="button" data-tile="calendar" aria-label="Refresh Calendar"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+            </span>
+          </summary>
+          <div class="body"></div>
+        </details>
+      </section>
 
-        <div class="grid">
-
-          <!-- This Sprint's Focus -->
-          <section class="tile" id="tile-week" data-tile="week" aria-labelledby="h-week">
-            <details open>
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><circle cx="8" cy="8" r="2.4" stroke="currentColor" stroke-width="1.4"/></svg><h3 id="h-week">This Sprint&rsquo;s Focus</h3><span class="count"></span></span>
-                <span class="tile-meta">
-                  <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 2h ago</span>
-                  <button class="refresh-btn" type="button" data-tile="week" aria-label="Refresh This Sprint&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-                </span>
-              </summary>
-              <div class="body"></div>
-            </details>
-          </section>
-
-          <!-- Recent Activity -->
-          <section class="tile" id="tile-activity" data-tile="activity" aria-labelledby="h-activity">
-            <details open>
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M1.5 8h3l2-4.5 3 9 2-4.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg><h3 id="h-activity">Recent Activity</h3><span class="count"></span></span>
-                <span class="tile-meta">
-                  <span class="stale"><span class="fdot" aria-hidden="true"></span>cached 5m ago</span>
-                  <button class="refresh-btn" type="button" data-tile="activity" aria-label="Refresh Recent Activity"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-                </span>
-              </summary>
-              <div class="body"></div>
-            </details>
-          </section>
-
-          <!-- Today's Focus -->
-          <section class="tile" id="tile-focus" data-tile="focus" aria-labelledby="h-focus">
-            <details open>
-              <summary>
-                <svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                <span class="tt"><svg class="ticon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 1.5l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.3 4.3 13.3l.7-4.3-3.1-3 4.3-.6z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg><h3 id="h-focus">Today&rsquo;s Focus</h3><span class="count"></span></span>
-                <span class="tile-meta">
-                  <span class="stale warn"><span class="fdot" aria-hidden="true"></span>cached 1h ago</span>
-                  <button class="refresh-btn" type="button" data-tile="focus" aria-label="Refresh Today&rsquo;s Focus"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 2.5V5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
-                </span>
-              </summary>
-              <div class="body"></div>
-            </details>
-          </section>
-
-        </div>
-      </details>
-    </section>
+    </div>
 
   </main>
 

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -301,44 +301,13 @@ button:focus-visible {
 .stat.s { --stat: var(--story); }
 .stat.g { --stat: var(--warn); }
 
-/* ---------- parent sections (Calendar / Azure DevOps) ---------- */
-.section { margin-bottom: var(--space-8); }
-.section:last-of-type { margin-bottom: 0; }
-.section.section-empty { display: none; }
-.section.ado { --tint: var(--story); }
-
-.section > details > summary {
-  list-style: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
-  padding: var(--space-3) var(--space-1);
-  margin-bottom: var(--space-6);
-  border-bottom: 1px solid var(--border);
-  user-select: none;
-}
-.section > details > summary::-webkit-details-marker { display: none; }
-.section > details > summary:hover .section-title { color: var(--text); }
-
-.section .sicon {
-  flex: none;
-  width: var(--icon); height: var(--icon);
-  color: var(--tint, var(--accent));
-}
-.section-title {
-  margin: 0;
-  font-size: var(--fs-lg);
-  font-weight: 700;
-  letter-spacing: .05em;
-  text-transform: uppercase;
-  color: var(--text-dim);
-}
-
-/* ---------- grid ---------- */
+/* ---------- top row — two composite container tiles side by side ---------- */
+/* align-items:start keeps each tile its natural height, so the shorter Calendar
+   tile doesn't stretch to match the taller Azure DevOps tile beside it. */
 .grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
   gap: var(--space-7);
 }
 @media (max-width: 51.25em) {
@@ -355,12 +324,10 @@ button:focus-visible {
   box-shadow: var(--shadow);
   overflow: hidden;
 }
-/* The Calendar tile stands alone above the Azure DevOps section, so it carries
-   its own bottom margin (the .section below supplies its own). */
-.tile[data-tile="calendar"] { --tint: var(--accent); margin-bottom: var(--space-8); }
-.tile[data-tile="week"]     { --tint: var(--feature); }
-.tile[data-tile="activity"] { --tint: var(--story); }
-.tile[data-tile="focus"]    { --tint: var(--warn); }
+/* The two composite container tiles sit side by side in the top-row grid, each
+   carrying its own accent tint. */
+.tile[data-tile="azuredevops"] { --tint: var(--story); }
+.tile[data-tile="calendar"]    { --tint: var(--accent); }
 
 .tile > details > summary {
   list-style: none;

--- a/daily-viewer/styles.css
+++ b/daily-viewer/styles.css
@@ -361,7 +361,7 @@ details[open] > summary > .chev { transform: rotate(90deg); }
   width: var(--icon); height: var(--icon);
   color: var(--tint, var(--accent));
 }
-.tt h3 {
+.tt h2 {
   margin: 0;
   font-size: var(--fs-smd);
   font-weight: 700;


### PR DESCRIPTION
<!-- toc:start -->
## Table of Contents

| Section | Status |
|---------|--------|
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #222 |
| [Changes](#changes) | ✅ 3 files |
| [Behavior preserved](#behavior-preserved) | ✅ |
| [Test Plan](#test-plan) | 0/5 |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](#issuecomment-5047721809) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](#issuecomment-5047722049) |
| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-5047735106) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](#issuecomment-5047745993) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](#issuecomment-5047755364) |
| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-5047787039) |

**Readiness:** all skill reports green (Bash/PowerShell/Clean-Code/Front-End APPROVE, Security/Criteria PASS). Remaining: the 5 manual Test Plan checks (in-browser walkthrough).
<!-- toc:end -->

<!-- pr-diagram:start -->
## How it works

This PR generalizes the Calendar-only tile engine into one composite engine that drives **both** the Calendar tile (agenda + prep) and the new Azure DevOps tile (week + activity + focus), all declared in the `COMPOSITES` config. On boot, `loadComposite` fans `loadCompositePanel` out to each panel's GET endpoint — storing the payload on success, falling back to the per-panel sample `MODEL` on failure — then paints the whole tile once. The refresh button drives `refreshComposite`, fanning POST `/refresh` out the same way; a dismissal or show-reviewed flip drives `repaintCompositePanel`, rebuilding just that one panel. Both paint paths run through `buildCompositePanel` (details shell + row-derived count), refresh each panel's stat, the header row count, and a single oldest-of-N staleness label via `setCompositeStale`.

```mermaid
flowchart TD
    Config[(COMPOSITES config<br/>Calendar + Azure DevOps panels)]:::io

    Boot([boot: COMPOSITES.map]):::pub
    Refresh([refresh-btn click]):::pub
    Dismiss([dismissal / show-reviewed]):::pub

    LoadComposite[loadComposite<br/>fan-out panels, paint once]:::priv
    LoadPanel[loadCompositePanel]:::priv
    GetApi["GET /api/tiles/{panel}"]:::io
    RefreshPost["POST /api/tiles/{panel}/refresh"]:::io
    Store[storePanelPayload<br/>writes panelState]:::priv
    Sample[(sample MODEL fallback)]:::io

    Paint[paintComposite<br/>rebuild every panel]:::priv
    Repaint[repaintCompositePanel<br/>rebuild one panel]:::priv
    Build[buildCompositePanel<br/>details + derived count]:::priv
    Stat[setStat / paintRowCount]:::priv
    Stale[setCompositeStale<br/>oldest-of-N age]:::priv

    Config --> Boot
    Boot --> LoadComposite --> LoadPanel --> GetApi
    GetApi -- ok --> Store
    GetApi -- fail --> Sample
    LoadComposite -. all settled .-> Paint

    Refresh --> RefreshPost
    RefreshPost -- ok --> Store
    RefreshPost -- fail --> Paint
    Refresh -. all settled .-> Paint

    Dismiss --> Repaint

    Store -.panelState.-> Paint
    Sample -.panelState.-> Paint

    Paint --> Build
    Paint --> Stat
    Paint --> Stale
    Repaint --> Build
    Repaint --> Stat

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
Collapses the three separate Azure DevOps tiles (This Sprint's Focus, Recent Activity, Today's Focus) into a **single Azure DevOps container tile** whose body holds three independently-collapsible groups — mirroring the pattern #220 used for the Calendar tile — and lays the two container tiles **side by side** in a top row: **Azure DevOps top-left, Calendar top-right** (stacking Azure DevOps first on narrow screens).

Front-end only (`daily-viewer/` surface). No backend/PowerShell changes — the three `az boards` endpoints and their `/refresh` POSTs are untouched.

## Issue
Closes #222

## Changes
- **`daily-viewer/app.js`** — Generalized the Calendar-specific composite engine into one reusable composite engine (`COMPOSITES`, `paintComposite`, `loadComposite`, `refreshComposite`, `repaintCompositePanel`, `setCompositeStale`, `buildCompositePanel`) that drives **both** the Calendar composite (`agenda` + `prep`) and the new Azure DevOps composite (`week` + `activity` + `focus`). Removed the now-dead per-tile engine (`TILES`, `loadTile`, `paintTile`, `renderTileBody`, `setStale`, `tileNameFromButton`) and the obsolete `.section` filter / stat-jump logic. Net **−176 lines**.
- **`daily-viewer/index.html`** — Replaced the `.section.ado` wrapper + three-tile grid with one `#tile-azuredevops` composite tile (three empty panel bodies rendered by JS); wrapped it and the Calendar tile in a `.grid.grid-top` two-up row (Azure DevOps first); retargeted the three Azure DevOps stats to `tile-azuredevops` + `data-group`.
- **`daily-viewer/styles.css`** — Added `.grid { align-items: start }` for the top row, added the `azuredevops` tile tint, dropped the Calendar standalone margin and all dead `.section*` rules.

## Behavior preserved
- Each Azure DevOps group collapses independently and works with JS off (native `<details>`); "Collapse all" / "Expand all" honored.
- All five summary stats kept; the three Azure DevOps stats jump to the single container and open their matching inner group via `data-group`.
- One refresh fans out to all three endpoints; one staleness label shows the **oldest** of the three cache ages; independent per-panel sample-data fallback.
- Recent Activity's "Mark reviewed" / "Show reviewed" dismissal stays scoped to its own group (siblings untouched).
- No `innerHTML`/XSS path added — model strings still reach the DOM only via `el()`/`textContent`; links via `safeUrl()`.

## Test Plan
- [ ] Open `daily-viewer/index.html` in a browser — Azure DevOps container top-left (three collapsible groups), Calendar top-right (two groups)
- [ ] Each of the five stats shows the correct count and jumps to the right tile + inner group
- [ ] One refresh per container; offline preview degrades to "sample data" without error
- [ ] Recent Activity "Mark reviewed" + "Show reviewed" affect only that group
- [ ] Narrow the window — the two containers stack, Azure DevOps first

_Verified in headless Chromium: structure, derived counts (Azure DevOps 11 / Calendar 6), stat-jumps, dismissal scoping, collapse-all, offline refresh, and cross-tile filter — zero page errors._

🤖 Generated with [Claude Code](https://claude.com/claude-code)