### PR TITLE
Daily Viewer — cache-first load with staleness-gated background refresh on open

### DIFF
--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -1550,20 +1550,18 @@ var bootLoads = COMPOSITES.map(function (composite) {
   return loadComposite(composite).then(function (allBackend) {
     rememberOpenState();
 
-    var refreshing = autoRefreshOnOpen(composite);
-    return { allBackend: allBackend, refreshing: refreshing };
+    autoRefreshOnOpen(composite);
+    return allBackend;
   });
 });
 
 Promise.all(bootLoads).then(function (results) {
-  var anyFallback = results.some(function (r) { return !r.allBackend; });
-  var anyRefreshing = results.some(function (r) { return r.refreshing; });
-
   // Screen-reader parity with the refresh path: if a tile couldn't reach the
-  // backend and fell back to the sample model, say so once (not per tile). When
-  // a refresh is in flight the refresh path announces its own progress, so the
-  // offline notice is suppressed — it belongs to the truly-unreachable case.
-  if (anyFallback && !anyRefreshing) {
+  // backend and fell back to the sample model, say so once (not per tile). A
+  // fallen-back tile never auto-refreshes (its refresh would be doomed), so a
+  // sibling tile that is refreshing can't starve this notice — that tile
+  // announces its own progress and settles independently.
+  if (results.indexOf(false) !== -1) {
     announce("Showing sample data — the daily-viewer server isn't reachable.");
   }
 });

--- a/daily-viewer/app.js
+++ b/daily-viewer/app.js
@@ -1512,18 +1512,58 @@ paintTodayDate();
 
 
 // ---------------------------------------------------------------------------
-// Boot — load every composite tile from cache (falling back to the sample
-// model), then record open state so the filter can restore it.
+// Boot — cache-first, then an independent background refresh per tile. Each
+// composite paints from its cache read first (instant, no blank screen), then
+// auto-triggers its own refresh through the existing refresh path so a stale
+// tile freshens up on its own spinner without blocking or resetting the other.
 // ---------------------------------------------------------------------------
 
-var bootLoads = COMPOSITES.map(loadComposite);
+// Kick a tile's background refresh on open, gated by staleness: refresh only
+// when at least one of its panels came back stale (reusing the server's own
+// `data.stale` flag, so the frontend invents no threshold). A tile whose panels
+// are all fresh stays put — no spinner, no redundant az/Outlook call. A tile
+// that fell back to the sample model (data === null, backend unreachable) is
+// left as sample rather than firing a doomed refresh, matching today's offline
+// preview. Reuses refreshTile → refreshComposite, so the spinner lifecycle,
+// aria-live announcements, and per-panel repaint are the existing ones — no new
+// refresh engine. Returns whether a refresh was started.
+function autoRefreshOnOpen(composite) {
+  var needsRefresh = composite.panels.some(function (panel) {
+    var data = (panelState[panel.key] || {}).data;
+    return data && data.stale === true;
+  });
+
+  if (!needsRefresh) {
+    return false;
+  }
+
+  var btn = tile(composite.key).querySelector(".refresh-btn");
+  if (!btn) {
+    return false;
+  }
+
+  refreshTile(btn);
+  return true;
+}
+
+var bootLoads = COMPOSITES.map(function (composite) {
+  return loadComposite(composite).then(function (allBackend) {
+    rememberOpenState();
+
+    var refreshing = autoRefreshOnOpen(composite);
+    return { allBackend: allBackend, refreshing: refreshing };
+  });
+});
 
 Promise.all(bootLoads).then(function (results) {
-  rememberOpenState();
+  var anyFallback = results.some(function (r) { return !r.allBackend; });
+  var anyRefreshing = results.some(function (r) { return r.refreshing; });
 
-  // Screen-reader parity with the refresh path: if any tile couldn't reach the
-  // backend and fell back to the sample model, say so once (not per tile).
-  if (results.indexOf(false) !== -1) {
+  // Screen-reader parity with the refresh path: if a tile couldn't reach the
+  // backend and fell back to the sample model, say so once (not per tile). When
+  // a refresh is in flight the refresh path announces its own progress, so the
+  // offline notice is suppressed — it belongs to the truly-unreachable case.
+  if (anyFallback && !anyRefreshing) {
     announce("Showing sample data — the daily-viewer server isn't reachable.");
   }
 });


### PR DESCRIPTION
<!-- toc:start -->
## Table of Contents

| Section | Status |
|---------|--------|
| [How it works](#how-it-works) | 🗺️ diagram |
| [Summary](#summary) | ✅ |
| [Issue](#issue) | Closes #225 |
| [Changes](#changes) | ✅ 1 file (`daily-viewer/app.js`) |
| [Test Plan](#test-plan) | ✅ 3 automated + 4 manual |
| **Skill Reports** | |
| 🐚 Bash Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/226#issuecomment-5049789977) |
| 💠 PowerShell Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/226#issuecomment-5049788526) |
| 🛡️ Security Audit | ✅ PASS — [View](https://github.com/jdschleicher/bashcuts/pull/226#issuecomment-5049797443) |
| 🧼 Clean-Code Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/226#issuecomment-5049800953) |
| 🎨 Front-End Engineer Review | ✅ APPROVE — [View](https://github.com/jdschleicher/bashcuts/pull/226#issuecomment-5049805733) |
| ✅ Criteria Check | ✅ PASS (11/11) — [View](https://github.com/jdschleicher/bashcuts/pull/226#issuecomment-5049844691) |

**Review follow-up:** Front-End LOW #1 (cross-tile suppression of the offline sample-data announcement) was folded in — commit `be6cf3d` gates the notice on fallback alone and drops the coarse global `anyRefreshing` check; re-verified in-browser. LOW #2 (unsolicited "refresh failed" on a rare partially-reachable composite) left as noted — fixing it cleanly would touch the shared `refreshComposite` path, out of scope for this PR.
<!-- toc:end -->
<!-- pr-diagram:start -->
## How it works

Each composite tile boots independently: it paints instantly from its cache read, then `autoRefreshOnOpen` gates on the server's own `data.stale` flag — a stale tile hands off to the existing `refreshTile → refreshComposite` path (spinner + `aria-live` + repaint), while a fresh or offline tile stays put.

```mermaid
flowchart TD
    Open([page open — boot<br/>per composite tile, independently]):::pub
    Load[loadComposite<br/>GET cache-read per panel]:::priv
    Cache[(tile cache)]:::io
    Paint[paintComposite<br/>instant cache paint + staleness label]:::priv
    Remember[rememberOpenState]:::priv
    Auto([autoRefreshOnOpen]):::pub
    Gate{any panel<br/>data.stale === true?}
    Stay[fresh cache or offline sample<br/>stay put — no spinner, no az call]
    Refresh[refreshTile to refreshComposite]:::priv
    Spin[beginRefreshSpinner<br/>aria-live: refreshing…]:::priv
    Post["POST …/refresh per panel"]:::io
    Settle([repaint + endRefreshSpinner<br/>aria-live: cached just now]):::pub

    Open --> Load --> Cache --> Paint --> Remember --> Auto --> Gate
    Gate -- no --> Stay
    Gate -- yes --> Refresh --> Spin --> Post --> Settle

    classDef pub fill:#1f3a5f,stroke:#4ea3ff,color:#fff
    classDef priv fill:#3a3a3a,stroke:#999,color:#fff
    classDef io fill:#5a4a1a,stroke:#e0c060,color:#fff
```
<!-- pr-diagram:end -->

## Summary
On open, the daily viewer now paints each composite tile from its cheap cache read first (instant, no blank screen) and then **auto-triggers its own background refresh** through the existing refresh path — so a stale tile freshens up on its own spinner without you clicking anything. The two tiles (Azure DevOps, Calendar) refresh **independently**: a slow or failing one never blocks or resets the other.

Auto-refresh is **gated by staleness** using the server's own `data.stale` flag, so the frontend invents no threshold: a fully-fresh tile stays put (no spinner, no redundant `az`/Outlook call), and a tile that fell back to the sample model (offline) is left as sample rather than firing a doomed refresh.

## Issue
Closes #225

## Changes
- `daily-viewer/app.js` — reworked the boot flow:
  - Added `autoRefreshOnOpen(composite)` — kicks a tile's background refresh on open only when at least one panel returned `data.stale === true`, reusing `refreshTile → refreshComposite` (and therefore `beginRefreshSpinner`/`endRefreshSpinner`, the aria-live announcements, and per-panel repaint). **No new refresh engine.**
  - Boot now maps each composite independently: cache paint → record open state → auto-refresh, so neither tile waits on the other.
  - The offline "sample data" announcement is gated on fallback alone (review follow-up), so an offline tile is still announced even while a sibling tile is refreshing.

No backend, markup, or CSS change — the boot flow only re-sequences calls to the existing `GET` cache-read and `POST …/refresh` endpoints. The reduced-motion spinner CSS and `aria-live` region were already in place.

## Test Plan
Verified in-browser with Playwright against a mocked backend:
- [x] **Stale cache** — tiles paint from cache, then auto-fire `POST …/refresh`; rows repaint to fresh data, labels flip `refreshing…` → `cached just now`, aria-live announces the update. Calendar settled independently while a deliberately-lagged Azure DevOps panel was still in flight.
- [x] **Fresh cache** — zero refresh calls, zero spinners; fresh tiles stay put.
- [x] **Offline (backend unreachable)** — sample fallback preserved, no spinner, `sample data` labels, `Showing sample data…` announced (and still announced in the mixed offline+stale case after the review fix).
- [ ] Manual: open the live daily viewer with a stale cache; confirm each tile shows cached data + timestamp instantly, then spins and settles on its own.
- [ ] Manual: confirm "Refresh all", per-tile refresh, live filter, and dismissal/marker toggles still work alongside auto-refresh-on-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)